### PR TITLE
Pilot: claude-code-action via Workload Identity Federation

### DIFF
--- a/.github/workflows/claude-wif-action-test.yml
+++ b/.github/workflows/claude-wif-action-test.yml
@@ -1,0 +1,21 @@
+name: claude-wif-action-test
+on:
+  push:
+    branches: [claude-wif-action-test]
+  workflow_dispatch:
+permissions:
+  contents: read
+  id-token: write
+jobs:
+  claude:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Run claude-code-action via WIF
+        uses: anthropics/claude-code-action@fad22eb3fa582b7357fc0ea48af6645851b884fd # v1
+        with:
+          prompt: "Reply with a single line confirming Claude authenticated via Workload Identity Federation. Do not read, modify, or create any files, and do not open any pull requests."
+          anthropic_organization_id: 28abd3d1-8842-4f2b-b558-c5b9700e3caa
+          anthropic_service_account_id: svac_01D5VqGf1Xvw7BNtFkt1jsLT
+          anthropic_workspace_id: wrkspc_01BZ6jESnWXxTpRTs59XtnKf
+          anthropic_federation_rule_id: fdrl_01FRty5eQYMGP2xh1AK3R5rk

--- a/.github/workflows/claude-wif-action-test.yml
+++ b/.github/workflows/claude-wif-action-test.yml
@@ -18,9 +18,12 @@ jobs:
           # GitHub App token exchange (App not installed on this repo). This
           # isolates the Anthropic-side WIF auth, which is what we're validating.
           github_token: ${{ github.token }}
-          # TEMPORARY diagnostic: surface the hidden Claude turn error. Revert
-          # once we understand why the WIF-authenticated turn fails.
+          # TEMPORARY diagnostic: surface the hidden Claude turn error.
           show_full_output: true
+          # Hypothesis test: the raw pilot (#49) requested the OIDC token with
+          # audience https://api.anthropic.com and the exchange succeeded; the
+          # action with an empty audience got 401. Set it explicitly to match.
+          anthropic_oidc_audience: https://api.anthropic.com
           prompt: "Reply with a single line confirming Claude authenticated via Workload Identity Federation. Do not read, modify, or create any files, and do not open any pull requests."
           anthropic_organization_id: 28abd3d1-8842-4f2b-b558-c5b9700e3caa
           anthropic_service_account_id: svac_01D5VqGf1Xvw7BNtFkt1jsLT

--- a/.github/workflows/claude-wif-action-test.yml
+++ b/.github/workflows/claude-wif-action-test.yml
@@ -18,6 +18,9 @@ jobs:
           # GitHub App token exchange (App not installed on this repo). This
           # isolates the Anthropic-side WIF auth, which is what we're validating.
           github_token: ${{ github.token }}
+          # TEMPORARY diagnostic: surface the hidden Claude turn error. Revert
+          # once we understand why the WIF-authenticated turn fails.
+          show_full_output: true
           prompt: "Reply with a single line confirming Claude authenticated via Workload Identity Federation. Do not read, modify, or create any files, and do not open any pull requests."
           anthropic_organization_id: 28abd3d1-8842-4f2b-b558-c5b9700e3caa
           anthropic_service_account_id: svac_01D5VqGf1Xvw7BNtFkt1jsLT

--- a/.github/workflows/claude-wif-action-test.yml
+++ b/.github/workflows/claude-wif-action-test.yml
@@ -14,6 +14,10 @@ jobs:
       - name: Run claude-code-action via WIF
         uses: anthropics/claude-code-action@fad22eb3fa582b7357fc0ea48af6645851b884fd # v1
         with:
+          # Use the workflow token for GitHub ops so the action skips the Claude
+          # GitHub App token exchange (App not installed on this repo). This
+          # isolates the Anthropic-side WIF auth, which is what we're validating.
+          github_token: ${{ github.token }}
           prompt: "Reply with a single line confirming Claude authenticated via Workload Identity Federation. Do not read, modify, or create any files, and do not open any pull requests."
           anthropic_organization_id: 28abd3d1-8842-4f2b-b558-c5b9700e3caa
           anthropic_service_account_id: svac_01D5VqGf1Xvw7BNtFkt1jsLT


### PR DESCRIPTION
## Summary

Second WIF pilot on `deputy`: exercises **`anthropics/claude-code-action` itself** authenticating via Workload Identity Federation (no static `ANTHROPIC_API_KEY`), following up the raw OIDC-exchange validation in #49.

Per the action's `action.yml`, setting `anthropic_federation_rule_id` + `anthropic_organization_id` makes the action exchange the workflow's GitHub OIDC token for a short-lived Claude token internally (requires `id-token: write`) — the same handshake #49 proved by hand, now driven by the action.

A minimal `prompt:` is included so the run exercises auth **and** execution; it's instructed to make no changes and open no PRs.

The federation IDs are identifiers, not secrets (WIF has no API key in the repo). Config set up by IT.

## Security notes
- `permissions:` least-privilege: `id-token: write` (required for the OIDC exchange) + `contents: read`. No `pull-requests`/`issues` write — this is an auth+execution smoke test, not a PR-acting workflow.
- Both actions SHA-pinned: `actions/checkout@9c091bb…` (v7.0.0), `anthropics/claude-code-action@fad22eb…` (v1).
- Trigger scoped to the `claude-wif-action-test` branch + `workflow_dispatch` (won't run org-wide on merge).

## Test plan
- [ ] Confirm the run authenticates via WIF (no API key) and the prompt step completes rather than erroring on auth.
- [ ] If green alongside #49, fold WIF into the real Claude workflows across the 11-repo footprint and drop both pilots.