### PR TITLE
Restrict deputy fix remediation to source-of-truth manifests

### DIFF
--- a/docs/commands/fix.md
+++ b/docs/commands/fix.md
@@ -22,6 +22,7 @@ deputy fix [repo] [flags]
 | `--plan` | | | Path to existing remediation plan JSON |
 | `--ref` | | `HEAD` | Git reference to scan |
 | `--ecosystems` | | all | Limit to specific ecosystems |
+| `--exclude-path` | | | Directory glob to skip during the walk (repeatable; e.g. `.bin/**`). Unioned with `scan.exclude_paths` from config |
 | `--ignore-unfixed` | | `false` | Skip vulns without fixes |
 | `--published-before` | | | Date filter for vulnerabilities |
 | `--published-after` | | | Date filter for vulnerabilities |

--- a/internal/cli/cmd/fix.go
+++ b/internal/cli/cmd/fix.go
@@ -114,6 +114,7 @@ AI ASSISTANCE:
 	fixCmd.Flags().Bool("agent-verbose", false, "Show full command output instead of compact summaries")
 	fixCmd.Flags().Bool("apply", false, "Execute runnable remediation commands in-place (local scans only)")
 	fixCmd.Flags().StringArray("policy", nil, "Path to CEL policy files or bundles to evaluate against remediation plans (repeatable)")
+	addExcludePathFlag(fixCmd)
 	root.AddCommand(fixCmd)
 }
 
