### PR TITLE
[THROWAWAY/DO NOT MERGE] opengrep gate canary (SEC-1975)

### DIFF
--- a/.github/workflows/zz-opengrep-canary.yml
+++ b/.github/workflows/zz-opengrep-canary.yml
@@ -1,0 +1,11 @@
+name: Opengrep canary (throwaway - do not merge)
+# Throwaway workflow to exercise the opengrep/scan gate (missing-permissions
+# rule + SEC-1975 stable-identity diff). Safe: workflow_dispatch only, never
+# auto-runs. Deleted along with the throwaway PR.
+on:
+  workflow_dispatch:
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "opengrep canary"

--- a/.github/workflows/zz-opengrep-canary.yml
+++ b/.github/workflows/zz-opengrep-canary.yml
@@ -4,6 +4,8 @@ name: Opengrep canary (throwaway - do not merge)
 # auto-runs. Deleted along with the throwaway PR.
 on:
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   noop:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Throwaway PR to exercise the org-wide opengrep/scan gate end to end. **Do not merge — will be closed.**

Step 1 (this commit): adds a new workflow with **no** `permissions:` block, which should trip `security.gha.missing-explicit-permissions` as a genuinely new finding and fail `opengrep/scan`.

Step 2 (follow-up commit): adds `permissions: contents: read`, which should clear the finding and flip the check green.

Validates the differential gate plus the SEC-1975 stable-identity diff (new file, finding count 0 -> 1 -> 0). The workflow is `workflow_dispatch`-only and never auto-runs.