### PR TITLE
Fix --ecosystems flag to properly filter to internal ecosystems only

### DIFF
--- a/internal/inventory/inventory.go
+++ b/internal/inventory/inventory.go
@@ -178,32 +178,36 @@ func resolvePlugins(opts ScanOptions, cap *plugin.Capabilities) ([]plugin.Plugin
 	names := normalizeEcosystems(opts.Ecosystems)
 	includeActions := shouldIncludeGitHubActions(names)
 	includeDockerfile := shouldIncludeDockerfile(names)
-	names = filterExternalEcosystems(names)
-	if len(names) == 0 {
-		plugins := pl.FromCapabilities(cap)
-		if includeActions {
-			plugins = append(plugins, ghactions.New())
+	scalibrNames := filterExternalEcosystems(names)
+
+	var plugins []plugin.Plugin
+
+	switch {
+	case len(scalibrNames) > 0:
+		// SCALIBR ecosystems specified
+		var err error
+		plugins, err = pl.FromNames(scalibrNames)
+		if err != nil {
+			return nil, fmt.Errorf("error creating plugins: %w", err)
 		}
-		if includeDockerfile {
-			plugins = append(plugins, dockerfilex.New())
-		}
-		// Add registered external plugins
 		plugins = appendRegisteredPlugins(plugins)
-		return plugins, nil
+		plugins = plugin.FilterByCapabilities(plugins, cap)
+	case names != nil:
+		// Only internal ecosystems (user specified something but no SCALIBR names)
+	default:
+		// "all" case
+		plugins = pl.FromCapabilities(cap)
+		plugins = appendRegisteredPlugins(plugins)
 	}
-	plugins, err := pl.FromNames(names)
-	if err != nil {
-		return nil, fmt.Errorf("error creating plugins: %w", err)
-	}
+
 	if includeActions {
 		plugins = append(plugins, ghactions.New())
 	}
 	if includeDockerfile {
 		plugins = append(plugins, dockerfilex.New())
 	}
-	// Add registered external plugins
-	plugins = appendRegisteredPlugins(plugins)
-	return plugin.FilterByCapabilities(plugins, cap), nil
+
+	return plugins, nil
 }
 
 // appendRegisteredPlugins adds SCALIBR-adapted plugins from the registry.

--- a/internal/inventory/inventory_filter_test.go
+++ b/internal/inventory/inventory_filter_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/osv-scalibr/plugin"
 	pl "github.com/google/osv-scalibr/plugin/list"
 
+	dockerfilex "github.com/picatz/deputy/internal/inventory/plugins/docker/dockerfilex"
 	ghactions "github.com/picatz/deputy/internal/inventory/plugins/github/actionsx"
 )
 
@@ -64,5 +65,141 @@ func TestFilterInventoryPluginsMixedPlugins(t *testing.T) {
 		if !found[name] {
 			t.Errorf("expected plugin %q not found in filtered results", name)
 		}
+	}
+}
+
+func TestResolvePluginsOnlyGitHubActions(t *testing.T) {
+	// When user specifies only github-actions, only the GitHub Actions plugin
+	// should be returned, not all SCALIBR plugins.
+	opts := ScanOptions{Ecosystems: []string{"github-actions"}}
+	cap := &plugin.Capabilities{OS: plugin.OSLinux}
+
+	plugins, err := resolvePlugins(opts, cap)
+	if err != nil {
+		t.Fatalf("resolvePlugins: %v", err)
+	}
+
+	if len(plugins) != 1 {
+		names := make([]string, len(plugins))
+		for i, p := range plugins {
+			names[i] = p.Name()
+		}
+		t.Fatalf("expected 1 plugin (github-actions only), got %d: %v", len(plugins), names)
+	}
+
+	if plugins[0].Name() != ghactions.Name {
+		t.Errorf("expected %s plugin, got %s", ghactions.Name, plugins[0].Name())
+	}
+}
+
+func TestResolvePluginsOnlyDockerfile(t *testing.T) {
+	// When user specifies only dockerfile, only the Dockerfile plugin
+	// should be returned, not all SCALIBR plugins.
+	opts := ScanOptions{Ecosystems: []string{"dockerfile"}}
+	cap := &plugin.Capabilities{OS: plugin.OSLinux}
+
+	plugins, err := resolvePlugins(opts, cap)
+	if err != nil {
+		t.Fatalf("resolvePlugins: %v", err)
+	}
+
+	if len(plugins) != 1 {
+		names := make([]string, len(plugins))
+		for i, p := range plugins {
+			names[i] = p.Name()
+		}
+		t.Fatalf("expected 1 plugin (dockerfile only), got %d: %v", len(plugins), names)
+	}
+
+	if plugins[0].Name() != dockerfilex.Name {
+		t.Errorf("expected %s plugin, got %s", dockerfilex.Name, plugins[0].Name())
+	}
+}
+
+func TestResolvePluginsBothInternalEcosystems(t *testing.T) {
+	// When user specifies both github-actions and dockerfile, only those
+	// two plugins should be returned.
+	opts := ScanOptions{Ecosystems: []string{"github-actions", "dockerfile"}}
+	cap := &plugin.Capabilities{OS: plugin.OSLinux}
+
+	plugins, err := resolvePlugins(opts, cap)
+	if err != nil {
+		t.Fatalf("resolvePlugins: %v", err)
+	}
+
+	if len(plugins) != 2 {
+		names := make([]string, len(plugins))
+		for i, p := range plugins {
+			names[i] = p.Name()
+		}
+		t.Fatalf("expected 2 plugins, got %d: %v", len(plugins), names)
+	}
+
+	found := make(map[string]bool)
+	for _, p := range plugins {
+		found[p.Name()] = true
+	}
+	if !found[ghactions.Name] {
+		t.Errorf("expected %s plugin not found", ghactions.Name)
+	}
+	if !found[dockerfilex.Name] {
+		t.Errorf("expected %s plugin not found", dockerfilex.Name)
+	}
+}
+
+func TestResolvePluginsExternalWithGitHubActions(t *testing.T) {
+	// When user specifies go and github-actions, both should be included.
+	opts := ScanOptions{Ecosystems: []string{"go", "github-actions"}}
+	cap := &plugin.Capabilities{OS: plugin.OSLinux}
+
+	plugins, err := resolvePlugins(opts, cap)
+	if err != nil {
+		t.Fatalf("resolvePlugins: %v", err)
+	}
+
+	// Should have go plugins + github-actions
+	found := make(map[string]bool)
+	for _, p := range plugins {
+		found[p.Name()] = true
+	}
+
+	if !found[ghactions.Name] {
+		t.Errorf("expected %s plugin not found", ghactions.Name)
+	}
+	// Should have at least one go plugin
+	hasGo := false
+	for name := range found {
+		if len(name) > 3 && name[:3] == "go/" {
+			hasGo = true
+			break
+		}
+	}
+	if !hasGo {
+		t.Errorf("expected at least one go plugin")
+	}
+}
+
+func TestResolvePluginsAllIncludesEverything(t *testing.T) {
+	// When user specifies "all", all plugins should be included.
+	opts := ScanOptions{Ecosystems: []string{"all"}}
+	cap := &plugin.Capabilities{OS: plugin.OSLinux}
+
+	plugins, err := resolvePlugins(opts, cap)
+	if err != nil {
+		t.Fatalf("resolvePlugins: %v", err)
+	}
+
+	// Should have many plugins including github-actions
+	if len(plugins) < 5 {
+		t.Errorf("expected many plugins for 'all', got %d", len(plugins))
+	}
+
+	found := make(map[string]bool)
+	for _, p := range plugins {
+		found[p.Name()] = true
+	}
+
+	if !found[ghactions.Name] {
+		t.Errorf("expected %s plugin not found when using 'all'", ghactions.Name)
 	}
 }


### PR DESCRIPTION
When specifying only internal ecosystems like github-actions or dockerfile, the scan was incorrectly loading all SCALIBR plugins instead of just the requested internal plugins. This was because filterExternalEcosystems() removed internal ecosystem names, leaving an empty list that was treated as "all ecosystems".

Refactored resolvePlugins() to use a switch statement that distinguishes between three cases:
1. SCALIBR ecosystems specified (len(scalibrNames) > 0)
2. Only internal ecosystems (names != nil but scalibrNames empty)
3. "all" case (names == nil)