@@ -182,7 +183,8 @@ func runFixPlan(c *services.Clients, cmd *cobra.Command, args []string) error {
 
 		// Build scan request
 		scanOpts := &scanv1.ScanOptions{
-			Ecosystems: ecos,
+			Ecosystems:   ecos,
+			ExcludePaths: excludePathsFromCmd(cmd),
 		}
 		if !beforeT.IsZero() {
 			scanOpts.PublishedBefore = timestamppb.New(beforeT)

--- a/internal/inventory/exclude.go
+++ b/internal/inventory/exclude.go
@@ -7,6 +7,47 @@ import (
 	"github.com/gobwas/glob"
 )
 
+// DefaultDependencyInstallDirs are directory names that unambiguously denote an
+// installed or vendored third-party dependency tree, never a source-of-truth
+// manifest location. A name qualifies only if it is the canonical install
+// directory for an ecosystem and is not also a common source-directory name:
+// that admits "node_modules", "site-packages", and "__pypackages__" but excludes
+// ambiguous names that are frequently real source dirs ("vendor", "target",
+// "build") and the virtualenv root (".venv"/"venv"), whose vendored manifests
+// live under the unambiguous "site-packages" child matched here.
+//
+// This backs [IsDependencyInstallPath], used by the remediation guard to avoid
+// emitting a fix against a manifest vendored inside an installed tree (a derived
+// copy that cannot be edited in place). It is deliberately small and serves as a
+// version-control-independent backstop, notably for non-git directory scans.
+// Scoping a repository scan to its committed source of truth is handled
+// separately by honoring version control, not by this list.
+var DefaultDependencyInstallDirs = []string{
+	"node_modules",
+	"site-packages",
+	"__pypackages__",
+}
+
+// IsDependencyInstallPath reports whether p traverses a dependency-install
+// directory (see [DefaultDependencyInstallDirs]). Path separators may be "/" or
+// "\\"; matching is per path segment, so "a/b/site-packages/pkg/Cargo.toml"
+// matches while "my-site-packages.txt" does not. Used to keep remediation from
+// targeting a manifest vendored inside an installed dependency tree.
+func IsDependencyInstallPath(p string) bool {
+	p = strings.ReplaceAll(strings.TrimSpace(p), "\\", "/")
+	if p == "" {
+		return false
+	}
+	for _, seg := range strings.Split(p, "/") {
+		for _, dir := range DefaultDependencyInstallDirs {
+			if seg == dir {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // CompileExcludePaths compiles a set of path-exclusion glob patterns into a
 // single matcher suitable for scalibr's SkipDirGlob. Patterns are matched
 // against directory paths (slash-separated, relative to the scan root) during

--- a/internal/inventory/exclude_test.go
+++ b/internal/inventory/exclude_test.go
@@ -95,3 +95,37 @@ func TestCompileExcludePaths_InvalidPattern(t *testing.T) {
 		t.Fatal("expected error for malformed glob pattern, got nil")
 	}
 }
+
+func TestIsDependencyInstallPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		// Matches: an unambiguous install-tree segment anywhere in the path.
+		{".venv/lib/python3.12/site-packages/pkg/Cargo.toml", true}, // via site-packages, not .venv
+		{".tox/py312/lib/python3.12/site-packages/req/METADATA", true},
+		{"node_modules/left-pad/package.json", true},
+		{"a/b/node_modules/c/package.json", true},
+		{"pdmproj/__pypackages__/3.12/lib/pkg/PKG-INFO", true},
+		{`api\node_modules\pkg\package.json`, true}, // backslash separators normalize
+		// Non-matches: the fuzzy venv root and build/cache dirs are NOT excluded
+		// on their own (only their unambiguous install children are).
+		{".venv/bin/activate", false},
+		{"venv/lib/foo", false},
+		{"src/__pycache__/mod.pyc", false},
+		{"build/out.js", false},
+		{"vendor/foo/bar.go", false},
+		{"Cargo.toml", false},
+		{"go.mod", false},
+		{"my-site-packages.txt", false}, // substring, not a path segment
+		{"node_modules_backup/x", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			if got := IsDependencyInstallPath(tt.path); got != tt.want {
+				t.Errorf("IsDependencyInstallPath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/remediation/remediation.go
+++ b/internal/remediation/remediation.go
@@ -13,6 +13,7 @@ import (
 	"github.com/temporalio/deputy/internal/collections"
 	"github.com/temporalio/deputy/internal/dependency"
 	"github.com/temporalio/deputy/internal/ecosystem"
+	"github.com/temporalio/deputy/internal/inventory"
 	"github.com/temporalio/deputy/internal/vulnerability"
 )
 
@@ -265,6 +266,14 @@ func dedupeCommands(upgrades []packageUpgrade) []Command {
 	for _, u := range upgrades {
 		for i := range u.References {
 			ref := &u.References[i]
+			// Never remediate a manifest vendored inside a dependency-install tree
+			// (e.g. a Cargo.toml under site-packages): it is a derived copy, not
+			// the source of truth, so any edit is wiped on reinstall. The inventory
+			// walk excludes these by default, but a manifest can still reach here
+			// when that default is overridden, so guard remediation too.
+			if inventory.IsDependencyInstallPath(ref.Path) {
+				continue
+			}
 			var rec commandResult
 			if u.Migration {
 				rec = migrationCommand(u.TargetModule, u.Recommended, u.IsDirect)
@@ -401,9 +410,16 @@ func stdlibCommands(version string, refs []dependencyv1.ManifestRef) []Command {
 	seen := collections.NewSet[string]()
 	sawManaged := false
 	sawGoMod := false
+	survived := 0
 
 	for i := range refs {
 		ref := &refs[i]
+		// Skip Go-version declarations vendored inside a dependency-install tree;
+		// only a source-of-truth manifest should drive a toolchain bump.
+		if inventory.IsDependencyInstallPath(ref.Path) {
+			continue
+		}
+		survived++
 		switch strings.ToLower(strings.TrimSpace(ref.Manager)) {
 		case "mise", "asdf":
 			sawManaged = true
@@ -432,7 +448,12 @@ func stdlibCommands(version string, refs []dependencyv1.ManifestRef) []Command {
 		}
 	}
 
-	if sawGoMod || !sawManaged {
+	// With no attributable source, fall back to a go.mod toolchain bump (prior
+	// behavior). But when refs existed and were all vendored install copies
+	// (none survived the filter), the finding came purely from a derived
+	// manifest, so there is nothing actionable to bump and we emit nothing.
+	allRefsVendored := len(refs) > 0 && survived == 0
+	if !allRefsVendored && (sawGoMod || !sawManaged) {
 		if tc, ok := buildGoToolchainCommand(version); ok {
 			cmds = append(cmds, tc)
 		}

--- a/internal/remediation/remediation_test.go
+++ b/internal/remediation/remediation_test.go
@@ -6,6 +6,7 @@ import (
 
 	dependencyv1 "github.com/temporalio/deputy/gen/deputy/dependency/v1"
 	"github.com/temporalio/deputy/internal/dependency"
+	"github.com/temporalio/deputy/internal/inventory"
 	"github.com/temporalio/deputy/internal/vulnerability"
 )
 
@@ -436,5 +437,67 @@ func TestIsContainerfilePath(t *testing.T) {
 				t.Errorf("isContainerfilePath(%q) = %v, want %v", tt.name, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestCommandsFromConsolidatedSkipsInstallArtifactManifests is the regression
+// for temporalio/deputy#40: a vulnerable package whose manifest is vendored
+// inside an install-artifact tree (e.g. a Cargo.toml under .venv/site-packages)
+// must not produce a remediation command, since editing the installed copy
+// fixes nothing. The source-of-truth manifest at the repo root still does.
+func TestCommandsFromConsolidatedSkipsInstallArtifactManifests(t *testing.T) {
+	cons := []vulnerability.Consolidated{
+		{
+			PrimaryID:     "GHSA-test",
+			Package:       "somecrate",
+			Version:       "1.0.0",
+			Ecosystem:     "crates.io",
+			IsDirect:      true,
+			FixedVersions: []string{"1.0.1"},
+			ManifestRefs: []dependencyv1.ManifestRef{
+				{Manager: "cargo", Path: "Cargo.toml"},
+				{Manager: "cargo", Path: ".venv/lib/python3.12/site-packages/wheelpkg/Cargo.toml"},
+			},
+		},
+	}
+
+	commands, _ := CommandsFromConsolidated(cons)
+
+	var sawRoot bool
+	for _, c := range commands {
+		if inventory.IsDependencyInstallPath(c.Path) {
+			t.Errorf("emitted remediation targeting install-artifact manifest %q (command %q)", c.Path, c.Command)
+		}
+		if c.Path == "Cargo.toml" {
+			sawRoot = true
+		}
+	}
+	if !sawRoot {
+		t.Error("expected a remediation command for the source-of-truth Cargo.toml")
+	}
+}
+
+// TestStdlibCommandsSkipsVendoredGoMod covers the toolchain-fallback edge of
+// temporalio/deputy#40: a Go stdlib finding whose only source is a go.mod
+// vendored inside an installed tree must not produce a `go get go@X` command,
+// since the fallback would otherwise emit one against a synthetic go.mod path.
+func TestStdlibCommandsSkipsVendoredGoMod(t *testing.T) {
+	cons := []vulnerability.Consolidated{
+		{
+			PrimaryID:     "GO-2026-0001",
+			Package:       "stdlib",
+			Version:       "1.25.0",
+			Ecosystem:     "Go",
+			FixedVersions: []string{"1.25.11"},
+			ManifestRefs: []dependencyv1.ManifestRef{
+				{Manager: "go", Path: ".venv/lib/python3.10/site-packages/wheelpkg/sdk-core/go.mod"},
+			},
+		},
+	}
+
+	commands, _ := CommandsFromConsolidated(cons)
+
+	if len(commands) != 0 {
+		t.Errorf("expected no commands for a stdlib finding sourced only from a vendored go.mod, got %d: %+v", len(commands), commands)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes temporalio/deputy#40. `deputy fix` derived each remediation command's target directly from the extracted manifest path, so a manifest *vendored inside an installed dependency tree* (e.g. a `Cargo.toml` inside an installed Python wheel under `.venv/site-packages`) produced a command that edits a derived copy, which fixes nothing and is wiped on the next reinstall. The reporter's repro (`uv venv` + `uv pip install temporalio`, then `deputy fix .`) produced 16 commands, 15 of them (94%) targeting `Cargo.toml` files inside `.venv`, all runnable.

- **Remediation guard:** `dedupeCommands` and `stdlibCommands` skip any `ManifestRef` whose path traverses a dependency-install directory, so `fix` never targets a vendored copy. Path-based and version-control-independent, which matters because the repro is a non-git directory.
- **Toolchain-fallback case:** the Go stdlib path emits a `go get go@X` against a synthetic `go.mod` when no source is attributable; that still fired when the only Go-version declaration was a vendored `go.mod` inside the wheel. Now suppressed when *every* ref was a vendored copy, while preserving the genuinely-unattributed case.
- **`IsDependencyInstallPath` helper** over a deliberately strict set (`node_modules`, `site-packages`, `__pypackages__`): canonical install-dir names that never denote a source-of-truth manifest location; excludes ambiguous names (`vendor`, `target`, `build`) and the fuzzy venv root on purpose.
- **`fix` now honors `--exclude-path`** (and `scan.exclude_paths`), consistent with `scan`/`diff`/`list`/`graph`.

Scope kept intentionally tight: this fixes the dangerous `fix` behavior without changing what `scan` reports. Whether repository scans should honor `.gitignore` (or a fixed install-dir list) by default, versus relying on `--exclude-path`, is tracked separately so the security-default tradeoff is decided deliberately rather than bundled here.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `staticcheck ./...` clean (no new findings)
- [x] Full `go test ./...` passes
- [x] `TestCommandsFromConsolidatedSkipsInstallArtifactManifests`: vendored `Cargo.toml` under `.venv` yields no command; root `Cargo.toml` still does
- [x] `TestStdlibCommandsSkipsVendoredGoMod`: stdlib finding sourced only from a vendored `go.mod` yields no command
- [x] `TestIsDependencyInstallPath`: path-segment matching, backslash normalization, substring non-matches
- [x] End-to-end against the reporter's repro: `deputy fix .` on a venv with an installed `temporalio` wheel went from 17 runnable commands (16 targeting `.venv`) to an empty plan