### PR TITLE
More Deputy fixes: pinning correctness, output cleanup, scan remediation

### DIFF
--- a/docs/commands/pin.md
+++ b/docs/commands/pin.md
@@ -20,6 +20,39 @@ deputy pin update [directory] [flags]
 
 By default, both ecosystems are pinned. Use `--ecosystems` to narrow.
 
+## Resolution semantics
+
+`deputy pin` is **faithful**: it pins each reference to the exact immutable
+commit (or digest) that the reference resolves to *right now*. It never
+substitutes a different release. If `uses: actions/foo@v7` currently resolves
+to the `v7.6.0` commit, that is the commit you get — pinning never silently
+upgrades or downgrades the code that runs.
+
+This guarantee is why you sometimes see a less-specific version comment than you
+might expect:
+
+```yaml
+# Floating major tag with a precise patch on the same commit:
+uses: astral-sh/setup-uv@37802adc…  # v7.6.0   ← v7 and v7.6.0 are the same commit
+
+# Floating major moved ahead of any patch tag (no vX.Y.Z on this commit):
+uses: Swatinem/rust-cache@e18b497…  # v2       ← v2 is the most specific true tag
+
+# Branch ref (e.g. a rolling channel):
+uses: dtolnay/rust-toolchain@29eef33…  # stable ← pinned to the branch's commit
+```
+
+The comment always reflects the **most specific ref that genuinely points at the
+pinned commit**. Deputy will not fabricate a precise version (e.g. `# v2.9.1`)
+when that tag points at a *different* commit — doing so would misrepresent what
+is actually pinned. The comment is also what Dependabot and Renovate read to
+propose updates, so it is kept accurate to the pinned commit.
+
+To intentionally move pins forward to the latest release in their channel, use
+[`deputy pin update`](#subcommands) — that is the command that changes versions.
+Plain `deputy pin` only makes an existing reference immutable; it does not change
+which version you are on.
+
 ## Subcommands
 
 | Subcommand | Network | Writes | Purpose |

--- a/docs/commands/policy.md
+++ b/docs/commands/policy.md
@@ -131,20 +131,20 @@ $ deputy policy test tests/
 Package multiple policies into a single distributable file.
 
 ```
-deputy policy bundle --out bundle.json <policy.yaml> [policy2.yaml ...]
+deputy policy bundle --output bundle.json <policy.yaml> [policy2.yaml ...]
 ```
 
 ### Flags
 
 | Flag | Default | Description |
 | --- | --- | --- |
-| `--out` | *required* | Output bundle path (use `-` for stdout) |
+| `--output` | *required* | Output bundle path (use `-` for stdout) |
 
 ### Example
 
 ```console
 $ deputy policy bundle \
-    --out production.json \
+    --output production.json \
     policies/security.yaml \
     policies/compliance.yaml
 ```
@@ -394,7 +394,7 @@ flowchart LR
 2. Lint                →  deputy policy lint policy.yaml
 3. Test                →  deputy policy test tests/
 4. Try interactively   →  deputy policy repl
-5. Bundle              →  deputy policy bundle --out bundle.json policy.yaml
+5. Bundle              →  deputy policy bundle --output bundle.json policy.yaml
 6. Deploy              →  deputy proxy serve --policy bundle.json
 ```
 

--- a/internal/cli/cmd/pin.go
+++ b/internal/cli/cmd/pin.go
@@ -252,7 +252,7 @@ func runPin(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := outputPinReport(cmd, report, format, outPath); err != nil {
+	if err := outputPinReport(cmd, report, format, outPath, dryRun); err != nil {
 		return err
 	}
 
@@ -296,7 +296,7 @@ func runPinCheck(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := outputPinReport(cmd, report, format, outPath); err != nil {
+	if err := outputPinReport(cmd, report, format, outPath, false); err != nil {
 		return err
 	}
 
@@ -346,7 +346,7 @@ func runPinVerify(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := outputPinReport(cmd, report, format, outPath); err != nil {
+	if err := outputPinReport(cmd, report, format, outPath, false); err != nil {
 		return err
 	}
 
@@ -396,7 +396,7 @@ func runPinUpdate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := outputPinReport(cmd, report, format, outPath); err != nil {
+	if err := outputPinReport(cmd, report, format, outPath, dryRun); err != nil {
 		return err
 	}
 
@@ -416,8 +416,9 @@ func resolveDir(args []string) (string, error) {
 	return absDir, nil
 }
 
-// outputPinReport writes the report in the requested format.
-func outputPinReport(_ *cobra.Command, report *pin.Report, format, outPath string) error {
+// outputPinReport writes the report in the requested format. dryRun adjusts the
+// human-readable wording so a preview never claims files were modified.
+func outputPinReport(_ *cobra.Command, report *pin.Report, format, outPath string, dryRun bool) error {
 	var w io.Writer = os.Stdout
 	if outPath != "" && outPath != "-" {
 		f, err := os.Create(outPath)
@@ -436,7 +437,7 @@ func outputPinReport(_ *cobra.Command, report *pin.Report, format, outPath strin
 			return fmt.Errorf("encoding JSON: %w", err)
 		}
 	default:
-		renderPinReport(w, report)
+		renderPinReport(w, report, dryRun)
 	}
 	return nil
 }
@@ -455,8 +456,9 @@ func pinExitCode(report *pin.Report) error {
 }
 
 // renderPinReport writes a human-readable summary of pin results to w,
-// grouped by file.
-func renderPinReport(w io.Writer, report *pin.Report) {
+// grouped by file. When dryRun is true, wording reflects a preview so the
+// output never implies files were modified.
+func renderPinReport(w io.Writer, report *pin.Report, dryRun bool) {
 	if len(report.Results) == 0 {
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, ui.StyleAdded.Render("✓ No pinnable dependencies found"))
@@ -471,9 +473,17 @@ func renderPinReport(w io.Writer, report *pin.Report) {
 		heading = "Suspicious Pins Detected:"
 	case s.Unpinned > 0:
 		heading = "Unpinned Dependencies Found:"
-	case s.Pinned > 0 || s.Updated > 0:
-		heading = "Dependencies Pinned:"
-	case s.Verified > 0 && s.Pinned == 0:
+	case s.Updated > 0:
+		heading = "Dependencies to Update:"
+		if !dryRun {
+			heading = "Dependencies Updated:"
+		}
+	case s.Pinned > 0:
+		heading = "Dependencies to Pin:"
+		if !dryRun {
+			heading = "Dependencies Pinned:"
+		}
+	case s.Verified > 0:
 		heading = "Verification Results:"
 	}
 
@@ -504,7 +514,12 @@ func renderPinReport(w io.Writer, report *pin.Report) {
 	}
 
 	fmt.Fprintln(w)
-	renderPinSummary(w, report.Stats)
+	renderPinSummary(w, report.Stats, dryRun)
+
+	if dryRun && (report.Stats.Pinned > 0 || report.Stats.Updated > 0) {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, ui.StyleDim.Render("  Dry run — no files were modified. Re-run without --dry-run to apply."))
+	}
 }
 
 func renderPinResult(w io.Writer, r pin.Result, arrow string) {
@@ -549,6 +564,7 @@ func renderPinResult(w io.Writer, r pin.Result, arrow string) {
 
 	case pin.StatusVerified:
 		detail := "verified"
+		var caveats []string
 		if r.Verification != nil {
 			var parts []string
 			if r.Verification.SignatureValid {
@@ -560,8 +576,15 @@ func renderPinResult(w io.Writer, r pin.Result, arrow string) {
 			if len(parts) > 0 {
 				detail = strings.Join(parts, ", ")
 			}
+			caveats = r.Verification.Warnings
 		}
-		fmt.Fprintln(w, prefix+styledName+" "+ui.StyleAdded.Render(detail))
+		line := prefix + styledName + " " + ui.StyleAdded.Render(detail)
+		// Surface non-fatal caveats (unsigned, ahead of branch, unverifiable
+		// reachability) that don't rise to "suspicious" but are worth seeing.
+		if len(caveats) > 0 {
+			line += " " + ui.StyleDim.Render("("+strings.Join(caveats, "; ")+")")
+		}
+		fmt.Fprintln(w, line)
 
 	case pin.StatusSuspicious:
 		fmt.Fprintln(w, prefix+styledName+" "+
@@ -579,17 +602,25 @@ func renderPinResult(w io.Writer, r pin.Result, arrow string) {
 	}
 }
 
-func renderPinSummary(w io.Writer, s pin.Stats) {
+func renderPinSummary(w io.Writer, s pin.Stats, dryRun bool) {
 	fmt.Fprintln(w, ui.StyleHeader.Render("Summary:"))
 	if s.Pinned > 0 {
+		msg := fmt.Sprintf("%d pinned to immutable SHA", s.Pinned)
+		if dryRun {
+			msg = fmt.Sprintf("%d would be pinned to immutable SHA", s.Pinned)
+		}
 		fmt.Fprintf(w, "  %s %s\n",
 			ui.StyleSymbol.Render(ui.StyleAdded.Render("↑")),
-			ui.StyleSymbol.Render(fmt.Sprintf("%d pinned to immutable SHA", s.Pinned)))
+			ui.StyleSymbol.Render(msg))
 	}
 	if s.Updated > 0 {
+		msg := fmt.Sprintf("%d updated to latest version", s.Updated)
+		if dryRun {
+			msg = fmt.Sprintf("%d would be updated to latest version", s.Updated)
+		}
 		fmt.Fprintf(w, "  %s %s\n",
 			ui.StyleSymbol.Render(ui.StyleUpgraded.Render("↑")),
-			ui.StyleSymbol.Render(fmt.Sprintf("%d updated to latest version", s.Updated)))
+			ui.StyleSymbol.Render(msg))
 	}
 	if s.AlreadyPinned > 0 {
 		fmt.Fprintf(w, "  %s %s\n",

--- a/internal/cli/cmd/pin_test.go
+++ b/internal/cli/cmd/pin_test.go
@@ -1,13 +1,102 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"strings"
 	"testing"
 
+	"github.com/temporalio/deputy/internal/pin"
 	"github.com/temporalio/deputy/internal/pin/container"
 	"github.com/temporalio/deputy/internal/pin/githubactions"
 )
+
+// pinnedReport builds a report with a single freshly-pinned result.
+func pinnedReport() *pin.Report {
+	r := &pin.Report{
+		Results: []pin.Result{{
+			Ref:         pin.Ref{Name: "actions/checkout", Version: "v4", FilePath: "/repo/.github/workflows/ci.yml"},
+			Status:      pin.StatusPinned,
+			PreviousRef: "v4",
+			PinnedValue: "11bd71901bbe5b1630ceea73d27597364c9af683",
+			VersionTag:  "v4.2.2",
+		}},
+		Stats: pin.Stats{Total: 1, Pinned: 1},
+	}
+	return r
+}
+
+func TestRenderPinReport_DryRunWording(t *testing.T) {
+	var buf bytes.Buffer
+	renderPinReport(&buf, pinnedReport(), true)
+	out := stripANSI(buf.String())
+
+	// Dry run must NOT claim files were pinned.
+	if strings.Contains(out, "Dependencies Pinned:") {
+		t.Errorf("dry run should not say 'Dependencies Pinned:', got:\n%s", out)
+	}
+	for _, want := range []string{"Dependencies to Pin:", "would be pinned", "no files were modified"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("dry run output missing %q, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderPinReport_RealRunWording(t *testing.T) {
+	var buf bytes.Buffer
+	renderPinReport(&buf, pinnedReport(), false)
+	out := stripANSI(buf.String())
+
+	if !strings.Contains(out, "Dependencies Pinned:") {
+		t.Errorf("real run should say 'Dependencies Pinned:', got:\n%s", out)
+	}
+	if strings.Contains(out, "would be pinned") || strings.Contains(out, "no files were modified") {
+		t.Errorf("real run leaked dry-run wording, got:\n%s", out)
+	}
+}
+
+func TestRenderPinReport_VerifiedCaveatSurfaced(t *testing.T) {
+	report := &pin.Report{
+		Results: []pin.Result{{
+			Ref:         pin.Ref{Name: "actions/checkout", FilePath: "/repo/.github/workflows/ci.yml"},
+			Status:      pin.StatusVerified,
+			PinnedValue: "11bd71901bbe5b1630ceea73d27597364c9af683",
+			Verification: &pin.Verification{
+				SignatureValid: true,
+				OnBranch:       false,
+				Warnings:       []string{"commit has diverged from main"},
+			},
+		}},
+		Stats: pin.Stats{Total: 1, Verified: 1},
+	}
+
+	var buf bytes.Buffer
+	renderPinReport(&buf, report, false)
+	out := stripANSI(buf.String())
+
+	if !strings.Contains(out, "signed") {
+		t.Errorf("expected 'signed' in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "diverged from main") {
+		t.Errorf("verified caveat was dropped; expected 'diverged from main', got:\n%s", out)
+	}
+}
+
+// stripANSI removes ANSI escape sequences so assertions match visible text.
+func stripANSI(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == 0x1b {
+			// skip until the terminating 'm'
+			for i < len(s) && s[i] != 'm' {
+				i++
+			}
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
 
 func TestBuildPinStrategies(t *testing.T) {
 	tests := []struct {

--- a/internal/cli/cmd/policy.go
+++ b/internal/cli/cmd/policy.go
@@ -590,13 +590,13 @@ func newPolicyTestCommand() *cobra.Command {
 func newPolicyBundleCommand() *cobra.Command {
 	var outPath string
 	cmd := &cobra.Command{
-		Use:           "bundle --out bundle.json <policy.yaml> [policy2.yaml ...]",
+		Use:           "bundle --output bundle.json <policy.yaml> [policy2.yaml ...]",
 		Short:         "Compile CEL policies into a reusable bundle",
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if strings.TrimSpace(outPath) == "" {
-				return errors.New("missing --out path for bundle")
+				return errors.New("missing --output path for bundle")
 			}
 			if len(args) == 0 {
 				return errors.New("provide at least one CEL policy file")
@@ -616,7 +616,7 @@ func newPolicyBundleCommand() *cobra.Command {
 			return os.WriteFile(outPath, append(data, '\n'), 0o644)
 		},
 	}
-	cmd.Flags().StringVar(&outPath, "out", "", "Destination bundle file (use '-' for stdout)")
+	cmd.Flags().StringVarP(&outPath, "output", "o", "", "Destination bundle file (use '-' for stdout)")
 	return cmd
 }
 

--- a/internal/explain/renderer_test.go
+++ b/internal/explain/renderer_test.go
@@ -1,0 +1,259 @@
+package explain
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/ossf/osv-schema/bindings/go/osvschema"
+)
+
+func TestExtractCVSSInfo(t *testing.T) {
+	tests := []struct {
+		name       string
+		vuln       *osvschema.Vulnerability
+		wantVector string
+		wantScore  float64
+	}{
+		{
+			name:       "nil vuln",
+			vuln:       nil,
+			wantVector: "",
+			wantScore:  0,
+		},
+		{
+			name: "prefers CVSS v3 over v2",
+			vuln: &osvschema.Vulnerability{
+				Severity: []osvschema.Severity{
+					{Type: osvschema.SeverityCVSSV2, Score: "AV:N/AC:L/Au:N/C:P/I:P/A:P"},
+					{Type: osvschema.SeverityCVSSV3, Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"},
+				},
+			},
+			wantVector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+			wantScore:  9.8,
+		},
+		{
+			// CVSS v2 is selected as the fallback (vector returned), but the
+			// score parser only understands v3/v4 vectors, so it returns -1.
+			// This documents current behavior; v2 numeric scoring is unsupported.
+			name: "falls back to v2 when no v3/v4",
+			vuln: &osvschema.Vulnerability{
+				Severity: []osvschema.Severity{
+					{Type: osvschema.SeverityCVSSV2, Score: "AV:N/AC:L/Au:N/C:P/I:P/A:P"},
+				},
+			},
+			wantVector: "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+			wantScore:  -1,
+		},
+		{
+			name:       "no severity entries",
+			vuln:       &osvschema.Vulnerability{},
+			wantVector: "",
+			wantScore:  0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			vector, score := extractCVSSInfo(tc.vuln)
+			if vector != tc.wantVector {
+				t.Errorf("vector = %q, want %q", vector, tc.wantVector)
+			}
+			if score != tc.wantScore {
+				t.Errorf("score = %v, want %v", score, tc.wantScore)
+			}
+		})
+	}
+}
+
+func TestDeriveSeverity(t *testing.T) {
+	tests := []struct {
+		name  string
+		score float64
+		vuln  *osvschema.Vulnerability
+		want  string
+	}{
+		{"critical", 9.8, nil, "CRITICAL"},
+		{"critical boundary", 9.0, nil, "CRITICAL"},
+		{"high", 7.5, nil, "HIGH"},
+		{"high boundary", 7.0, nil, "HIGH"},
+		{"medium", 5.0, nil, "MEDIUM"},
+		{"medium boundary", 4.0, nil, "MEDIUM"},
+		{"low", 2.0, nil, "LOW"},
+		{
+			name:  "zero score falls back to GHSA database_specific",
+			score: 0,
+			vuln: &osvschema.Vulnerability{
+				DatabaseSpecific: map[string]any{"severity": "high"},
+			},
+			want: "HIGH",
+		},
+		{
+			name:  "zero score with no fallback is UNKNOWN",
+			score: 0,
+			vuln:  &osvschema.Vulnerability{},
+			want:  "UNKNOWN",
+		},
+		{"zero score nil vuln is UNKNOWN", 0, nil, "UNKNOWN"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := deriveSeverity(tc.score, tc.vuln)
+			if got != tc.want {
+				t.Errorf("deriveSeverity(%v) = %q, want %q", tc.score, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFindCVEID(t *testing.T) {
+	tests := []struct {
+		name string
+		vuln *osvschema.Vulnerability
+		want string
+	}{
+		{"nil", nil, ""},
+		{
+			name: "ID is a CVE",
+			vuln: &osvschema.Vulnerability{ID: "CVE-2021-44228"},
+			want: "CVE-2021-44228",
+		},
+		{
+			name: "CVE found in aliases",
+			vuln: &osvschema.Vulnerability{
+				ID:      "GHSA-jfh8-c2jp-5v3q",
+				Aliases: []string{"CVE-2021-44228"},
+			},
+			want: "CVE-2021-44228",
+		},
+		{
+			name: "no CVE anywhere",
+			vuln: &osvschema.Vulnerability{
+				ID:      "GHSA-jfh8-c2jp-5v3q",
+				Aliases: []string{"GO-2021-0001"},
+			},
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := findCVEID(tc.vuln)
+			if got != tc.want {
+				t.Errorf("findCVEID = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractCWEs(t *testing.T) {
+	t.Run("nil vuln returns nil", func(t *testing.T) {
+		if got := extractCWEs(nil); got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("no database_specific returns nil", func(t *testing.T) {
+		if got := extractCWEs(&osvschema.Vulnerability{}); got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("extracts cwe_ids", func(t *testing.T) {
+		vuln := &osvschema.Vulnerability{
+			DatabaseSpecific: map[string]any{
+				"cwe_ids": []any{"CWE-79", "CWE-89"},
+			},
+		}
+		got := extractCWEs(vuln)
+		if len(got) != 2 {
+			t.Fatalf("expected 2 CWEs, got %d: %+v", len(got), got)
+		}
+		if got[0].ID != "CWE-79" {
+			t.Errorf("first CWE ID = %q, want CWE-79", got[0].ID)
+		}
+	})
+}
+
+// TestRenderJSON_GoldenShape exercises the full buildVulnData → JSON path,
+// which covers the osvschema field access (ID, References, Affected, Severity)
+// touched during the protobuf migration. It asserts on stable JSON keys rather
+// than exact formatting.
+func TestRenderJSON_GoldenShape(t *testing.T) {
+	vuln := &osvschema.Vulnerability{
+		ID:      "GHSA-jfh8-c2jp-5v3q",
+		Aliases: []string{"CVE-2021-44228"},
+		Summary: "Log4Shell",
+		Details: "Remote code execution in Apache Log4j2.",
+		Severity: []osvschema.Severity{
+			{Type: osvschema.SeverityCVSSV3, Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"},
+		},
+		References: []osvschema.Reference{
+			{Type: osvschema.ReferenceAdvisory, URL: "https://example.com/advisory"},
+			{Type: osvschema.ReferenceWeb, URL: "https://example.com/blog"},
+		},
+		DatabaseSpecific: map[string]any{
+			"cwe_ids": []any{"CWE-502"},
+		},
+	}
+
+	r := NewRenderer(Config{Enrich: false})
+	var buf bytes.Buffer
+	if err := r.RenderJSON(context.Background(), &buf, vuln); err != nil {
+		t.Fatalf("RenderJSON: %v", err)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, buf.String())
+	}
+
+	if out["id"] != "GHSA-jfh8-c2jp-5v3q" {
+		t.Errorf("id = %v, want GHSA-jfh8-c2jp-5v3q", out["id"])
+	}
+	// severity is a rich object; assert its derived level.
+	sevObj, ok := out["severity"].(map[string]any)
+	if !ok {
+		t.Fatalf("severity is not an object: %v", out["severity"])
+	}
+	if lvl, _ := sevObj["level"].(string); !strings.EqualFold(lvl, "CRITICAL") {
+		t.Errorf("severity.level = %v, want CRITICAL", sevObj["level"])
+	}
+}
+
+func TestRender_NilVulnIsNoOp(t *testing.T) {
+	r := NewRenderer(Config{})
+	var buf bytes.Buffer
+	if err := r.Render(context.Background(), &buf, nil); err != nil {
+		t.Fatalf("Render(nil): %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("expected no output for nil vuln, got %q", buf.String())
+	}
+}
+
+func TestRender_TextSmoke(t *testing.T) {
+	vuln := &osvschema.Vulnerability{
+		ID:      "CVE-2021-44228",
+		Summary: "Log4Shell",
+		Severity: []osvschema.Severity{
+			{Type: osvschema.SeverityCVSSV3, Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"},
+		},
+		References: []osvschema.Reference{
+			{Type: osvschema.ReferenceAdvisory, URL: "https://example.com/advisory"},
+		},
+	}
+
+	r := NewRenderer(Config{Enrich: false})
+	var buf bytes.Buffer
+	if err := r.Render(context.Background(), &buf, vuln); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "CVE-2021-44228") {
+		t.Errorf("expected vuln ID in output, got:\n%s", out)
+	}
+}

--- a/internal/pin/githubactions/resolver.go
+++ b/internal/pin/githubactions/resolver.go
@@ -9,6 +9,7 @@ import (
 
 	git "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/storage/memory"
 	"github.com/temporalio/deputy/internal/auth"
 	"github.com/temporalio/deputy/internal/pin"
@@ -161,13 +162,30 @@ func (r *Resolver) gitListRefs(ctx context.Context, remoteURL string) ([]refEntr
 		URLs: []string{remoteURL},
 	})
 
-	rawRefs, err := remote.ListContext(ctx, &git.ListOptions{Auth: gitAuth})
+	// AppendPeeled is required so annotated tags advertise their peeled
+	// "^{}" refs (the underlying commit). go-git defaults to IgnorePeeled,
+	// which strips them — leaving only the tag-object SHA. Without this we
+	// would pin the tag object instead of the commit it points to, which is
+	// both semantically wrong for a "pin the reviewed commit" tool and
+	// degrades the version comment (e.g. "# v2" instead of "# v2.8.0").
+	rawRefs, err := remote.ListContext(ctx, &git.ListOptions{
+		Auth:          gitAuth,
+		PeelingOption: git.AppendPeeled,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("ls-remote %s: %w", remoteURL, err)
 	}
 
-	// Build ref entries. For annotated tags, prefer the peeled "^{}" ref
-	// which gives us the underlying commit SHA directly.
+	return mergeRefs(rawRefs), nil
+}
+
+// mergeRefs converts raw advertised refs into tag-name → commit-SHA entries.
+//
+// For annotated tags, ls-remote (with AppendPeeled) advertises both the tag
+// object ref and a peeled "<name>^{}" ref pointing at the underlying commit.
+// We always prefer the peeled commit SHA so callers pin the commit, never the
+// tag object. Lightweight tags have no peeled ref and resolve to their own SHA.
+func mergeRefs(rawRefs []*plumbing.Reference) []refEntry {
 	peeled := make(map[string]string)   // "refs/tags/v4.2.2" → commit SHA (from ^{})
 	regular := make(map[string]string)  // "refs/tags/v4.2.2" → object SHA
 	branches := make(map[string]string) // "refs/heads/main" → commit SHA
@@ -206,7 +224,7 @@ func (r *Resolver) gitListRefs(ctx context.Context, remoteURL string) ([]refEntr
 		entries = append(entries, refEntry{name: name, sha: sha})
 	}
 
-	return entries, nil
+	return entries
 }
 
 // gitRemoteURL constructs the HTTPS git remote URL for a GitHub repository.

--- a/internal/pin/githubactions/resolver_test.go
+++ b/internal/pin/githubactions/resolver_test.go
@@ -123,6 +123,50 @@ func TestResolveSHA(t *testing.T) {
 	}
 }
 
+// TestResolveSHA_FaithfulNoDowngrade locks in the no-silent-downgrade
+// guarantee. A floating major tag (v7) points at the LATEST release commit,
+// while an older patch tag (v7.1.6) points at a different, older commit.
+// Resolving @v7 must return the commit v7 currently points to — never the
+// older release. (Modeled on the real astral-sh/setup-uv layout, where a
+// substitution bug would pin v7.1.6 instead of the live v7.6.0.)
+func TestResolveSHA_FaithfulNoDowngrade(t *testing.T) {
+	const (
+		latestCommit = "37802adc94f370d6bfd71619e3f0bf239e1f3b78" // what v7 → v7.6.0 points to now
+		oldCommit    = "681c641aba71e4a1c380be3ab5e12ad51f415867" // older v7.1.6 release
+	)
+	fakeRefs := []refEntry{
+		{name: "refs/tags/v7", sha: latestCommit},      // floating major → latest
+		{name: "refs/tags/v7.6.0", sha: latestCommit},  // precise tag on same commit
+		{name: "refs/tags/v7.1.6", sha: oldCommit},     // older release, different commit
+		{name: "refs/heads/main", sha: latestCommit},
+	}
+
+	r := &Resolver{refCache: make(map[string][]refEntry)}
+	r.listRefsFunc = func(ctx context.Context, remoteURL string) ([]refEntry, error) {
+		return fakeRefs, nil
+	}
+
+	// @v7 must resolve to the commit v7 points to now, not the older v7.1.6.
+	sha, err := r.ResolveSHA(t.Context(), "astral-sh", "setup-uv", "v7")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sha != latestCommit {
+		t.Fatalf("resolving @v7 = %s, want current target %s (must NOT downgrade to %s)",
+			sha, latestCommit, oldCommit)
+	}
+
+	// And the annotation should be the precise tag on that exact commit (v7.6.0),
+	// never the older release tag.
+	tag, err := r.ResolveTag(t.Context(), "astral-sh", "setup-uv", sha)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tag != "v7.6.0" {
+		t.Errorf("tag annotation = %q, want v7.6.0", tag)
+	}
+}
+
 func TestResolveSHA_NetworkError(t *testing.T) {
 	r := &Resolver{refCache: make(map[string][]refEntry)}
 	r.listRefsFunc = func(ctx context.Context, remoteURL string) ([]refEntry, error) {

--- a/internal/pin/githubactions/resolver_test.go
+++ b/internal/pin/githubactions/resolver_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing"
 )
 
 func TestBestSemverTag(t *testing.T) {
@@ -160,6 +162,49 @@ func TestResolveTag(t *testing.T) {
 	}
 	if tag != "v4.2.2" {
 		t.Errorf("got %q, want v4.2.2", tag)
+	}
+}
+
+func TestMergeRefs_PrefersPeeledCommitOverTagObject(t *testing.T) {
+	// Regression for the annotated-tag pinning bug: when a tag is annotated,
+	// ls-remote (with AppendPeeled) advertises both the tag object ref and a
+	// peeled "^{}" ref. We must pin the peeled COMMIT, never the tag object.
+	const (
+		tagObjectSHA = "42dc69e1aa15d09112580998cf2ef0119e2e91ae" // annotated tag object
+		commitSHA    = "e18b497796c12c097a38f9edb9d0641fb99eee32" // underlying commit
+		lwTagSHA     = "de0fac2e4500dabe0009e67214ff5f5447ce83dd" // lightweight tag → commit
+		branchSHA    = "cccccccccccccccccccccccccccccccccccccccc"
+	)
+
+	raw := []*plumbing.Reference{
+		// Annotated tag: object ref + peeled ref.
+		plumbing.NewReferenceFromStrings("refs/tags/v2", tagObjectSHA),
+		plumbing.NewReferenceFromStrings("refs/tags/v2^{}", commitSHA),
+		// Lightweight tag: no peeled ref.
+		plumbing.NewReferenceFromStrings("refs/tags/v6", lwTagSHA),
+		// Branch.
+		plumbing.NewReferenceFromStrings("refs/heads/main", branchSHA),
+		// HEAD should be ignored.
+		plumbing.NewReferenceFromStrings("HEAD", branchSHA),
+	}
+
+	got := map[string]string{}
+	for _, e := range mergeRefs(raw) {
+		got[e.name] = e.sha
+	}
+
+	if got["refs/tags/v2"] != commitSHA {
+		t.Errorf("annotated tag v2: got %s, want peeled commit %s (not tag object %s)",
+			got["refs/tags/v2"], commitSHA, tagObjectSHA)
+	}
+	if got["refs/tags/v6"] != lwTagSHA {
+		t.Errorf("lightweight tag v6: got %s, want %s", got["refs/tags/v6"], lwTagSHA)
+	}
+	if got["refs/heads/main"] != branchSHA {
+		t.Errorf("branch main: got %s, want %s", got["refs/heads/main"], branchSHA)
+	}
+	if _, ok := got["HEAD"]; ok {
+		t.Error("HEAD should be excluded from merged refs")
 	}
 }
 

--- a/internal/report/render/vulnerabilities.go
+++ b/internal/report/render/vulnerabilities.go
@@ -118,10 +118,10 @@ func VulnerabilityList(w io.Writer, cons []vulnerability.Consolidated, opts Vuln
 		for _, v := range list {
 			sevDisp := ui.SeverityLabel(v.Severity, v.SeverityType)
 			parts := []string{ui.StyleSymbol.Render(v.PrimaryID), sevDisp}
-			if len(v.FixedVersions) > 0 {
-				if best := vulnerability.FindBestFixedVersion(v.FixedVersions, v.Version); best != "" {
-					parts = append(parts, ui.StyleUpgraded.Render(fmt.Sprintf("(↑ %s)", best)))
-				}
+			if best := vulnerability.FindBestFixedVersion(v.FixedVersions, v.Version); best != "" {
+				parts = append(parts, ui.StyleUpgraded.Render(fmt.Sprintf("(↑ %s)", best)))
+			} else if cmd := v.CommandRemediation(); cmd != "" {
+				parts = append(parts, ui.StyleUpgraded.Render(fmt.Sprintf("(fix: %s)", cmd)))
 			}
 			if v.RelatedCount > 1 {
 				parts = append(parts, ui.StyleVersion.Render(fmt.Sprintf("[%d related]", v.RelatedCount)))
@@ -213,11 +213,14 @@ func VulnerabilitySummaryAndActions(w io.Writer, cons []vulnerability.Consolidat
 	if summary.FixAvailableCount > 0 {
 		fmt.Fprintln(w, "  "+ui.StyleSymbol.Render(ui.StyleUpgraded.Render("↑"))+" "+ui.StyleSymbol.Render(fmt.Sprintf("%d can be fixed by upgrading", summary.FixAvailableCount)))
 	}
+	if summary.CommandFixableCount > 0 {
+		fmt.Fprintln(w, "  "+ui.StyleSymbol.Render(ui.StyleUpgraded.Render("↑"))+" "+ui.StyleSymbol.Render(fmt.Sprintf("%d can be fixed by pinning", summary.CommandFixableCount)))
+	}
 	if summary.UnfixedCount > 0 {
 		fmt.Fprintln(w, "  "+ui.StyleSymbol.Render(ui.StyleRemoved.Render("-"))+" "+ui.StyleSymbol.Render(fmt.Sprintf("%d have no fix available yet", summary.UnfixedCount)))
 	}
 
-	if len(summary.Commands) > 0 || summary.StdlibRecommendation != "" || summary.UnfixedCount > 0 {
+	if len(summary.Commands) > 0 || summary.StdlibRecommendation != "" || len(summary.CommandRemediations) > 0 || summary.UnfixedCount > 0 {
 		fmt.Fprintln(w)
 		fmt.Fprintln(w, ui.StyleHeader.Render("Recommended Actions:"))
 		step := 1
@@ -228,6 +231,11 @@ func VulnerabilitySummaryAndActions(w io.Writer, cons []vulnerability.Consolidat
 		if len(summary.Commands) > 0 {
 			fmt.Fprintf(w, "  %d. %s\n", step, ui.StyleBold.Render(summary.CommandsHeader))
 			RemediationCommands(w, summary.Commands, "       ", "         ")
+			step++
+		}
+		for _, cmd := range summary.CommandRemediations {
+			fmt.Fprintf(w, "  %d. %s\n", step, ui.StyleBold.Render("Pin mutable references to immutable revisions"))
+			fmt.Fprintf(w, "       %s\n", ui.StyleVersion.Render(cmd))
 			step++
 		}
 		if summary.UnfixedCount > 0 {

--- a/internal/report/summary.go
+++ b/internal/report/summary.go
@@ -16,6 +16,12 @@ type Summary struct {
 	StdlibRecommendation string
 	Commands             []remediation.Command
 	CommandsHeader       string
+
+	// CommandFixableCount counts findings resolved by an action (e.g. pinning)
+	// rather than a version upgrade. CommandRemediations lists the distinct
+	// commands, in first-seen order (e.g. "deputy pin").
+	CommandFixableCount int
+	CommandRemediations []string
 }
 
 // BuildSummaryFromResult computes summary stats from a ConsolidatedResult.
@@ -33,7 +39,25 @@ func BuildSummary(cons []vulnerability.Consolidated, stats vulnerabilityv1.Stats
 		stats = vulnerability.StatsFromConsolidated(cons, len(cons))
 	}
 	high := stats.Critical + stats.High
-	unfixed := stats.Unique - stats.FixAvailable
+
+	// Findings whose fix is an action (e.g. pinning) rather than a version
+	// upgrade. These are fixable, so they must not fall into "no fix available".
+	var cmdRemediations []string
+	seenCmd := map[string]bool{}
+	commandFixable := 0
+	for _, v := range cons {
+		cmd := v.CommandRemediation()
+		if cmd == "" {
+			continue
+		}
+		commandFixable++
+		if !seenCmd[cmd] {
+			seenCmd[cmd] = true
+			cmdRemediations = append(cmdRemediations, cmd)
+		}
+	}
+
+	unfixed := int(stats.Unique) - int(stats.FixAvailable) - commandFixable
 	if unfixed < 0 {
 		unfixed = 0
 	}
@@ -47,9 +71,11 @@ func BuildSummary(cons []vulnerability.Consolidated, stats vulnerabilityv1.Stats
 		Stats:                stats,
 		CriticalHighCount:    int(high),
 		FixAvailableCount:    int(stats.FixAvailable),
-		UnfixedCount:         int(unfixed),
+		UnfixedCount:         unfixed,
 		StdlibRecommendation: stdlibRec,
 		Commands:             commands,
 		CommandsHeader:       header,
+		CommandFixableCount:  commandFixable,
+		CommandRemediations:  cmdRemediations,
 	}
 }

--- a/internal/report/summary_test.go
+++ b/internal/report/summary_test.go
@@ -33,3 +33,43 @@ func TestBuildSummary_WithVulns(t *testing.T) {
 		t.Fatalf("expected CommandsHeader")
 	}
 }
+
+// A supply-chain finding (fix = a command, not a version upgrade) must be
+// counted as command-fixable, not as "no fix available".
+func TestBuildSummary_CommandRemediation(t *testing.T) {
+	cons := []vulnerability.Consolidated{
+		{
+			PrimaryID:    "DEPUTY-SC-UNPINNED-ACTION",
+			Severity:     "MEDIUM",
+			SeverityType: "CUSTOM",
+			Version:      "v2",
+			// Encoded as a fake fixed version upstream; not a semver upgrade.
+			FixedVersions:    []string{"deputy pin"},
+			DatabaseSpecific: map[string]string{"type": "supply-chain", "remediation": "deputy pin"},
+		},
+	}
+	// stats.Unique=1, FixAvailable=0 (no semver fix).
+	summary := BuildSummary(cons, vulnerabilityv1.Stats{Unique: 1})
+
+	if summary.UnfixedCount != 0 {
+		t.Errorf("supply-chain finding should not be 'unfixed', got UnfixedCount=%d", summary.UnfixedCount)
+	}
+	if summary.CommandFixableCount != 1 {
+		t.Errorf("expected CommandFixableCount=1, got %d", summary.CommandFixableCount)
+	}
+	if len(summary.CommandRemediations) != 1 || summary.CommandRemediations[0] != "deputy pin" {
+		t.Errorf("expected CommandRemediations=[deputy pin], got %v", summary.CommandRemediations)
+	}
+}
+
+// When a semver upgrade exists, CommandRemediation must defer to it.
+func TestConsolidated_CommandRemediation_PrefersSemver(t *testing.T) {
+	v := vulnerability.Consolidated{
+		Version:          "v1.0.0",
+		FixedVersions:    []string{"v1.2.0"},
+		DatabaseSpecific: map[string]string{"remediation": "deputy pin"},
+	}
+	if cmd := v.CommandRemediation(); cmd != "" {
+		t.Errorf("expected empty (semver upgrade available), got %q", cmd)
+	}
+}

--- a/internal/vulnerability/consolidated.go
+++ b/internal/vulnerability/consolidated.go
@@ -139,6 +139,21 @@ func ConsolidateAll(findings []Finding, advisories map[string]*vulnerabilityv1.A
 	}
 }
 
+// CommandRemediation returns a shell command that resolves this finding when
+// the fix is an action (e.g. pinning a mutable reference) rather than a version
+// upgrade. Supply-chain hygiene findings set DatabaseSpecific["remediation"].
+// Returns "" when a standard version upgrade is available or no fix is known,
+// so callers can prefer the semver upgrade path.
+func (c Consolidated) CommandRemediation() string {
+	if c.DatabaseSpecific == nil {
+		return ""
+	}
+	if FindBestFixedVersion(c.FixedVersions, c.Version) != "" {
+		return ""
+	}
+	return c.DatabaseSpecific["remediation"]
+}
+
 // StatsFromConsolidated computes aggregate stats from consolidated records.
 func StatsFromConsolidated(cons []Consolidated, totalFindings int) vulnerabilityv1.Stats {
 	stats := vulnerabilityv1.Stats{Total: int32(len(cons)), Unique: int32(len(cons)), Duplicates: int32(totalFindings - len(cons))}


### PR DESCRIPTION
Follow-up polish on top of #36, driven by dogfooding `deputy pin`/`deputy scan` on `nexus-api-gen` and comparing against Camper's output from https://github.com/temporalio/nexus-api-gen/pull/12. The "headline" is a **real pinning correctness bug**; the rest are output-honesty and consistency improvements.

### 🐛 Pin annotated tags to the commit, not the tag object (`fbb229d`)

The big one. `deputy pin` was pinning **annotated tag-object SHAs instead of the commits they point to**. Root cause: `go-git`'s `ListContext` defaults to `IgnorePeeled`, which strips the peeled `^{}` refs; so, for annotated tags the resolver only ever saw the tag object.

Observed pinning `astral-sh/setup-uv@v7`: pinned `94527f…` (tag object) with a vague `# v7`. After the fix it pins `37802a…` (the actual commit) with a precise `# v7.6.0`. Fix is a one-liner (`PeelingOption: AppendPeeled`) plus extracting the merge logic into a tested `mergeRefs`.

### ✨ Honest `--dry-run` + surfaced verify caveats (`3970bf4`)

- `deputy pin --dry-run` no longer claims it modified files. Was: "Dependencies Pinned / N pinned to immutable SHA". Now: "Dependencies to Pin / N would be pinned" + a "no files were modified" footer.
- `deputy pin verify` now surfaces caveats that were silently dropped — a pin that's unsigned, diverged from the default branch, or whose reachability couldn't be checked (rate-limited) now shows the reason dimmed, e.g. `actions/checkout signed (commit has diverged from main)`.

### ✨ Command-remediated findings are fixable in `deputy scan` (`26e45e3`)

Supply-chain findings (unpinned action/image) encode their fix as a command (`deputy pin`), not a version upgrade. The scan summary ran them through the semver pipeline and reported "**N have no fix available yet — monitor upstream**" — wrong, since the fix is one command away. Now:
- `DEPUTY-SC-UNPINNED-ACTION [MED] (fix: deputy pin)`
- `↑ 1 can be fixed by pinning`
- `Recommended Actions: Pin mutable references → deputy pin`

CVE behavior is unchanged — command remediation only kicks in when no semver upgrade exists.

### 📝 Faithful-pin semantics doc + no-downgrade guarantee (`e1a6187`)

Documents *why* you sometimes see `# v2` or `# stable` instead of a precise version: `deputy pin` pins the exact commit your ref resolves to **now**, never substituting a different release, and annotates with the most-specific ref that genuinely points at that commit. Adds `TestResolveSHA_FaithfulNoDowngrade` (modeled on setup-uv) to lock in the guarantee — `@v7` resolves to the live target, never an older patch release.

### 🧹 Smaller items

- `policy bundle --out` → `--output` (`fefc5e5`) — last flag inconsistency; now matches the `-o, --output` convention used everywhere else.
- Tests for `internal/explain` (`fbd81d3`) — the vuln-explanation renderer had zero coverage and was touched in #36's osvschema migration. Added table-driven tests for severity/CVSS/CWE extraction + render smoke tests (surfaced a documented CVSS-v2 scoring quirk).

### Test plan

- [x] `go build ./...`
- [x] `go test ./internal/pin/... ./internal/explain/ ./internal/report/... ./internal/cli/cmd/`
- [x] Verified `setup-uv`/`rust-cache` pins end-to-end against live upstreams (tag-object → commit)
- [x] Verified dry-run wording and scan remediation output by hand