### PR TITLE
feat(diff): expose release-freshness registry metadata as a policy signal

### DIFF
--- a/api/deputy/diff/v1/service.proto
+++ b/api/deputy/diff/v1/service.proto
@@ -122,6 +122,30 @@ message PackageChange {
 
   // IsDirect indicates whether this is a direct dependency.
   bool is_direct = 6;
+
+  // TargetMetadata is registry metadata for target_version (e.g. when it was
+  // published). It is unset for Removed changes and when registry-metadata
+  // fetching is disabled (see the diff --registry-metadata flag).
+  RegistryMetadata target_metadata = 7;
+}
+
+// RegistryMetadata captures registry-sourced facts about a single package version,
+// fetched from deps.dev. It is exposed as a policy signal so policies can reason
+// about supply-chain risk that a known-vulnerability scan cannot see — most notably
+// release freshness, since a version published minutes or hours ago has had no time
+// to be vetted and is a common shape for a malicious release.
+message RegistryMetadata {
+  // PublishedAt is when this version was published to its registry, per deps.dev.
+  // Unset when deps.dev has no publish date for the version.
+  google.protobuf.Timestamp published_at = 1;
+
+  // AgeDays is the age of this version in days at evaluation time (now - published_at).
+  // It is -1 when published_at is unknown. Provided as a convenience because CEL has no
+  // notion of "now", so policies can gate on freshness with e.g. age_days < 7.0.
+  double age_days = 2;
+
+  // Registries lists the registries deps.dev reports as hosting this version.
+  repeated string registries = 3;
 }
 
 // ChangeKind classifies the type of dependency change.

--- a/docs/commands/diff.md
+++ b/docs/commands/diff.md
@@ -365,6 +365,7 @@ flowchart TB
 | `--repo` | cwd | Path to the repository |
 | `--licenses` | `false` | Include license information |
 | `--license-source` | `depsdev` | License source: `depsdev`, `scan`, `both` |
+| `--registry-metadata` | `false` | Fetch registry metadata (publish date) from deps.dev and expose it to `diff_dependency_change` policies as `change.target_metadata` |
 | `--published-before` | | Only show vulns published before this date |
 | `--published-after` | | Only show vulns published on/after this date |
 | `--as-of` | | Historical view (implies `--published-before`) |

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -9,6 +9,7 @@ This section is for contributors and maintainers.
 | [Contributing](contributing.md) | Local setup, development workflow, PR checklist |
 | [Architecture](architecture.md) | System design, package structure |
 | [Adding ecosystems](adding-ecosystems.md) | How to add support for a new package ecosystem |
+| [Registry metadata signals](registry-metadata.md) | Release-freshness policy signal and the deferred maintainer-change design |
 | [Docs style](docs-style.md) | Documentation conventions |
 
 ## Quick Commands

