### PR TITLE
VLN-1427: remediate unpinned-github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
 
@@ -34,10 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
 
@@ -50,8 +50,7 @@ jobs:
         run: go test -v -race -coverprofile=coverage.out ./...
 
       - name: Upload coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: coverage
           path: coverage.out
-

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -83,14 +83,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Deputy
-        uses: picatz/deputy/actions/setup@main
+        uses: ./actions/setup
 
       - name: Run scan
         id: scan
-        uses: picatz/deputy/actions/scan@main
+        uses: ./actions/scan
         with:
           target: ${{ inputs.target }}
           policy: ${{ inputs.scan-policy }}
@@ -110,16 +110,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Setup Deputy
-        uses: picatz/deputy/actions/setup@main
+        uses: ./actions/setup
 
       - name: Run diff
         id: diff
-        uses: picatz/deputy/actions/diff@main
+        uses: ./actions/diff
         with:
           base: ${{ github.base_ref }}
           target: ${{ github.head_ref }}

--- a/.github/workflows/release-sbom.yml
+++ b/.github/workflows/release-sbom.yml
@@ -67,14 +67,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Deputy
-        uses: picatz/deputy/actions/setup@main
+        uses: ./actions/setup
 
       - name: Generate SBOM
         id: sbom
-        uses: picatz/deputy/actions/sbom@main
+        uses: ./actions/sbom
         with:
           target: ${{ inputs.target }}
           format: ${{ inputs.format }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
   # Security gate before release
   security:
     name: Security Gate
-    uses: picatz/deputy/.github/workflows/scan.yml@main
+    uses: ./.github/workflows/scan.yml
     with:
       policy: policy/ci/release-gate.yaml
       fail-on-policy-violation: true
@@ -34,20 +34,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -57,7 +57,7 @@ jobs:
 
       # Generate SBOM with Deputy (dogfooding)
       - name: Setup Deputy
-        uses: picatz/deputy/actions/setup@main
+        uses: ./actions/setup
 
       - name: Generate and sign SBOM
         env:

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -81,14 +81,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Deputy
-        uses: picatz/deputy/actions/setup@main
+        uses: ./actions/setup
 
       - name: Run scan
         id: scan
-        uses: picatz/deputy/actions/scan@main
+        uses: ./actions/scan
         with:
           target: ${{ inputs.target }}
           policy: ${{ inputs.policy }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -24,7 +24,7 @@ jobs:
   # Full security scan on all events
   scan:
     name: Scan
-    uses: picatz/deputy/.github/workflows/scan.yml@main
+    uses: ./.github/workflows/scan.yml
     with:
       policy: policy/ci/security-gate.yaml
       upload-sarif: true
@@ -34,7 +34,7 @@ jobs:
   pr-gate:
     name: PR Gate
     if: github.event_name == 'pull_request'
-    uses: picatz/deputy/.github/workflows/pr-gate.yml@main
+    uses: ./.github/workflows/pr-gate.yml
     with:
       scan-policy: policy/ci/security-gate.yaml
       diff-policy: policy/ci/pr-review.yaml


### PR DESCRIPTION
> 🏕️ This pull request was created by [camper](https://github.com/temporalio/camper), an automated security campaign tool.

## Finding

<table>
  <tr><td><strong>Rule</strong></td><td><code>unpinned-github-actions</code></td></tr>
  <tr><td><strong>Severity</strong></td><td>MEDIUM</td></tr>
  <tr><td><strong>Repository</strong></td><td><code>temporalio/deputy</code></td></tr>
  <tr><td><strong>Ticket</strong></td><td><a href="https://temporalio.atlassian.net/browse/VLN-1427">VLN-1427</a></td></tr>
</table>

## Summary

- `.github/workflows/ci.yml`: Pinned all third-party `uses:` entries (`actions/checkout`, `actions/setup-go`, `actions/upload-artifact`) to full 40-character commit SHAs and added exact semver tag comments.
- `.github/workflows/pr-gate.yml`: Pinned `actions/checkout` to a full commit SHA with semver comment, and converted `picatz/deputy/actions/*@main` references to same-repo local `./actions/*` references.
- `.github/workflows/release-sbom.yml`: Pinned `actions/checkout` to a full commit SHA with semver comment, and converted `picatz/deputy/actions/*@main` references to local `./actions/*` references.
- `.github/workflows/release.yml`: Converted reusable workflow and setup references from `picatz/deputy/...@main` to local `./...` paths; pinned `actions/checkout`, `actions/setup-go`, `sigstore/cosign-installer`, and `goreleaser/goreleaser-action` to full SHAs with exact semver comments.
- `.github/workflows/scan.yml`: Pinned `actions/checkout` to a full commit SHA with semver comment, and converted `picatz/deputy/actions/*@main` references to local `./actions/*` references.
- `.github/workflows/security.yml`: Converted reusable workflow references from `picatz/deputy/.github/workflows/*@main` to local `./.github/workflows/*` paths.
- `.github/dependabot.yml`: Added Dependabot configuration for `github-actions` updates at weekly cadence with a 14-day cooldown.

## Instructions

- **Approve** to merge this fix
- **Request changes** to trigger a new remediation attempt
- `/camper rebase` — rebase onto the base branch
- `/camper close` — close this PR without merging
- `/camper retry` — close and retry with a new fix