### PR TITLE
Resolve slashed branch names via origin/ fallback in CI

### DIFF
--- a/internal/gitutil/origin_fallback_test.go
+++ b/internal/gitutil/origin_fallback_test.go
@@ -1,0 +1,99 @@
+package gitutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+func TestShouldTryOriginFallback(t *testing.T) {
+	tests := []struct {
+		ref  string
+		want bool
+	}{
+		{"main", true},
+		{"fix/foo", true},                 // slashed branch name: must still get the fallback
+		{"feature/a/b", true},             // multi-slash branch name
+		{"origin/main", false},            // already remote-qualified
+		{"origin/fix/foo", false},         // already remote-qualified, slashed
+		{"remotes/origin/fix/foo", false}, // fully-qualified remotes ref
+	}
+	for _, tt := range tests {
+		t.Run(tt.ref, func(t *testing.T) {
+			if got := shouldTryOriginFallback(tt.ref); got != tt.want {
+				t.Errorf("shouldTryOriginFallback(%q) = %v, want %v", tt.ref, got, tt.want)
+			}
+		})
+	}
+}
+
+// slashedBranchRemoteOnlyRepo builds a repo that mirrors a CI checkout: a commit
+// reachable only through a remote-tracking ref (refs/remotes/origin/fix/foo),
+// with no local branch of that name. It returns the repo and the commit hash.
+func slashedBranchRemoteOnlyRepo(t *testing.T) (*git.Repository, plumbing.Hash) {
+	t.Helper()
+	dir := t.TempDir()
+	repo, err := git.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("PlainInit: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "file.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("Worktree: %v", err)
+	}
+	if _, err := wt.Add("file.txt"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	hash, err := wt.Commit("initial", &git.CommitOptions{
+		Author: &object.Signature{Name: "test", Email: "test@example.com", When: time.Now()},
+	})
+	if err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	// Remote-tracking ref only; deliberately no local refs/heads/fix/foo.
+	remoteRef := plumbing.NewHashReference("refs/remotes/origin/fix/foo", hash)
+	if err := repo.Storer.SetReference(remoteRef); err != nil {
+		t.Fatalf("SetReference: %v", err)
+	}
+	return repo, hash
+}
+
+// TestResolveRevisionEnhanced_SlashedBranchViaOrigin is the regression for the
+// PR-gate failure: a slashed branch name present only as a remote-tracking ref
+// must resolve via the origin/ fallback rather than being rejected for
+// containing a slash.
+func TestResolveRevisionEnhanced_SlashedBranchViaOrigin(t *testing.T) {
+	repo, want := slashedBranchRemoteOnlyRepo(t)
+
+	got, err := ResolveRevisionEnhanced(repo, "fix/foo")
+	if err != nil {
+		t.Fatalf("ResolveRevisionEnhanced(fix/foo): %v", err)
+	}
+	if got == nil || *got != want {
+		t.Errorf("resolved %v, want %v", got, want)
+	}
+
+	// A genuinely unknown slashed ref still errors (no silent success).
+	if _, err := ResolveRevisionEnhanced(repo, "fix/does-not-exist"); err == nil {
+		t.Error("expected error for an unknown slashed ref")
+	}
+}
+
+func TestValidateReference_SlashedBranchViaOrigin(t *testing.T) {
+	repo, _ := slashedBranchRemoteOnlyRepo(t)
+
+	if err := validateReference(repo, "fix/foo"); err != nil {
+		t.Errorf("validateReference(fix/foo) = %v, want nil", err)
+	}
+	if err := validateReference(repo, "fix/does-not-exist"); err == nil {
+		t.Error("expected error for an unknown slashed ref")
+	}
+}

--- a/internal/gitutil/origin_fallback_test.go
+++ b/internal/gitutil/origin_fallback_test.go
@@ -17,11 +17,15 @@ func TestShouldTryOriginFallback(t *testing.T) {
 		want bool
 	}{
 		{"main", true},
-		{"fix/foo", true},                 // slashed branch name: must still get the fallback
-		{"feature/a/b", true},             // multi-slash branch name
-		{"origin/main", false},            // already remote-qualified
-		{"origin/fix/foo", false},         // already remote-qualified, slashed
-		{"remotes/origin/fix/foo", false}, // fully-qualified remotes ref
+		{"fix/foo", true},                      // slashed branch name: must still get the fallback
+		{"feature/a/b", true},                  // multi-slash branch name
+		{"  fix/foo  ", true},                  // whitespace-padded slashed branch still gets the fallback
+		{"origin/main", false},                 // already remote-qualified
+		{"origin/fix/foo", false},              // already remote-qualified, slashed
+		{"remotes/origin/fix/foo", false},      // remotes-qualified
+		{"refs/remotes/origin/fix/foo", false}, // fully-qualified remote-tracking ref
+		{"refs/heads/main", false},             // fully-qualified local ref
+		{" origin/main ", false},               // whitespace + already remote-qualified
 	}
 	for _, tt := range tests {
 		t.Run(tt.ref, func(t *testing.T) {

--- a/internal/gitutil/refs.go
+++ b/internal/gitutil/refs.go
@@ -222,6 +222,15 @@ func isLikelyDefaultBranch(branchName string) bool {
 	return slices.Contains(DefaultBranchPatterns, branchName)
 }
 
+// shouldTryOriginFallback reports whether the origin/<ref> CI fallback should be
+// attempted for ref. It is skipped only when ref is already remote-qualified
+// (origin/... or remotes/...), so ordinary slashed branch names like "fix/foo"
+// still resolve in CI checkouts where the local branch ref is absent. Guards
+// against producing "origin/origin/...".
+func shouldTryOriginFallback(ref string) bool {
+	return !strings.HasPrefix(ref, "origin/") && !strings.HasPrefix(ref, "remotes/")
+}
+
 // validateReference checks if a Git reference is valid and provides helpful error messages.
 func validateReference(repo *git.Repository, ref string) error {
 	upper := strings.ToUpper(strings.TrimSpace(ref))
@@ -231,8 +240,11 @@ func validateReference(repo *git.Repository, ref string) error {
 	if _, err := ResolveRevisionEnhanced(repo, ref); err == nil {
 		return nil
 	}
-	// Try with origin/ prefix for CI environments where branch names are remote refs
-	if !strings.Contains(ref, "/") {
+	// Try with origin/ prefix for CI environments where the local branch ref is
+	// absent and only the remote-tracking ref exists. Branch names commonly
+	// contain '/' (fix/x, feature/y), so this must run for slashed refs too; it
+	// is skipped only when the ref is already remote-qualified.
+	if shouldTryOriginFallback(ref) {
 		if _, err := ResolveRevisionEnhanced(repo, "origin/"+ref); err == nil {
 			return nil
 		}

--- a/internal/gitutil/refs.go
+++ b/internal/gitutil/refs.go
@@ -224,11 +224,16 @@ func isLikelyDefaultBranch(branchName string) bool {
 
 // shouldTryOriginFallback reports whether the origin/<ref> CI fallback should be
 // attempted for ref. It is skipped only when ref is already remote-qualified
-// (origin/... or remotes/...), so ordinary slashed branch names like "fix/foo"
-// still resolve in CI checkouts where the local branch ref is absent. Guards
-// against producing "origin/origin/...".
+// (origin/..., remotes/...) or fully qualified (refs/...), so ordinary slashed
+// branch names like "fix/foo" still resolve in CI checkouts where the local
+// branch ref is absent. Guards against producing bogus prefixes like
+// "origin/origin/..." or "origin/refs/remotes/...". Input is trimmed so leading
+// or trailing whitespace doesn't change the decision.
 func shouldTryOriginFallback(ref string) bool {
-	return !strings.HasPrefix(ref, "origin/") && !strings.HasPrefix(ref, "remotes/")
+	ref = strings.TrimSpace(ref)
+	return !strings.HasPrefix(ref, "origin/") &&
+		!strings.HasPrefix(ref, "remotes/") &&
+		!strings.HasPrefix(ref, "refs/")
 }
 
 // validateReference checks if a Git reference is valid and provides helpful error messages.
@@ -245,7 +250,10 @@ func validateReference(repo *git.Repository, ref string) error {
 	// contain '/' (fix/x, feature/y), so this must run for slashed refs too; it
 	// is skipped only when the ref is already remote-qualified.
 	if shouldTryOriginFallback(ref) {
-		if _, err := ResolveRevisionEnhanced(repo, "origin/"+ref); err == nil {
+		// Trim before composing: ResolveRevisionEnhanced trims its argument, but
+		// only at the ends, so a leading space would otherwise survive inside
+		// "origin/ <ref>" and break resolution.
+		if _, err := ResolveRevisionEnhanced(repo, "origin/"+strings.TrimSpace(ref)); err == nil {
 			return nil
 		}
 	}

--- a/internal/gitutil/resolution.go
+++ b/internal/gitutil/resolution.go
@@ -87,8 +87,10 @@ func ResolveRevisionEnhanced(repo *git.Repository, ref string) (*plumbing.Hash, 
 	if !found {
 		rn := NormalizeGitRefForGoGit(r)
 		hash, err := repo.ResolveRevision(plumbing.Revision(rn))
-		if err != nil && !strings.Contains(rn, "/") {
-			// Try with origin/ prefix for CI environments
+		if err != nil && shouldTryOriginFallback(rn) {
+			// Try with origin/ prefix for CI environments where the local branch
+			// ref is absent. Runs for slashed branch names (fix/x) too, skipping
+			// only already-remote-qualified refs.
 			if remoteHash, remoteErr := repo.ResolveRevision(plumbing.Revision("origin/" + rn)); remoteErr == nil {
 				return remoteHash, nil
 			}


### PR DESCRIPTION
## Summary

`validateReference` (`internal/gitutil/refs.go`) and `ResolveRevisionEnhanced` (`internal/gitutil/resolution.go`) only attempted the `origin/<ref>` fallback when the ref contained no slash (`!strings.Contains(ref, "/")`). The guard was meant to avoid double-prefixing (`origin/origin/...`), but it over-broadly excluded ordinary slashed branch names (`fix/x`, `feature/y`). In a CI checkout where the local branch ref is absent and only the remote-tracking ref exists, `deputy diff`/`scan` on such a branch fails with `invalid reference`.

This is latent on no-slash branches (e.g. #42's `cleanup-tech-debt`) and breaks the **PR Gate / Dependency Diff** step for any slashed-branch PR, since the gate runs `deputy diff main <branch>` using the binary from `actions/setup@main`.

- Replace the slash check with `shouldTryOriginFallback`, which skips the fallback only when the ref is already remote-qualified (`origin/...`, `remotes/...`), so slashed branch names still resolve while `origin/origin/...` is still avoided.
- Applied identically in both the validator and the resolver.

Surfaced by #45, whose branch `fix/repo-scan-install-artifact-handling` hit this in the gate. Merging this to `main` unblocks that PR on re-run (the gate uses main's `deputy`).

## Test plan

- [x] `go build ./...`, `go vet ./internal/gitutil/...`, `staticcheck ./internal/gitutil/...` clean
- [x] Full `go test ./internal/gitutil/...` passes
- [x] `TestShouldTryOriginFallback` — slashed names get the fallback; already-remote-qualified refs don't
- [x] `TestResolveRevisionEnhanced_SlashedBranchViaOrigin` — `fix/foo` present only as `refs/remotes/origin/fix/foo` resolves; unknown slashed ref still errors
- [x] `TestValidateReference_SlashedBranchViaOrigin` — same at the validation layer