--- a/docs/development/registry-metadata.md
+++ b/docs/development/registry-metadata.md
@@ -1,0 +1,64 @@
+# Registry metadata policy signals
+
+Deputy can fetch registry-sourced metadata about the version a dependency bump
+introduces and expose it to `diff_dependency_change` policies. The goal is to
+surface supply-chain risk that a known-vulnerability scan cannot see: a poisoned
+release has no CVE on the day it lands, but it often *looks* wrong — it was
+published minutes ago, or by an account that has never published the package
+before.
+
+This metadata comes from the deps.dev Insights API that Deputy already depends
+on, so the engine stays self-contained (no Python runtime, no shelling out to
+other tools).
+
+## What ships today: release freshness
+
+`deputy diff --registry-metadata` fetches each changed package's publish date
+from deps.dev and attaches it to the policy input as
+`change.target_metadata` (see
+[policy-inputs.md](../reference/policy-inputs.md#dependency-change-registry-metadata)).
+Policies gate on `change.target_metadata.age_days` to flag bumps to versions
+that are only hours or days old. See
+[`policy/examples/release-freshness.yaml`](../../policy/examples/release-freshness.yaml).
+
+Implementation:
+
+- `internal/registry` — the deps.dev-backed `Fetcher` and the pure
+  response→`Metadata` conversion.
+- `internal/cli/cmd/diff.go` — `enrichChangesWithRegistryMetadata` populates
+  `change.target_metadata` before policy evaluation, concurrently and
+  non-fatally (a flaky upstream leaves the field unset rather than failing the
+  diff).
+- `api/deputy/diff/v1/service.proto` — the `RegistryMetadata` message and the
+  `PackageChange.target_metadata` field.
+
+## Deferred: maintainer / publisher change
+
+A second high-value signal is a **maintainer change** — a brand-new or very
+young account suddenly publishing an established package, the shape of an
+account-takeover or infiltration (e.g. XZ-style). This is deliberately **not**
+in the initial change, for a concrete reason:
+
+> deps.dev does not expose registry publisher/maintainer account identity or
+> account age. It returns publish dates and related source repositories, but not
+> "who pushed this version" or "how old is that account."
+
+So a faithful maintainer-change check cannot be built on deps.dev alone. It needs
+**per-registry** lookups against each ecosystem's own API, since each models
+publishers differently:
+
+- **npm** — the packument's `maintainers` list and each version's `_npmUser`;
+  account age via the npm user API.
+- **PyPI** — project/role data (no per-version uploader in the JSON API; the
+  newer integrity/provenance endpoints are closer).
+- **RubyGems** — gem `owners`.
+- **Maven / Cargo / NuGet** — varying owner/account models.
+
+The natural shape, mirroring the release-freshness work, is a per-ecosystem
+maintainer fetcher behind the same `internal/registry` package, exposing
+something like `change.target_metadata.publishers` and a derived
+`change.maintainer_changed` / new-account-age signal for policies. Because each
+registry differs, this is best landed incrementally (npm first, where the data is
+richest) rather than as one large change.
+
+Tracking: see deputy issue #41.

--- a/docs/reference/policy-inputs.md
+++ b/docs/reference/policy-inputs.md
@@ -147,6 +147,39 @@ Container images have three license sources:
 
 See [License enrichment concepts](../concepts/inventory-and-sboms.md#license-enrichment) for details.
 
+## Dependency change registry metadata
+
+The `diff_dependency_change` entrypoint can optionally carry registry-sourced
+metadata about the version a bump introduces, so policies can reason about
+supply-chain risk a known-vulnerability scan cannot see — most notably **release
+freshness**. A version published minutes or hours ago has had no time to be
+vetted, and malicious releases are typically live only briefly before they are
+caught and pulled.
+
+This metadata is fetched from deps.dev and is populated only when you pass
+`deputy diff --registry-metadata`. When the flag is absent — or deps.dev has no
+record for a package — the fields are unset, so always guard them with `has()`.
+
+`change.target_metadata` describes `change.target_version`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `change.target_metadata.published_at` | `timestamp` | When the version was published, per deps.dev (RFC 3339). Unset when unknown. |
+| `change.target_metadata.age_days` | `double` | Age of the version in days at evaluation time (`now - published_at`). `-1` when `published_at` is unknown. Provided because CEL has no `now`. |
+| `change.target_metadata.registries` | `list(string)` | Registries deps.dev reports as hosting the version. |
+
+Example — warn on bumps to a version published less than a week ago:
+
+```cel
+env.entrypoint == "diff_dependency_change" &&
+  has(change.target_metadata) &&
+  change.target_metadata.age_days >= 0.0 &&
+  change.target_metadata.age_days < 7.0
+```
+
+See [`policy/examples/release-freshness.yaml`](../../policy/examples/release-freshness.yaml)
+for a complete policy.
+
 ## Target metadata
 
 `target` summarizes what Deputy is evaluating, regardless of command or entrypoint. It is always present but may be empty when a command does not provide target details. Common fields:

--- a/gen/deputy/diff/v1/service.pb.go
+++ b/gen/deputy/diff/v1/service.pb.go
@@ -479,9 +479,13 @@ type PackageChange struct {
 	// OldName is the previous package name if it changed (e.g., import path canonicalization).
 	OldName string `protobuf:"bytes,5,opt,name=old_name,json=oldName,proto3" json:"old_name,omitempty"`
 	// IsDirect indicates whether this is a direct dependency.
-	IsDirect      bool `protobuf:"varint,6,opt,name=is_direct,json=isDirect,proto3" json:"is_direct,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	IsDirect bool `protobuf:"varint,6,opt,name=is_direct,json=isDirect,proto3" json:"is_direct,omitempty"`
+	// TargetMetadata is registry metadata for target_version (e.g. when it was
+	// published). It is unset for Removed changes and when registry-metadata
+	// fetching is disabled (see the diff --registry-metadata flag).
+	TargetMetadata *RegistryMetadata `protobuf:"bytes,7,opt,name=target_metadata,json=targetMetadata,proto3" json:"target_metadata,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *PackageChange) Reset() {
@@ -556,6 +560,84 @@ func (x *PackageChange) GetIsDirect() bool {
 	return false
 }
 
+func (x *PackageChange) GetTargetMetadata() *RegistryMetadata {
+	if x != nil {
+		return x.TargetMetadata
+	}
+	return nil
+}
+
+// RegistryMetadata captures registry-sourced facts about a single package version,
+// fetched from deps.dev. It is exposed as a policy signal so policies can reason
+// about supply-chain risk that a known-vulnerability scan cannot see — most notably
+// release freshness, since a version published minutes or hours ago has had no time
+// to be vetted and is a common shape for a malicious release.
+type RegistryMetadata struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// PublishedAt is when this version was published to its registry, per deps.dev.
+	// Unset when deps.dev has no publish date for the version.
+	PublishedAt *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=published_at,json=publishedAt,proto3" json:"published_at,omitempty"`
+	// AgeDays is the age of this version in days at evaluation time (now - published_at).
+	// It is -1 when published_at is unknown. Provided as a convenience because CEL has no
+	// notion of "now", so policies can gate on freshness with e.g. age_days < 7.0.
+	AgeDays float64 `protobuf:"fixed64,2,opt,name=age_days,json=ageDays,proto3" json:"age_days,omitempty"`
+	// Registries lists the registries deps.dev reports as hosting this version.
+	Registries    []string `protobuf:"bytes,3,rep,name=registries,proto3" json:"registries,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RegistryMetadata) Reset() {
+	*x = RegistryMetadata{}
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RegistryMetadata) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RegistryMetadata) ProtoMessage() {}
+
+func (x *RegistryMetadata) ProtoReflect() protoreflect.Message {
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RegistryMetadata.ProtoReflect.Descriptor instead.
+func (*RegistryMetadata) Descriptor() ([]byte, []int) {
+	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *RegistryMetadata) GetPublishedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.PublishedAt
+	}
+	return nil
+}
+
+func (x *RegistryMetadata) GetAgeDays() float64 {
+	if x != nil {
+		return x.AgeDays
+	}
+	return 0
+}
+
+func (x *RegistryMetadata) GetRegistries() []string {
+	if x != nil {
+		return x.Registries
+	}
+	return nil
+}
+
 // DiffStats summarizes diff results.
 type DiffStats struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -577,7 +659,7 @@ type DiffStats struct {
 
 func (x *DiffStats) Reset() {
 	*x = DiffStats{}
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[4]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -589,7 +671,7 @@ func (x *DiffStats) String() string {
 func (*DiffStats) ProtoMessage() {}
 
 func (x *DiffStats) ProtoReflect() protoreflect.Message {
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[4]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -602,7 +684,7 @@ func (x *DiffStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DiffStats.ProtoReflect.Descriptor instead.
 func (*DiffStats) Descriptor() ([]byte, []int) {
-	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{4}
+	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *DiffStats) GetAddedCount() int32 {
@@ -664,7 +746,7 @@ type DiffVulnerabilitiesRequest struct {
 
 func (x *DiffVulnerabilitiesRequest) Reset() {
 	*x = DiffVulnerabilitiesRequest{}
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[5]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -676,7 +758,7 @@ func (x *DiffVulnerabilitiesRequest) String() string {
 func (*DiffVulnerabilitiesRequest) ProtoMessage() {}
 
 func (x *DiffVulnerabilitiesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[5]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -689,7 +771,7 @@ func (x *DiffVulnerabilitiesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DiffVulnerabilitiesRequest.ProtoReflect.Descriptor instead.
 func (*DiffVulnerabilitiesRequest) Descriptor() ([]byte, []int) {
-	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{5}
+	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *DiffVulnerabilitiesRequest) GetBaseTarget() string {
@@ -745,7 +827,7 @@ type DiffVulnerabilitiesResponse struct {
 
 func (x *DiffVulnerabilitiesResponse) Reset() {
 	*x = DiffVulnerabilitiesResponse{}
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[6]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -757,7 +839,7 @@ func (x *DiffVulnerabilitiesResponse) String() string {
 func (*DiffVulnerabilitiesResponse) ProtoMessage() {}
 
 func (x *DiffVulnerabilitiesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[6]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -770,7 +852,7 @@ func (x *DiffVulnerabilitiesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DiffVulnerabilitiesResponse.ProtoReflect.Descriptor instead.
 func (*DiffVulnerabilitiesResponse) Descriptor() ([]byte, []int) {
-	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{6}
+	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *DiffVulnerabilitiesResponse) GetBaseTarget() *v1.Target {
@@ -846,7 +928,7 @@ type VulnerabilityDiffStats struct {
 
 func (x *VulnerabilityDiffStats) Reset() {
 	*x = VulnerabilityDiffStats{}
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[7]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -858,7 +940,7 @@ func (x *VulnerabilityDiffStats) String() string {
 func (*VulnerabilityDiffStats) ProtoMessage() {}
 
 func (x *VulnerabilityDiffStats) ProtoReflect() protoreflect.Message {
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[7]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -871,7 +953,7 @@ func (x *VulnerabilityDiffStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VulnerabilityDiffStats.ProtoReflect.Descriptor instead.
 func (*VulnerabilityDiffStats) Descriptor() ([]byte, []int) {
-	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{7}
+	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *VulnerabilityDiffStats) GetAddedCount() int32 {
@@ -917,7 +999,7 @@ type DiffContainerImagesRequest struct {
 
 func (x *DiffContainerImagesRequest) Reset() {
 	*x = DiffContainerImagesRequest{}
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[8]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -929,7 +1011,7 @@ func (x *DiffContainerImagesRequest) String() string {
 func (*DiffContainerImagesRequest) ProtoMessage() {}
 
 func (x *DiffContainerImagesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[8]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -942,7 +1024,7 @@ func (x *DiffContainerImagesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DiffContainerImagesRequest.ProtoReflect.Descriptor instead.
 func (*DiffContainerImagesRequest) Descriptor() ([]byte, []int) {
-	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{8}
+	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *DiffContainerImagesRequest) GetBaseImage() string {
@@ -989,7 +1071,7 @@ type ContainerDiffOptions struct {
 
 func (x *ContainerDiffOptions) Reset() {
 	*x = ContainerDiffOptions{}
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[9]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1001,7 +1083,7 @@ func (x *ContainerDiffOptions) String() string {
 func (*ContainerDiffOptions) ProtoMessage() {}
 
 func (x *ContainerDiffOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[9]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1014,7 +1096,7 @@ func (x *ContainerDiffOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContainerDiffOptions.ProtoReflect.Descriptor instead.
 func (*ContainerDiffOptions) Descriptor() ([]byte, []int) {
-	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{9}
+	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *ContainerDiffOptions) GetScanVulnerabilities() bool {
@@ -1085,7 +1167,7 @@ type DiffContainerImagesResponse struct {
 
 func (x *DiffContainerImagesResponse) Reset() {
 	*x = DiffContainerImagesResponse{}
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[10]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1097,7 +1179,7 @@ func (x *DiffContainerImagesResponse) String() string {
 func (*DiffContainerImagesResponse) ProtoMessage() {}
 
 func (x *DiffContainerImagesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[10]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1110,7 +1192,7 @@ func (x *DiffContainerImagesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DiffContainerImagesResponse.ProtoReflect.Descriptor instead.
 func (*DiffContainerImagesResponse) Descriptor() ([]byte, []int) {
-	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{10}
+	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *DiffContainerImagesResponse) GetBaseImage() *ContainerImageRef {
@@ -1216,7 +1298,7 @@ type ContainerImageRef struct {
 
 func (x *ContainerImageRef) Reset() {
 	*x = ContainerImageRef{}
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[11]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1228,7 +1310,7 @@ func (x *ContainerImageRef) String() string {
 func (*ContainerImageRef) ProtoMessage() {}
 
 func (x *ContainerImageRef) ProtoReflect() protoreflect.Message {
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[11]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1241,7 +1323,7 @@ func (x *ContainerImageRef) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContainerImageRef.ProtoReflect.Descriptor instead.
 func (*ContainerImageRef) Descriptor() ([]byte, []int) {
-	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{11}
+	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ContainerImageRef) GetReference() string {
@@ -1296,7 +1378,7 @@ type ContainerImageContext struct {
 
 func (x *ContainerImageContext) Reset() {
 	*x = ContainerImageContext{}
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[12]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1308,7 +1390,7 @@ func (x *ContainerImageContext) String() string {
 func (*ContainerImageContext) ProtoMessage() {}
 
 func (x *ContainerImageContext) ProtoReflect() protoreflect.Message {
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[12]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1321,7 +1403,7 @@ func (x *ContainerImageContext) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContainerImageContext.ProtoReflect.Descriptor instead.
 func (*ContainerImageContext) Descriptor() ([]byte, []int) {
-	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{12}
+	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ContainerImageContext) GetDistro() string {
@@ -1379,7 +1461,7 @@ type ContainerPackageChange struct {
 
 func (x *ContainerPackageChange) Reset() {
 	*x = ContainerPackageChange{}
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[13]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1391,7 +1473,7 @@ func (x *ContainerPackageChange) String() string {
 func (*ContainerPackageChange) ProtoMessage() {}
 
 func (x *ContainerPackageChange) ProtoReflect() protoreflect.Message {
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[13]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1404,7 +1486,7 @@ func (x *ContainerPackageChange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContainerPackageChange.ProtoReflect.Descriptor instead.
 func (*ContainerPackageChange) Descriptor() ([]byte, []int) {
-	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{13}
+	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ContainerPackageChange) GetName() string {
@@ -1507,7 +1589,7 @@ type ContainerVulnerabilityChange struct {
 
 func (x *ContainerVulnerabilityChange) Reset() {
 	*x = ContainerVulnerabilityChange{}
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[14]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1519,7 +1601,7 @@ func (x *ContainerVulnerabilityChange) String() string {
 func (*ContainerVulnerabilityChange) ProtoMessage() {}
 
 func (x *ContainerVulnerabilityChange) ProtoReflect() protoreflect.Message {
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[14]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1532,7 +1614,7 @@ func (x *ContainerVulnerabilityChange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContainerVulnerabilityChange.ProtoReflect.Descriptor instead.
 func (*ContainerVulnerabilityChange) Descriptor() ([]byte, []int) {
-	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{14}
+	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ContainerVulnerabilityChange) GetId() string {
@@ -1676,7 +1758,7 @@ type ContainerConfigDiff struct {
 
 func (x *ContainerConfigDiff) Reset() {
 	*x = ContainerConfigDiff{}
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[15]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1688,7 +1770,7 @@ func (x *ContainerConfigDiff) String() string {
 func (*ContainerConfigDiff) ProtoMessage() {}
 
 func (x *ContainerConfigDiff) ProtoReflect() protoreflect.Message {
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[15]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1701,7 +1783,7 @@ func (x *ContainerConfigDiff) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContainerConfigDiff.ProtoReflect.Descriptor instead.
 func (*ContainerConfigDiff) Descriptor() ([]byte, []int) {
-	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{15}
+	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *ContainerConfigDiff) GetUserChanged() bool {
@@ -1886,7 +1968,7 @@ type EnvChange struct {
 
 func (x *EnvChange) Reset() {
 	*x = EnvChange{}
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[16]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1898,7 +1980,7 @@ func (x *EnvChange) String() string {
 func (*EnvChange) ProtoMessage() {}
 
 func (x *EnvChange) ProtoReflect() protoreflect.Message {
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[16]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1911,7 +1993,7 @@ func (x *EnvChange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EnvChange.ProtoReflect.Descriptor instead.
 func (*EnvChange) Descriptor() ([]byte, []int) {
-	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{16}
+	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *EnvChange) GetName() string {
@@ -1962,7 +2044,7 @@ type LabelChange struct {
 
 func (x *LabelChange) Reset() {
 	*x = LabelChange{}
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[17]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1974,7 +2056,7 @@ func (x *LabelChange) String() string {
 func (*LabelChange) ProtoMessage() {}
 
 func (x *LabelChange) ProtoReflect() protoreflect.Message {
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[17]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1987,7 +2069,7 @@ func (x *LabelChange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LabelChange.ProtoReflect.Descriptor instead.
 func (*LabelChange) Descriptor() ([]byte, []int) {
-	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{17}
+	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *LabelChange) GetKey() string {
@@ -2035,7 +2117,7 @@ type LayerDiffAnalysis struct {
 
 func (x *LayerDiffAnalysis) Reset() {
 	*x = LayerDiffAnalysis{}
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[18]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2047,7 +2129,7 @@ func (x *LayerDiffAnalysis) String() string {
 func (*LayerDiffAnalysis) ProtoMessage() {}
 
 func (x *LayerDiffAnalysis) ProtoReflect() protoreflect.Message {
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[18]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2060,7 +2142,7 @@ func (x *LayerDiffAnalysis) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LayerDiffAnalysis.ProtoReflect.Descriptor instead.
 func (*LayerDiffAnalysis) Descriptor() ([]byte, []int) {
-	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{18}
+	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *LayerDiffAnalysis) GetBaseLayerCount() int32 {
@@ -2108,7 +2190,7 @@ type LayerChange struct {
 
 func (x *LayerChange) Reset() {
 	*x = LayerChange{}
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[19]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2120,7 +2202,7 @@ func (x *LayerChange) String() string {
 func (*LayerChange) ProtoMessage() {}
 
 func (x *LayerChange) ProtoReflect() protoreflect.Message {
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[19]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2133,7 +2215,7 @@ func (x *LayerChange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LayerChange.ProtoReflect.Descriptor instead.
 func (*LayerChange) Descriptor() ([]byte, []int) {
-	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{19}
+	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *LayerChange) GetIndex() int32 {
@@ -2193,7 +2275,7 @@ type ContainerDiffSummary struct {
 
 func (x *ContainerDiffSummary) Reset() {
 	*x = ContainerDiffSummary{}
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[20]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2205,7 +2287,7 @@ func (x *ContainerDiffSummary) String() string {
 func (*ContainerDiffSummary) ProtoMessage() {}
 
 func (x *ContainerDiffSummary) ProtoReflect() protoreflect.Message {
-	mi := &file_deputy_diff_v1_service_proto_msgTypes[20]
+	mi := &file_deputy_diff_v1_service_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2218,7 +2300,7 @@ func (x *ContainerDiffSummary) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ContainerDiffSummary.ProtoReflect.Descriptor instead.
 func (*ContainerDiffSummary) Descriptor() ([]byte, []int) {
-	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{20}
+	return file_deputy_diff_v1_service_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *ContainerDiffSummary) GetPackagesAdded() int32 {
@@ -2317,7 +2399,7 @@ const file_deputy_diff_v1_service_proto_rawDesc = "" +
 	"\fgenerated_at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\vgeneratedAt\x127\n" +
 	"\achanges\x18\x04 \x03(\v2\x1d.deputy.diff.v1.PackageChangeR\achanges\x12/\n" +
 	"\x05stats\x18\x05 \x01(\v2\x19.deputy.diff.v1.DiffStatsR\x05stats\x12\x1a\n" +
-	"\bwarnings\x18\x06 \x03(\tR\bwarnings\"\x87\x02\n" +
+	"\bwarnings\x18\x06 \x03(\tR\bwarnings\"\xd2\x02\n" +
 	"\rPackageChange\x127\n" +
 	"\apackage\x18\x01 \x01(\v2\x1d.deputy.dependency.v1.PackageR\apackage\x12;\n" +
 	"\vchange_kind\x18\x02 \x01(\x0e2\x1a.deputy.diff.v1.ChangeKindR\n" +
@@ -2325,7 +2407,14 @@ const file_deputy_diff_v1_service_proto_rawDesc = "" +
 	"\fbase_version\x18\x03 \x01(\tR\vbaseVersion\x12%\n" +
 	"\x0etarget_version\x18\x04 \x01(\tR\rtargetVersion\x12\x19\n" +
 	"\bold_name\x18\x05 \x01(\tR\aoldName\x12\x1b\n" +
-	"\tis_direct\x18\x06 \x01(\bR\bisDirect\"\xed\x01\n" +
+	"\tis_direct\x18\x06 \x01(\bR\bisDirect\x12I\n" +
+	"\x0ftarget_metadata\x18\a \x01(\v2 .deputy.diff.v1.RegistryMetadataR\x0etargetMetadata\"\x8c\x01\n" +
+	"\x10RegistryMetadata\x12=\n" +
+	"\fpublished_at\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\vpublishedAt\x12\x19\n" +
+	"\bage_days\x18\x02 \x01(\x01R\aageDays\x12\x1e\n" +
+	"\n" +
+	"registries\x18\x03 \x03(\tR\n" +
+	"registries\"\xed\x01\n" +
 	"\tDiffStats\x12\x1f\n" +
 	"\vadded_count\x18\x01 \x01(\x05R\n" +
 	"addedCount\x12#\n" +
@@ -2548,7 +2637,7 @@ func file_deputy_diff_v1_service_proto_rawDescGZIP() []byte {
 }
 
 var file_deputy_diff_v1_service_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_deputy_diff_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 25)
+var file_deputy_diff_v1_service_proto_msgTypes = make([]protoimpl.MessageInfo, 26)
 var file_deputy_diff_v1_service_proto_goTypes = []any{
 	(ChangeKind)(0),                      // 0: deputy.diff.v1.ChangeKind
 	(VulnerabilityChangeKind)(0),         // 1: deputy.diff.v1.VulnerabilityChangeKind
@@ -2557,96 +2646,99 @@ var file_deputy_diff_v1_service_proto_goTypes = []any{
 	(*DiffOptions)(nil),                  // 4: deputy.diff.v1.DiffOptions
 	(*DiffPackagesResponse)(nil),         // 5: deputy.diff.v1.DiffPackagesResponse
 	(*PackageChange)(nil),                // 6: deputy.diff.v1.PackageChange
-	(*DiffStats)(nil),                    // 7: deputy.diff.v1.DiffStats
-	(*DiffVulnerabilitiesRequest)(nil),   // 8: deputy.diff.v1.DiffVulnerabilitiesRequest
-	(*DiffVulnerabilitiesResponse)(nil),  // 9: deputy.diff.v1.DiffVulnerabilitiesResponse
-	(*VulnerabilityDiffStats)(nil),       // 10: deputy.diff.v1.VulnerabilityDiffStats
-	(*DiffContainerImagesRequest)(nil),   // 11: deputy.diff.v1.DiffContainerImagesRequest
-	(*ContainerDiffOptions)(nil),         // 12: deputy.diff.v1.ContainerDiffOptions
-	(*DiffContainerImagesResponse)(nil),  // 13: deputy.diff.v1.DiffContainerImagesResponse
-	(*ContainerImageRef)(nil),            // 14: deputy.diff.v1.ContainerImageRef
-	(*ContainerImageContext)(nil),        // 15: deputy.diff.v1.ContainerImageContext
-	(*ContainerPackageChange)(nil),       // 16: deputy.diff.v1.ContainerPackageChange
-	(*ContainerVulnerabilityChange)(nil), // 17: deputy.diff.v1.ContainerVulnerabilityChange
-	(*ContainerConfigDiff)(nil),          // 18: deputy.diff.v1.ContainerConfigDiff
-	(*EnvChange)(nil),                    // 19: deputy.diff.v1.EnvChange
-	(*LabelChange)(nil),                  // 20: deputy.diff.v1.LabelChange
-	(*LayerDiffAnalysis)(nil),            // 21: deputy.diff.v1.LayerDiffAnalysis
-	(*LayerChange)(nil),                  // 22: deputy.diff.v1.LayerChange
-	(*ContainerDiffSummary)(nil),         // 23: deputy.diff.v1.ContainerDiffSummary
-	nil,                                  // 24: deputy.diff.v1.DiffVulnerabilitiesResponse.AdvisoriesEntry
-	nil,                                  // 25: deputy.diff.v1.VulnerabilityDiffStats.AddedBySeverityEntry
-	nil,                                  // 26: deputy.diff.v1.VulnerabilityDiffStats.RemovedBySeverityEntry
-	nil,                                  // 27: deputy.diff.v1.DiffContainerImagesResponse.AdvisoriesEntry
-	(v1.TargetKind)(0),                   // 28: deputy.target.v1.TargetKind
-	(*v1.Target)(nil),                    // 29: deputy.target.v1.Target
-	(*timestamppb.Timestamp)(nil),        // 30: google.protobuf.Timestamp
-	(*v11.Package)(nil),                  // 31: deputy.dependency.v1.Package
-	(*v12.ScanOptions)(nil),              // 32: deputy.scan.v1.ScanOptions
-	(*v13.Finding)(nil),                  // 33: deputy.vulnerability.v1.Finding
-	(*v14.LayerDetails)(nil),             // 34: deputy.container.v1.LayerDetails
-	(*v13.Advisory)(nil),                 // 35: deputy.vulnerability.v1.Advisory
+	(*RegistryMetadata)(nil),             // 7: deputy.diff.v1.RegistryMetadata
+	(*DiffStats)(nil),                    // 8: deputy.diff.v1.DiffStats
+	(*DiffVulnerabilitiesRequest)(nil),   // 9: deputy.diff.v1.DiffVulnerabilitiesRequest
+	(*DiffVulnerabilitiesResponse)(nil),  // 10: deputy.diff.v1.DiffVulnerabilitiesResponse
+	(*VulnerabilityDiffStats)(nil),       // 11: deputy.diff.v1.VulnerabilityDiffStats
+	(*DiffContainerImagesRequest)(nil),   // 12: deputy.diff.v1.DiffContainerImagesRequest
+	(*ContainerDiffOptions)(nil),         // 13: deputy.diff.v1.ContainerDiffOptions
+	(*DiffContainerImagesResponse)(nil),  // 14: deputy.diff.v1.DiffContainerImagesResponse
+	(*ContainerImageRef)(nil),            // 15: deputy.diff.v1.ContainerImageRef
+	(*ContainerImageContext)(nil),        // 16: deputy.diff.v1.ContainerImageContext
+	(*ContainerPackageChange)(nil),       // 17: deputy.diff.v1.ContainerPackageChange
+	(*ContainerVulnerabilityChange)(nil), // 18: deputy.diff.v1.ContainerVulnerabilityChange
+	(*ContainerConfigDiff)(nil),          // 19: deputy.diff.v1.ContainerConfigDiff
+	(*EnvChange)(nil),                    // 20: deputy.diff.v1.EnvChange
+	(*LabelChange)(nil),                  // 21: deputy.diff.v1.LabelChange
+	(*LayerDiffAnalysis)(nil),            // 22: deputy.diff.v1.LayerDiffAnalysis
+	(*LayerChange)(nil),                  // 23: deputy.diff.v1.LayerChange
+	(*ContainerDiffSummary)(nil),         // 24: deputy.diff.v1.ContainerDiffSummary
+	nil,                                  // 25: deputy.diff.v1.DiffVulnerabilitiesResponse.AdvisoriesEntry
+	nil,                                  // 26: deputy.diff.v1.VulnerabilityDiffStats.AddedBySeverityEntry
+	nil,                                  // 27: deputy.diff.v1.VulnerabilityDiffStats.RemovedBySeverityEntry
+	nil,                                  // 28: deputy.diff.v1.DiffContainerImagesResponse.AdvisoriesEntry
+	(v1.TargetKind)(0),                   // 29: deputy.target.v1.TargetKind
+	(*v1.Target)(nil),                    // 30: deputy.target.v1.Target
+	(*timestamppb.Timestamp)(nil),        // 31: google.protobuf.Timestamp
+	(*v11.Package)(nil),                  // 32: deputy.dependency.v1.Package
+	(*v12.ScanOptions)(nil),              // 33: deputy.scan.v1.ScanOptions
+	(*v13.Finding)(nil),                  // 34: deputy.vulnerability.v1.Finding
+	(*v14.LayerDetails)(nil),             // 35: deputy.container.v1.LayerDetails
+	(*v13.Advisory)(nil),                 // 36: deputy.vulnerability.v1.Advisory
 }
 var file_deputy_diff_v1_service_proto_depIdxs = []int32{
 	4,  // 0: deputy.diff.v1.DiffPackagesRequest.options:type_name -> deputy.diff.v1.DiffOptions
-	28, // 1: deputy.diff.v1.DiffOptions.base_target_hint:type_name -> deputy.target.v1.TargetKind
-	28, // 2: deputy.diff.v1.DiffOptions.target_target_hint:type_name -> deputy.target.v1.TargetKind
-	29, // 3: deputy.diff.v1.DiffPackagesResponse.base_target:type_name -> deputy.target.v1.Target
-	29, // 4: deputy.diff.v1.DiffPackagesResponse.target_target:type_name -> deputy.target.v1.Target
-	30, // 5: deputy.diff.v1.DiffPackagesResponse.generated_at:type_name -> google.protobuf.Timestamp
+	29, // 1: deputy.diff.v1.DiffOptions.base_target_hint:type_name -> deputy.target.v1.TargetKind
+	29, // 2: deputy.diff.v1.DiffOptions.target_target_hint:type_name -> deputy.target.v1.TargetKind
+	30, // 3: deputy.diff.v1.DiffPackagesResponse.base_target:type_name -> deputy.target.v1.Target
+	30, // 4: deputy.diff.v1.DiffPackagesResponse.target_target:type_name -> deputy.target.v1.Target
+	31, // 5: deputy.diff.v1.DiffPackagesResponse.generated_at:type_name -> google.protobuf.Timestamp
 	6,  // 6: deputy.diff.v1.DiffPackagesResponse.changes:type_name -> deputy.diff.v1.PackageChange
-	7,  // 7: deputy.diff.v1.DiffPackagesResponse.stats:type_name -> deputy.diff.v1.DiffStats
-	31, // 8: deputy.diff.v1.PackageChange.package:type_name -> deputy.dependency.v1.Package
+	8,  // 7: deputy.diff.v1.DiffPackagesResponse.stats:type_name -> deputy.diff.v1.DiffStats
+	32, // 8: deputy.diff.v1.PackageChange.package:type_name -> deputy.dependency.v1.Package
 	0,  // 9: deputy.diff.v1.PackageChange.change_kind:type_name -> deputy.diff.v1.ChangeKind
-	4,  // 10: deputy.diff.v1.DiffVulnerabilitiesRequest.diff_options:type_name -> deputy.diff.v1.DiffOptions
-	32, // 11: deputy.diff.v1.DiffVulnerabilitiesRequest.scan_options:type_name -> deputy.scan.v1.ScanOptions
-	29, // 12: deputy.diff.v1.DiffVulnerabilitiesResponse.base_target:type_name -> deputy.target.v1.Target
-	29, // 13: deputy.diff.v1.DiffVulnerabilitiesResponse.target_target:type_name -> deputy.target.v1.Target
-	30, // 14: deputy.diff.v1.DiffVulnerabilitiesResponse.generated_at:type_name -> google.protobuf.Timestamp
-	33, // 15: deputy.diff.v1.DiffVulnerabilitiesResponse.added_vulnerabilities:type_name -> deputy.vulnerability.v1.Finding
-	33, // 16: deputy.diff.v1.DiffVulnerabilitiesResponse.removed_vulnerabilities:type_name -> deputy.vulnerability.v1.Finding
-	24, // 17: deputy.diff.v1.DiffVulnerabilitiesResponse.advisories:type_name -> deputy.diff.v1.DiffVulnerabilitiesResponse.AdvisoriesEntry
-	10, // 18: deputy.diff.v1.DiffVulnerabilitiesResponse.stats:type_name -> deputy.diff.v1.VulnerabilityDiffStats
-	25, // 19: deputy.diff.v1.VulnerabilityDiffStats.added_by_severity:type_name -> deputy.diff.v1.VulnerabilityDiffStats.AddedBySeverityEntry
-	26, // 20: deputy.diff.v1.VulnerabilityDiffStats.removed_by_severity:type_name -> deputy.diff.v1.VulnerabilityDiffStats.RemovedBySeverityEntry
-	12, // 21: deputy.diff.v1.DiffContainerImagesRequest.options:type_name -> deputy.diff.v1.ContainerDiffOptions
-	32, // 22: deputy.diff.v1.ContainerDiffOptions.scan_options:type_name -> deputy.scan.v1.ScanOptions
-	14, // 23: deputy.diff.v1.DiffContainerImagesResponse.base_image:type_name -> deputy.diff.v1.ContainerImageRef
-	14, // 24: deputy.diff.v1.DiffContainerImagesResponse.target_image:type_name -> deputy.diff.v1.ContainerImageRef
-	30, // 25: deputy.diff.v1.DiffContainerImagesResponse.generated_at:type_name -> google.protobuf.Timestamp
-	16, // 26: deputy.diff.v1.DiffContainerImagesResponse.package_changes:type_name -> deputy.diff.v1.ContainerPackageChange
-	17, // 27: deputy.diff.v1.DiffContainerImagesResponse.vulnerability_changes:type_name -> deputy.diff.v1.ContainerVulnerabilityChange
-	27, // 28: deputy.diff.v1.DiffContainerImagesResponse.advisories:type_name -> deputy.diff.v1.DiffContainerImagesResponse.AdvisoriesEntry
-	18, // 29: deputy.diff.v1.DiffContainerImagesResponse.config_changes:type_name -> deputy.diff.v1.ContainerConfigDiff
-	21, // 30: deputy.diff.v1.DiffContainerImagesResponse.layer_analysis:type_name -> deputy.diff.v1.LayerDiffAnalysis
-	23, // 31: deputy.diff.v1.DiffContainerImagesResponse.summary:type_name -> deputy.diff.v1.ContainerDiffSummary
-	15, // 32: deputy.diff.v1.DiffContainerImagesResponse.base_context:type_name -> deputy.diff.v1.ContainerImageContext
-	15, // 33: deputy.diff.v1.DiffContainerImagesResponse.target_context:type_name -> deputy.diff.v1.ContainerImageContext
-	0,  // 34: deputy.diff.v1.ContainerPackageChange.change_kind:type_name -> deputy.diff.v1.ChangeKind
-	34, // 35: deputy.diff.v1.ContainerPackageChange.base_layer_details:type_name -> deputy.container.v1.LayerDetails
-	34, // 36: deputy.diff.v1.ContainerPackageChange.target_layer_details:type_name -> deputy.container.v1.LayerDetails
-	1,  // 37: deputy.diff.v1.ContainerVulnerabilityChange.change_kind:type_name -> deputy.diff.v1.VulnerabilityChangeKind
-	34, // 38: deputy.diff.v1.ContainerVulnerabilityChange.base_layer_details:type_name -> deputy.container.v1.LayerDetails
-	34, // 39: deputy.diff.v1.ContainerVulnerabilityChange.target_layer_details:type_name -> deputy.container.v1.LayerDetails
-	19, // 40: deputy.diff.v1.ContainerConfigDiff.env_changes:type_name -> deputy.diff.v1.EnvChange
-	20, // 41: deputy.diff.v1.ContainerConfigDiff.label_changes:type_name -> deputy.diff.v1.LabelChange
-	0,  // 42: deputy.diff.v1.EnvChange.change_kind:type_name -> deputy.diff.v1.ChangeKind
-	0,  // 43: deputy.diff.v1.LabelChange.change_kind:type_name -> deputy.diff.v1.ChangeKind
-	22, // 44: deputy.diff.v1.LayerDiffAnalysis.layer_changes:type_name -> deputy.diff.v1.LayerChange
-	2,  // 45: deputy.diff.v1.LayerChange.change_kind:type_name -> deputy.diff.v1.LayerChangeKind
-	35, // 46: deputy.diff.v1.DiffVulnerabilitiesResponse.AdvisoriesEntry.value:type_name -> deputy.vulnerability.v1.Advisory
-	35, // 47: deputy.diff.v1.DiffContainerImagesResponse.AdvisoriesEntry.value:type_name -> deputy.vulnerability.v1.Advisory
-	3,  // 48: deputy.diff.v1.DiffService.DiffPackages:input_type -> deputy.diff.v1.DiffPackagesRequest
-	8,  // 49: deputy.diff.v1.DiffService.DiffVulnerabilities:input_type -> deputy.diff.v1.DiffVulnerabilitiesRequest
-	11, // 50: deputy.diff.v1.DiffService.DiffContainerImages:input_type -> deputy.diff.v1.DiffContainerImagesRequest
-	5,  // 51: deputy.diff.v1.DiffService.DiffPackages:output_type -> deputy.diff.v1.DiffPackagesResponse
-	9,  // 52: deputy.diff.v1.DiffService.DiffVulnerabilities:output_type -> deputy.diff.v1.DiffVulnerabilitiesResponse
-	13, // 53: deputy.diff.v1.DiffService.DiffContainerImages:output_type -> deputy.diff.v1.DiffContainerImagesResponse
-	51, // [51:54] is the sub-list for method output_type
-	48, // [48:51] is the sub-list for method input_type
-	48, // [48:48] is the sub-list for extension type_name
-	48, // [48:48] is the sub-list for extension extendee
-	0,  // [0:48] is the sub-list for field type_name
+	7,  // 10: deputy.diff.v1.PackageChange.target_metadata:type_name -> deputy.diff.v1.RegistryMetadata
+	31, // 11: deputy.diff.v1.RegistryMetadata.published_at:type_name -> google.protobuf.Timestamp
+	4,  // 12: deputy.diff.v1.DiffVulnerabilitiesRequest.diff_options:type_name -> deputy.diff.v1.DiffOptions
+	33, // 13: deputy.diff.v1.DiffVulnerabilitiesRequest.scan_options:type_name -> deputy.scan.v1.ScanOptions
+	30, // 14: deputy.diff.v1.DiffVulnerabilitiesResponse.base_target:type_name -> deputy.target.v1.Target
+	30, // 15: deputy.diff.v1.DiffVulnerabilitiesResponse.target_target:type_name -> deputy.target.v1.Target
+	31, // 16: deputy.diff.v1.DiffVulnerabilitiesResponse.generated_at:type_name -> google.protobuf.Timestamp
+	34, // 17: deputy.diff.v1.DiffVulnerabilitiesResponse.added_vulnerabilities:type_name -> deputy.vulnerability.v1.Finding
+	34, // 18: deputy.diff.v1.DiffVulnerabilitiesResponse.removed_vulnerabilities:type_name -> deputy.vulnerability.v1.Finding
+	25, // 19: deputy.diff.v1.DiffVulnerabilitiesResponse.advisories:type_name -> deputy.diff.v1.DiffVulnerabilitiesResponse.AdvisoriesEntry
+	11, // 20: deputy.diff.v1.DiffVulnerabilitiesResponse.stats:type_name -> deputy.diff.v1.VulnerabilityDiffStats
+	26, // 21: deputy.diff.v1.VulnerabilityDiffStats.added_by_severity:type_name -> deputy.diff.v1.VulnerabilityDiffStats.AddedBySeverityEntry
+	27, // 22: deputy.diff.v1.VulnerabilityDiffStats.removed_by_severity:type_name -> deputy.diff.v1.VulnerabilityDiffStats.RemovedBySeverityEntry
+	13, // 23: deputy.diff.v1.DiffContainerImagesRequest.options:type_name -> deputy.diff.v1.ContainerDiffOptions
+	33, // 24: deputy.diff.v1.ContainerDiffOptions.scan_options:type_name -> deputy.scan.v1.ScanOptions
+	15, // 25: deputy.diff.v1.DiffContainerImagesResponse.base_image:type_name -> deputy.diff.v1.ContainerImageRef
+	15, // 26: deputy.diff.v1.DiffContainerImagesResponse.target_image:type_name -> deputy.diff.v1.ContainerImageRef
+	31, // 27: deputy.diff.v1.DiffContainerImagesResponse.generated_at:type_name -> google.protobuf.Timestamp
+	17, // 28: deputy.diff.v1.DiffContainerImagesResponse.package_changes:type_name -> deputy.diff.v1.ContainerPackageChange
+	18, // 29: deputy.diff.v1.DiffContainerImagesResponse.vulnerability_changes:type_name -> deputy.diff.v1.ContainerVulnerabilityChange
+	28, // 30: deputy.diff.v1.DiffContainerImagesResponse.advisories:type_name -> deputy.diff.v1.DiffContainerImagesResponse.AdvisoriesEntry
+	19, // 31: deputy.diff.v1.DiffContainerImagesResponse.config_changes:type_name -> deputy.diff.v1.ContainerConfigDiff
+	22, // 32: deputy.diff.v1.DiffContainerImagesResponse.layer_analysis:type_name -> deputy.diff.v1.LayerDiffAnalysis
+	24, // 33: deputy.diff.v1.DiffContainerImagesResponse.summary:type_name -> deputy.diff.v1.ContainerDiffSummary
+	16, // 34: deputy.diff.v1.DiffContainerImagesResponse.base_context:type_name -> deputy.diff.v1.ContainerImageContext
+	16, // 35: deputy.diff.v1.DiffContainerImagesResponse.target_context:type_name -> deputy.diff.v1.ContainerImageContext
+	0,  // 36: deputy.diff.v1.ContainerPackageChange.change_kind:type_name -> deputy.diff.v1.ChangeKind
+	35, // 37: deputy.diff.v1.ContainerPackageChange.base_layer_details:type_name -> deputy.container.v1.LayerDetails
+	35, // 38: deputy.diff.v1.ContainerPackageChange.target_layer_details:type_name -> deputy.container.v1.LayerDetails
+	1,  // 39: deputy.diff.v1.ContainerVulnerabilityChange.change_kind:type_name -> deputy.diff.v1.VulnerabilityChangeKind
+	35, // 40: deputy.diff.v1.ContainerVulnerabilityChange.base_layer_details:type_name -> deputy.container.v1.LayerDetails
+	35, // 41: deputy.diff.v1.ContainerVulnerabilityChange.target_layer_details:type_name -> deputy.container.v1.LayerDetails
+	20, // 42: deputy.diff.v1.ContainerConfigDiff.env_changes:type_name -> deputy.diff.v1.EnvChange
+	21, // 43: deputy.diff.v1.ContainerConfigDiff.label_changes:type_name -> deputy.diff.v1.LabelChange
+	0,  // 44: deputy.diff.v1.EnvChange.change_kind:type_name -> deputy.diff.v1.ChangeKind
+	0,  // 45: deputy.diff.v1.LabelChange.change_kind:type_name -> deputy.diff.v1.ChangeKind
+	23, // 46: deputy.diff.v1.LayerDiffAnalysis.layer_changes:type_name -> deputy.diff.v1.LayerChange
+	2,  // 47: deputy.diff.v1.LayerChange.change_kind:type_name -> deputy.diff.v1.LayerChangeKind
+	36, // 48: deputy.diff.v1.DiffVulnerabilitiesResponse.AdvisoriesEntry.value:type_name -> deputy.vulnerability.v1.Advisory
+	36, // 49: deputy.diff.v1.DiffContainerImagesResponse.AdvisoriesEntry.value:type_name -> deputy.vulnerability.v1.Advisory
+	3,  // 50: deputy.diff.v1.DiffService.DiffPackages:input_type -> deputy.diff.v1.DiffPackagesRequest
+	9,  // 51: deputy.diff.v1.DiffService.DiffVulnerabilities:input_type -> deputy.diff.v1.DiffVulnerabilitiesRequest
+	12, // 52: deputy.diff.v1.DiffService.DiffContainerImages:input_type -> deputy.diff.v1.DiffContainerImagesRequest
+	5,  // 53: deputy.diff.v1.DiffService.DiffPackages:output_type -> deputy.diff.v1.DiffPackagesResponse
+	10, // 54: deputy.diff.v1.DiffService.DiffVulnerabilities:output_type -> deputy.diff.v1.DiffVulnerabilitiesResponse
+	14, // 55: deputy.diff.v1.DiffService.DiffContainerImages:output_type -> deputy.diff.v1.DiffContainerImagesResponse
+	53, // [53:56] is the sub-list for method output_type
+	50, // [50:53] is the sub-list for method input_type
+	50, // [50:50] is the sub-list for extension type_name
+	50, // [50:50] is the sub-list for extension extendee
+	0,  // [0:50] is the sub-list for field type_name
 }
 
 func init() { file_deputy_diff_v1_service_proto_init() }
@@ -2660,7 +2752,7 @@ func file_deputy_diff_v1_service_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_deputy_diff_v1_service_proto_rawDesc), len(file_deputy_diff_v1_service_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   25,
+			NumMessages:   26,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/cli/cmd/diff.go
+++ b/internal/cli/cmd/diff.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"connectrpc.com/connect"
 	pb "deps.dev/api/v3"
@@ -35,6 +36,7 @@ import (
 	"github.com/temporalio/deputy/internal/output"
 	"github.com/temporalio/deputy/internal/policy"
 	internalproto "github.com/temporalio/deputy/internal/proto"
+	"github.com/temporalio/deputy/internal/registry"
 	"github.com/temporalio/deputy/internal/report"
 	"github.com/temporalio/deputy/internal/report/render"
 	"github.com/temporalio/deputy/internal/repository"
@@ -56,6 +58,7 @@ func AddDiffCommand(root *cobra.Command, c *services.Clients) {
 		repoPath                                       string
 		skipVulnScan                                   bool
 		enrichLicenses                                 bool
+		enrichRegistryMetadata                         bool
 		licenseSource                                  string
 		publishedBeforeStr, publishedAfterStr, asOfStr string
 		ignoreUnfixed                                  bool
@@ -170,7 +173,7 @@ Can be disabled with --skip-vuln-scan for faster execution.`,
 			if err != nil {
 				return fmt.Errorf("failed to parse references: %w", err)
 			}
-			return runDiffAnalysis(cmd.Context(), c, repo, baseRef, targetRef, !skipVulnScan, enrichLicenses, licenseSource, publishedAfterStr, publishedBeforeStr, asOfStr, ignoreUnfixed, showUnchanged, unchangedThreshold, policyPaths, scanOpts, matcher, debugMatcher, outputFormat, outW, cmd.ErrOrStderr())
+			return runDiffAnalysis(cmd.Context(), c, repo, baseRef, targetRef, !skipVulnScan, enrichLicenses, enrichRegistryMetadata, licenseSource, publishedAfterStr, publishedBeforeStr, asOfStr, ignoreUnfixed, showUnchanged, unchangedThreshold, policyPaths, scanOpts, matcher, debugMatcher, outputFormat, outW, cmd.ErrOrStderr())
 		},
 		Example: `BASIC USAGE:
   # Compare current work with default branch (beginner-friendly)
@@ -298,6 +301,7 @@ PERFORMANCE TIPS:
 	cmd.Flags().StringVar(&repoPath, "repo", "", "Path to the repository (defaults to current directory)")
 	cmd.Flags().BoolVar(&skipVulnScan, "skip-vuln-scan", false, "Skip vulnerability scanning (faster execution)")
 	cmd.Flags().BoolVar(&enrichLicenses, "licenses", false, "Include license information for changed dependencies")
+	cmd.Flags().BoolVar(&enrichRegistryMetadata, "registry-metadata", false, "Fetch registry metadata (publish date) for changed dependencies from deps.dev and expose it to diff_dependency_change policies")
 	cmd.Flags().StringVar(&licenseSource, "license-source", "depsdev", "License information source: depsdev | scan | both")
 	cmd.Flags().StringVar(&publishedBeforeStr, "published-before", "", "Only include vulnerabilities published before this date (YYYY, YYYY-MM, YYYY-MM-DD, or RFC3339)")
 	cmd.Flags().StringVar(&publishedAfterStr, "published-after", "", "Only include vulnerabilities published on/after this date (YYYY, YYYY-MM, YYYY-MM-DD, or RFC3339)")
@@ -330,7 +334,7 @@ type DiffPolicyReport struct {
 // runDiffAnalysis orchestrates dependency inventory collection for the base and
 // target references, computes a dependency diff, and optionally queries OSV to
 // enrich added/updated modules with vulnerability data.
-func runDiffAnalysis(ctx context.Context, c *services.Clients, repoPath, baseRef, targetRef string, enableVulnScan bool, enrichLicenses bool, licenseSource string, publishedAfterStr, publishedBeforeStr, asOfStr string, ignoreUnfixed bool, showUnchanged bool, unchangedThreshold string, policyPaths []string, scanOpts inv.ScanOptions, matcher *inv.DependencyMatcher, debugMatcher bool, outputFormat string, outW io.Writer, errW io.Writer) error {
+func runDiffAnalysis(ctx context.Context, c *services.Clients, repoPath, baseRef, targetRef string, enableVulnScan bool, enrichLicenses bool, enrichRegistryMetadata bool, licenseSource string, publishedAfterStr, publishedBeforeStr, asOfStr string, ignoreUnfixed bool, showUnchanged bool, unchangedThreshold string, policyPaths []string, scanOpts inv.ScanOptions, matcher *inv.DependencyMatcher, debugMatcher bool, outputFormat string, outW io.Writer, errW io.Writer) error {
 	ctx, span := otel.StartSpan(ctx, "deputy.diff",
 		trace.WithAttributes(
 			attribute.String("deputy.target.path", repoPath),
@@ -605,7 +609,7 @@ func runDiffAnalysis(ctx context.Context, c *services.Clients, repoPath, baseRef
 			Changes:         changes,
 			Vulnerabilities: reportVulns,
 		}
-		if err := runDiffPolicies(ctx, policyPaths, policyReport, errW); err != nil {
+		if err := runDiffPolicies(ctx, policyPaths, policyReport, enrichRegistryMetadata, errW); err != nil {
 			otel.SetSpanError(span, err)
 			return err
 		}
@@ -1090,7 +1094,7 @@ func mergeGoDirectMaps(maps ...map[string]bool) map[string]bool {
 
 // runDiffPolicies evaluates the configured policies against the diff report.
 // Passes proto messages directly to CEL for type-safe evaluation.
-func runDiffPolicies(ctx context.Context, policyPaths []string, diffReport DiffPolicyReport, errW io.Writer) error {
+func runDiffPolicies(ctx context.Context, policyPaths []string, diffReport DiffPolicyReport, enrichRegistryMetadata bool, errW io.Writer) error {
 	if len(policyPaths) == 0 {
 		return nil
 	}
@@ -1098,6 +1102,15 @@ func runDiffPolicies(ctx context.Context, policyPaths []string, diffReport DiffP
 	// Convert to proto types for CEL evaluation
 	protoChanges := internalproto.PackageChangesToProto(diffReport.Changes)
 	protoFindings := report.VulnerabilitiesToFindings(diffReport.Vulnerabilities)
+
+	// Optionally enrich changes with registry metadata (publish date) so policies
+	// can reason about release freshness. Failures are non-fatal: policies guard
+	// the fields with has().
+	if enrichRegistryMetadata {
+		if err := enrichChangesWithRegistryMetadata(ctx, protoChanges, errW); err != nil {
+			fmt.Fprintf(errW, "warning: registry metadata enrichment unavailable: %v\n", err)
+		}
+	}
 
 	// Build report-level payload with proto messages
 	payload := map[string]any{
@@ -1140,6 +1153,71 @@ func runDiffPolicies(ctx context.Context, policyPaths []string, diffReport DiffP
 		}
 	}
 	return nil
+}
+
+// registryMetadataConcurrency bounds parallel deps.dev lookups during diff
+// enrichment, matching the default used by SBOM enrichment.
+const registryMetadataConcurrency = 10
+
+// metadataFetcher fetches registry metadata for a single package version. It is
+// the subset of *registry.Fetcher that enrichment needs, declared here so the
+// concurrent enrichment loop can be exercised with a fake in tests.
+type metadataFetcher interface {
+	Fetch(ctx context.Context, ecosystem, name, version string) (*registry.Metadata, error)
+}
+
+// enrichChangesWithRegistryMetadata populates each change's target_metadata
+// (publish date / age) from deps.dev. Per-package lookup failures are tolerated —
+// the field is simply left unset — so a flaky upstream never sinks policy
+// evaluation. An error is returned only if deps.dev cannot be reached at all.
+//
+// Only the target version is fetched: release freshness is a property of the new
+// version a bump introduces, so the base version's publish date is not needed.
+func enrichChangesWithRegistryMetadata(ctx context.Context, changes []*diffv1.PackageChange, errW io.Writer) error {
+	if len(changes) == 0 {
+		return nil
+	}
+
+	fetcher, err := registry.NewFetcher()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := fetcher.Close(); cerr != nil {
+			fmt.Fprintf(errW, "warning: closing registry metadata fetcher: %v\n", cerr)
+		}
+	}()
+
+	enrichChangesWith(ctx, fetcher, changes, time.Now())
+	return nil
+}
+
+// enrichChangesWith is the concurrent core of registry-metadata enrichment,
+// split out so it can be driven by any metadataFetcher. Each change is fetched
+// in its own goroutine (bounded by registryMetadataConcurrency); a fetch error
+// leaves that change's target_metadata unset rather than failing the batch.
+func enrichChangesWith(ctx context.Context, fetcher metadataFetcher, changes []*diffv1.PackageChange, now time.Time) {
+	sem := make(chan struct{}, registryMetadataConcurrency)
+	var wg sync.WaitGroup
+
+	for _, change := range changes {
+		if change == nil || change.Package == nil || change.TargetVersion == "" {
+			continue
+		}
+		wg.Add(1)
+		go func(c *diffv1.PackageChange) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			m, ferr := fetcher.Fetch(ctx, c.Package.Ecosystem, c.Package.Name, c.TargetVersion)
+			if ferr != nil {
+				return // non-fatal: leave target_metadata unset for this package
+			}
+			c.TargetMetadata = m.ToProto(now)
+		}(change)
+	}
+	wg.Wait()
 }
 
 // outputDiffProtoJSON writes a diff response as JSON using protojson.

--- a/internal/cli/cmd/diff_registry_metadata_test.go
+++ b/internal/cli/cmd/diff_registry_metadata_test.go
@@ -1,0 +1,127 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	dependencyv1 "github.com/temporalio/deputy/gen/deputy/dependency/v1"
+	diffv1 "github.com/temporalio/deputy/gen/deputy/diff/v1"
+	"github.com/temporalio/deputy/internal/registry"
+)
+
+// fakeFetcher implements metadataFetcher without any network access. It records
+// peak concurrency so the test can assert the semaphore bound, and varies its
+// result by package name to exercise the success, error, and not-found paths.
+type fakeFetcher struct {
+	published time.Time
+	delay     time.Duration
+
+	calls     atomic.Int32
+	inFlight  atomic.Int32
+	maxFlight atomic.Int32
+}
+
+func (f *fakeFetcher) Fetch(_ context.Context, _, name, _ string) (*registry.Metadata, error) {
+	cur := f.inFlight.Add(1)
+	for {
+		prev := f.maxFlight.Load()
+		if cur <= prev || f.maxFlight.CompareAndSwap(prev, cur) {
+			break
+		}
+	}
+	f.calls.Add(1)
+	if f.delay > 0 {
+		time.Sleep(f.delay)
+	}
+	f.inFlight.Add(-1)
+
+	switch {
+	case strings.Contains(name, "err"):
+		return nil, errors.New("simulated deps.dev failure")
+	case strings.Contains(name, "skip"):
+		return nil, nil // unsupported ecosystem / not found in deps.dev
+	default:
+		return &registry.Metadata{PublishedAt: f.published, Registries: []string{"r"}}, nil
+	}
+}
+
+func change(name, version string) *diffv1.PackageChange {
+	return &diffv1.PackageChange{
+		Package:       &dependencyv1.Package{Name: name, Version: version, Ecosystem: "npm"},
+		TargetVersion: version,
+	}
+}
+
+// TestEnrichChangesWithConcurrent drives the concurrent enrichment core over many
+// changes with a fake fetcher. Run with -race, it exercises the goroutine fan-out
+// and the per-change writes that the production path performs against deps.dev.
+func TestEnrichChangesWithConcurrent(t *testing.T) {
+	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	fetcher := &fakeFetcher{
+		published: now.Add(-2 * 24 * time.Hour), // 2 days old
+		delay:     time.Millisecond,             // encourage goroutine overlap
+	}
+
+	// Build a large, mixed batch: mostly normal, some error/not-found, plus
+	// entries the guard must skip without touching the fetcher.
+	var changes []*diffv1.PackageChange
+	const normalCount = 60
+	for i := range normalCount {
+		changes = append(changes, change(fmt.Sprintf("pkg-%d", i), "1.0.0"))
+	}
+	errChange := change("err-pkg", "2.0.0")
+	skipChange := change("skip-pkg", "3.0.0")
+	changes = append(changes, errChange, skipChange)
+
+	// Guarded-out entries: must be ignored and must not reach the fetcher.
+	changes = append(changes,
+		nil,
+		&diffv1.PackageChange{Package: nil, TargetVersion: "9.9.9"},
+		change("no-version", ""),
+	)
+
+	enrichChangesWith(context.Background(), fetcher, changes, now)
+
+	// Normal changes get target_metadata with the expected age.
+	for i := range normalCount {
+		c := changes[i]
+		if c.TargetMetadata == nil {
+			t.Fatalf("pkg-%d: TargetMetadata = nil, want set", i)
+		}
+		if got := c.TargetMetadata.GetAgeDays(); got != 2 {
+			t.Errorf("pkg-%d: age_days = %v, want 2", i, got)
+		}
+	}
+
+	// Error and not-found leave target_metadata unset (graceful degradation).
+	if errChange.TargetMetadata != nil {
+		t.Errorf("err-pkg: TargetMetadata = %v, want nil on fetch error", errChange.TargetMetadata)
+	}
+	if skipChange.TargetMetadata != nil {
+		t.Errorf("skip-pkg: TargetMetadata = %v, want nil when deps.dev has no record", skipChange.TargetMetadata)
+	}
+
+	// The fetcher is called once per eligible change only (guarded entries excluded).
+	if got, want := fetcher.calls.Load(), int32(normalCount+2); got != want {
+		t.Errorf("fetcher calls = %d, want %d", got, want)
+	}
+
+	// The semaphore bounds concurrency.
+	if peak := fetcher.maxFlight.Load(); peak > registryMetadataConcurrency {
+		t.Errorf("peak concurrency = %d, exceeds bound %d", peak, registryMetadataConcurrency)
+	}
+}
+
+// TestEnrichChangesWithEmpty is a guard: no changes means no work and no panic.
+func TestEnrichChangesWithEmpty(t *testing.T) {
+	fetcher := &fakeFetcher{published: time.Now()}
+	enrichChangesWith(context.Background(), fetcher, nil, time.Now())
+	if got := fetcher.calls.Load(); got != 0 {
+		t.Errorf("fetcher calls = %d, want 0", got)
+	}
+}

--- a/internal/registry/metadata.go
+++ b/internal/registry/metadata.go
@@ -1,0 +1,174 @@
+// Package registry fetches registry-sourced metadata about specific package
+// versions from deps.dev and exposes it as policy signals.
+//
+// The metadata it surfaces — when a version was published — is the kind of
+// supply-chain signal a known-vulnerability scan cannot see: a freshly published
+// version has had no time to be vetted and is a common shape for a malicious
+// release, well before any CVE is assigned. Deputy stays self-contained here;
+// everything is fetched from the deps.dev Insights API it already depends on.
+package registry
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	pb "deps.dev/api/v3"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	diffv1 "github.com/temporalio/deputy/gen/deputy/diff/v1"
+	"github.com/temporalio/deputy/internal/cache/memory"
+)
+
+const (
+	// depsDevEndpoint is the gRPC endpoint for the deps.dev Insights API.
+	depsDevEndpoint = "api.deps.dev:443"
+
+	// defaultCacheSize bounds the number of cached version-metadata responses.
+	defaultCacheSize = 4096
+
+	// defaultCacheTTL is how long cached responses remain valid. A version's
+	// publish date is immutable once released, so a long TTL is safe.
+	defaultCacheTTL = 1 * time.Hour
+)
+
+// Metadata is the registry-sourced view of a single package version.
+type Metadata struct {
+	// PublishedAt is when the version was published to its registry. The zero
+	// value means deps.dev had no publish date for the version.
+	PublishedAt time.Time
+	// Registries lists the registries deps.dev reports as hosting the version.
+	Registries []string
+}
+
+// ToProto converts the metadata to its policy-input proto representation,
+// computing age relative to now. It returns nil for a nil receiver so callers
+// can pass through "no metadata" without branching.
+func (m *Metadata) ToProto(now time.Time) *diffv1.RegistryMetadata {
+	if m == nil {
+		return nil
+	}
+	out := &diffv1.RegistryMetadata{
+		Registries: m.Registries,
+		AgeDays:    -1,
+	}
+	if !m.PublishedAt.IsZero() {
+		out.PublishedAt = timestamppb.New(m.PublishedAt)
+		out.AgeDays = now.Sub(m.PublishedAt).Hours() / 24
+	}
+	return out
+}
+
+// Fetcher retrieves version metadata from deps.dev. It is safe for concurrent
+// use. Construct it with NewFetcher and Close it when done.
+type Fetcher struct {
+	client pb.InsightsClient
+	conn   *grpc.ClientConn
+	cache  *memory.TTLCache[string, *Metadata]
+}
+
+// NewFetcher dials deps.dev and returns a ready-to-use Fetcher.
+func NewFetcher() (*Fetcher, error) {
+	creds := credentials.NewClientTLSFromCert(nil, "")
+	conn, err := grpc.NewClient(depsDevEndpoint, grpc.WithTransportCredentials(creds))
+	if err != nil {
+		return nil, fmt.Errorf("connecting to deps.dev: %w", err)
+	}
+	return &Fetcher{
+		client: pb.NewInsightsClient(conn),
+		conn:   conn,
+		cache:  memory.NewTTLCache[string, *Metadata](defaultCacheSize, defaultCacheTTL),
+	}, nil
+}
+
+// Close releases the underlying gRPC connection.
+func (f *Fetcher) Close() error {
+	if f == nil || f.conn == nil {
+		return nil
+	}
+	return f.conn.Close()
+}
+
+// Fetch returns registry metadata for the given package version. It returns
+// (nil, nil) when the ecosystem is not supported by deps.dev or the coordinates
+// are incomplete, so callers can treat "no metadata" uniformly. Network and
+// lookup errors are returned so callers can decide whether to degrade.
+func (f *Fetcher) Fetch(ctx context.Context, ecosystem, name, version string) (*Metadata, error) {
+	system := systemFromEcosystem(ecosystem)
+	if system == pb.System_SYSTEM_UNSPECIFIED {
+		return nil, nil
+	}
+	name = strings.TrimSpace(name)
+	version = normalizeVersion(system, version)
+	if name == "" || version == "" {
+		return nil, nil
+	}
+
+	cacheKey := fmt.Sprintf("%s/%s@%s", system, name, version)
+	if m, ok := f.cache.Get(cacheKey); ok {
+		return m, nil
+	}
+
+	resp, err := f.client.GetVersion(ctx, &pb.GetVersionRequest{
+		VersionKey: &pb.VersionKey{System: system, Name: name, Version: version},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("deps.dev GetVersion %s: %w", cacheKey, err)
+	}
+
+	m := metadataFromVersion(resp)
+	f.cache.Set(cacheKey, m)
+	return m, nil
+}
+
+// metadataFromVersion extracts the fields we expose from a deps.dev version
+// response. It is pure so it can be unit tested without a network round-trip.
+func metadataFromVersion(v *pb.Version) *Metadata {
+	if v == nil {
+		return nil
+	}
+	m := &Metadata{Registries: v.GetRegistries()}
+	if ts := v.GetPublishedAt(); ts != nil {
+		m.PublishedAt = ts.AsTime()
+	}
+	return m
+}
+
+// systemFromEcosystem maps a free-form ecosystem string to a deps.dev system,
+// returning SYSTEM_UNSPECIFIED for ecosystems deps.dev does not cover.
+func systemFromEcosystem(ecosystem string) pb.System {
+	switch strings.ToLower(strings.TrimSpace(ecosystem)) {
+	case "go", "golang":
+		return pb.System_GO
+	case "npm", "javascript", "node", "nodejs":
+		return pb.System_NPM
+	case "cargo", "rust", "crates", "crates.io":
+		return pb.System_CARGO
+	case "maven", "java":
+		return pb.System_MAVEN
+	case "pypi", "python":
+		return pb.System_PYPI
+	case "nuget", "dotnet", ".net":
+		return pb.System_NUGET
+	case "rubygems", "ruby", "gem":
+		return pb.System_RUBYGEMS
+	default:
+		return pb.System_SYSTEM_UNSPECIFIED
+	}
+}
+
+// normalizeVersion applies the version normalization deps.dev expects, notably
+// the leading "v" that Go module versions carry.
+func normalizeVersion(system pb.System, version string) string {
+	v := strings.TrimSpace(version)
+	if v == "" {
+		return ""
+	}
+	if system == pb.System_GO && !strings.HasPrefix(v, "v") {
+		return "v" + v
+	}
+	return v
+}

--- a/internal/registry/metadata_test.go
+++ b/internal/registry/metadata_test.go
@@ -1,0 +1,127 @@
+package registry
+
+import (
+	"testing"
+	"time"
+
+	pb "deps.dev/api/v3"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestSystemFromEcosystem(t *testing.T) {
+	tests := []struct {
+		ecosystem string
+		want      pb.System
+	}{
+		{"go", pb.System_GO},
+		{"Go", pb.System_GO},
+		{"golang", pb.System_GO},
+		{"npm", pb.System_NPM},
+		{"NodeJS", pb.System_NPM},
+		{"pypi", pb.System_PYPI},
+		{"python", pb.System_PYPI},
+		{"cargo", pb.System_CARGO},
+		{"maven", pb.System_MAVEN},
+		{"rubygems", pb.System_RUBYGEMS},
+		{"nuget", pb.System_NUGET},
+		{"  npm  ", pb.System_NPM},
+		{"hex", pb.System_SYSTEM_UNSPECIFIED},
+		{"", pb.System_SYSTEM_UNSPECIFIED},
+	}
+	for _, tt := range tests {
+		t.Run(tt.ecosystem, func(t *testing.T) {
+			if got := systemFromEcosystem(tt.ecosystem); got != tt.want {
+				t.Errorf("systemFromEcosystem(%q) = %v, want %v", tt.ecosystem, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		system  pb.System
+		version string
+		want    string
+	}{
+		{"go gets v prefix", pb.System_GO, "1.2.3", "v1.2.3"},
+		{"go keeps existing v", pb.System_GO, "v1.2.3", "v1.2.3"},
+		{"go trims space", pb.System_GO, "  1.2.3 ", "v1.2.3"},
+		{"npm untouched", pb.System_NPM, "1.2.3", "1.2.3"},
+		{"empty stays empty", pb.System_GO, "  ", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeVersion(tt.system, tt.version); got != tt.want {
+				t.Errorf("normalizeVersion(%v, %q) = %q, want %q", tt.system, tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMetadataFromVersion(t *testing.T) {
+	published := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	t.Run("nil version", func(t *testing.T) {
+		if got := metadataFromVersion(nil); got != nil {
+			t.Fatalf("metadataFromVersion(nil) = %v, want nil", got)
+		}
+	})
+
+	t.Run("with publish date and registries", func(t *testing.T) {
+		v := &pb.Version{
+			PublishedAt: timestamppb.New(published),
+			Registries:  []string{"https://registry.npmjs.org/"},
+		}
+		got := metadataFromVersion(v)
+		if !got.PublishedAt.Equal(published) {
+			t.Errorf("PublishedAt = %v, want %v", got.PublishedAt, published)
+		}
+		if len(got.Registries) != 1 || got.Registries[0] != "https://registry.npmjs.org/" {
+			t.Errorf("Registries = %v", got.Registries)
+		}
+	})
+
+	t.Run("missing publish date leaves zero time", func(t *testing.T) {
+		got := metadataFromVersion(&pb.Version{})
+		if !got.PublishedAt.IsZero() {
+			t.Errorf("PublishedAt = %v, want zero", got.PublishedAt)
+		}
+	})
+}
+
+func TestMetadataToProto(t *testing.T) {
+	now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+
+	t.Run("nil receiver", func(t *testing.T) {
+		var m *Metadata
+		if got := m.ToProto(now); got != nil {
+			t.Fatalf("ToProto() = %v, want nil", got)
+		}
+	})
+
+	t.Run("computes age in days", func(t *testing.T) {
+		m := &Metadata{
+			PublishedAt: now.Add(-7 * 24 * time.Hour),
+			Registries:  []string{"r"},
+		}
+		got := m.ToProto(now)
+		if got.GetAgeDays() != 7 {
+			t.Errorf("AgeDays = %v, want 7", got.GetAgeDays())
+		}
+		if got.GetPublishedAt() == nil {
+			t.Error("PublishedAt = nil, want set")
+		}
+	})
+
+	t.Run("unknown publish date yields -1 age and nil timestamp", func(t *testing.T) {
+		m := &Metadata{}
+		got := m.ToProto(now)
+		if got.GetAgeDays() != -1 {
+			t.Errorf("AgeDays = %v, want -1", got.GetAgeDays())
+		}
+		if got.GetPublishedAt() != nil {
+			t.Error("PublishedAt should be nil when unknown")
+		}
+	})
+}

--- a/policy/examples/release-freshness.yaml
+++ b/policy/examples/release-freshness.yaml
@@ -1,0 +1,26 @@
+policies:
+  - name: release-freshness
+    description: >-
+      Flag dependency bumps to versions that were published very recently.
+      A version that is only hours or a few days old has had no time to be
+      vetted, and malicious releases are typically live for only a short window
+      before they are caught and pulled. Requires `deputy diff --registry-metadata`,
+      which fetches publish dates from deps.dev and exposes them as
+      change.target_metadata.
+    vars:
+      # has() guards the field so the rules are inert when --registry-metadata is
+      # not set (target_metadata absent) or deps.dev had no publish date for the
+      # version (age_days == -1).
+      hasAge: 'has(change.target_metadata) && change.target_metadata.age_days >= 0.0'
+      ageDays: 'change.target_metadata.age_days'
+      isBump: 'env.entrypoint == "diff_dependency_change"'
+    rules:
+      # Block direct-dependency bumps to a version less than a day old.
+      - action: deny
+        when: isBump && change.is_direct && hasAge && ageDays < 1.0
+        reason: Direct dependency bumped to a version published less than 24h ago
+        remediation: Wait for the release to age, or pin to a previously vetted version
+      # Warn on any bump to a version less than a week old.
+      - action: warn
+        when: isBump && hasAge && ageDays < 7.0
+        reason: Dependency bumped to a version published less than 7 days ago


### PR DESCRIPTION
## Summary

Implements the **release-freshness** signal from #41 (signal #3). Adds an opt-in
`deputy diff --registry-metadata` that fetches each changed package's publish
date from deps.dev and exposes it to `diff_dependency_change` policies as
`change.target_metadata`, so policies can flag bumps to versions that were
published only hours or days ago.

A freshly published version has had no time to be vetted and is a common shape
for a malicious release — exactly the kind of thing a known-CVE scan sees nothing
of on day zero. As you noted in the issue, Deputy already fetches per-version
publish dates via deps.dev; this wires that up as an actual policy input.

Everything is fetched from the deps.dev Insights API Deputy already depends on,
so the engine stays self-contained.

## What's in scope

Per your comment that **"2 and 3 sort of fold together as registry metadata we
can fetch and expose in the policy"** — this PR ships **#3 (release freshness)**
and intentionally **defers #2 (maintainer change)**, because they actually split
on where the data comes from:

- **#3 release freshness** → deps.dev has publish dates. Done here.
- **#2 maintainer change** → deps.dev does **not** expose registry
  publisher/maintainer account identity or account age. A faithful
  maintainer-change check needs **per-registry** lookups (npm `maintainers` /
  `_npmUser` + account age, RubyGems `owners`, etc.). That's a larger,
  per-ecosystem change best landed incrementally.

## CEL usage

```cel
env.entrypoint == "diff_dependency_change" &&
  has(change.target_metadata) &&
  change.target_metadata.age_days >= 0.0 &&
  change.target_metadata.age_days < 7.0
```

`age_days` is precomputed (deps.dev publish date vs. now) because CEL has no
`now`. Fields are unset when `--registry-metadata` is off or deps.dev has no
record, so policies guard with `has()`. See
`policy/examples/release-freshness.yaml`.

## Changes

- `api/deputy/diff/v1/service.proto` — `RegistryMetadata` message +
  `PackageChange.target_metadata` (regenerated into `gen/`).
- `internal/registry/` — deps.dev-backed `Fetcher` + a pure response→`Metadata`
  conversion (unit tested without network).
- `internal/cli/cmd/diff.go` — `--registry-metadata` flag and a concurrent,
  non-fatal per-change enrichment pass.
- `policy/examples/release-freshness.yaml` — example policy.
- Docs: `policy-inputs.md`, `diff.md`, and the development note.

## Notes / graceful degradation

- Off by default; only fetches (and only adds latency) when `--registry-metadata`
  is passed alongside `--policy`.
- deps.dev failures are non-fatal — `target_metadata` is simply left unset, the
  diff still completes.
- Only the **target** version is fetched (freshness is a property of the new
  version a bump introduces).

## Testing

- `go test ./...` — 100 packages pass, 0 failures.
- `buf generate` is idempotent.
- Verified end-to-end with `deputy policy lint`, `eval`, and `simulate`: a fresh
  (<1d, direct) bump yields DENY + WARN; an aged version yields nothing; a diff
  without `--registry-metadata` yields nothing (has() guard holds).

Refs #41.

---

This is a starting point — happy to adjust the field shape, flag naming, or where
this lands (you mentioned "likely a mix of all three").
