### PR TITLE
noop-finding-go-git-cve-2026-25934: remediate go-git-packfile-integrity-bypass

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/charmbracelet/glamour v0.10.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/go-git/go-billy/v5 v5.6.2
-	github.com/go-git/go-git/v5 v5.16.3
+	github.com/go-git/go-git/v5 v5.16.5
 	github.com/goccy/go-yaml v1.12.0
 	github.com/google/cel-go v0.26.1
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
> This pull request was created by [camper](https://github.com/temporalio/camper), an automated security remediation tool.

## Finding

| | |
|---|---|
| **Rule** | `go-git-packfile-integrity-bypass` |
| **Severity** | MEDIUM |
| **Repository** | `temporalio/deputy` |

## Changes

## Summary

- `go.mod`: Bumped github.com/go-git/go-git/v5 from v5.16.3 to v5.16.5 to pick up the packfile integrity fix for CVE-2026-25934; no other module requirements or Go sources were touched.
- `go.mod`: go mod tidy was attempted with GOCACHE=/tmp/go-build and GOMODCACHE=/tmp/go-mod, but it failed because the sandbox cannot access /Users/picat/Library/Caches/go-build, outbound network to proxy.golang.org is blocked (needed for golang.org/toolchain@go1.25.5 and github.com/go-git/go-git/v5@v5.16.5), and only Go 1.25.4 is installed. As a result go.sum still references v5.16.3; run go mod tidy once Go 1.25.5 and network access are available.

## Tracking

Ticket: noop-finding-go-git-cve-2026-25934

## Reviewer Instructions

- **Approve** to merge this fix
- **Request changes** to trigger a new remediation attempt
- `/camper rebase` — rebase onto the base branch
- `/camper close` — close this PR without merging
- `/camper retry` — close and retry with a new fix