### PR TITLE
Adopt t.Context() throughout the test suite

### DIFF
--- a/internal/agent/registry_test.go
+++ b/internal/agent/registry_test.go
@@ -93,7 +93,7 @@ func TestRegistry(t *testing.T) {
 		}
 
 		// Verify by calling GetInfo
-		ctx := context.Background()
+		ctx := t.Context()
 		info, err := got.GetInfo(ctx, connect.NewRequest(&agentv1.GetInfoRequest{}))
 		if err != nil {
 			t.Fatalf("GetInfo failed: %v", err)
@@ -188,7 +188,7 @@ func TestAsExecutor(t *testing.T) {
 		}
 
 		// Test ExecuteIter
-		ctx := context.Background()
+		ctx := t.Context()
 		req := &agentv1.ExecuteRequest{Prompt: "test"}
 		var count int
 		for event, err := range exec.ExecuteIter(ctx, req) {
@@ -247,7 +247,7 @@ func TestGetOrDiscover(t *testing.T) {
 		handler := newMockHandler("registered")
 		_ = reg.RegisterBuiltin("registered", handler)
 
-		ctx := context.Background()
+		ctx := t.Context()
 		got, err := reg.GetOrDiscover(ctx, "registered")
 		if err != nil {
 			t.Fatalf("GetOrDiscover failed: %v", err)
@@ -259,7 +259,7 @@ func TestGetOrDiscover(t *testing.T) {
 
 	t.Run("returns error for unknown plugin not in PATH", func(t *testing.T) {
 		reg := NewRegistry()
-		ctx := context.Background()
+		ctx := t.Context()
 
 		_, err := reg.GetOrDiscover(ctx, "nonexistent-plugin-xyz")
 		if err == nil {

--- a/internal/ai/render/render_test.go
+++ b/internal/ai/render/render_test.go
@@ -2,7 +2,6 @@ package render
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -481,7 +480,7 @@ func TestStreamingRenderer_SpinnerMethods(t *testing.T) {
 		errW := &bytes.Buffer{}
 		r := NewStreamingRenderer(out, errW, "claude")
 
-		ctx := context.Background()
+		ctx := t.Context()
 		r.StartSpinner(ctx, "Loading...")
 
 		// Should not create a spinner for non-TTY

--- a/internal/ai/session_test.go
+++ b/internal/ai/session_test.go
@@ -63,7 +63,7 @@ func TestSession_Send(t *testing.T) {
 
 	session := NewSession(SessionConfig{Provider: provider})
 
-	resp, err := session.Send(context.Background(), "Say hello")
+	resp, err := session.Send(t.Context(), "Say hello")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestSession_Stream(t *testing.T) {
 	session := NewSession(SessionConfig{Provider: provider})
 
 	var parts []string
-	for event, err := range session.Stream(context.Background(), "Test prompt") {
+	for event, err := range session.Stream(t.Context(), "Test prompt") {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -123,7 +123,7 @@ func TestSession_Run(t *testing.T) {
 		}
 
 		session := NewSession(SessionConfig{Provider: provider})
-		result, err := session.Run(context.Background(), "Run task")
+		result, err := session.Run(t.Context(), "Run task")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -150,7 +150,7 @@ func TestSession_Run(t *testing.T) {
 		}
 
 		session := NewSession(SessionConfig{Provider: provider})
-		result, err := session.Run(context.Background(), "Fail task")
+		result, err := session.Run(t.Context(), "Fail task")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -190,7 +190,7 @@ func TestSession_Hooks(t *testing.T) {
 		})
 
 		var errorEvents []ErrorEvent
-		for event, _ := range session.Stream(context.Background(), "Run echo") {
+		for event, _ := range session.Stream(t.Context(), "Run echo") {
 			if ee, ok := event.(ErrorEvent); ok {
 				errorEvents = append(errorEvents, ee)
 			}
@@ -228,7 +228,7 @@ func TestSession_Hooks(t *testing.T) {
 			},
 		})
 
-		for range session.Stream(context.Background(), "Modify file") {
+		for range session.Stream(t.Context(), "Modify file") {
 			// Just iterate
 		}
 
@@ -256,7 +256,7 @@ func TestSession_Hooks(t *testing.T) {
 			},
 		})
 
-		_, _ = session.Run(context.Background(), "Test")
+		_, _ = session.Run(t.Context(), "Test")
 
 		if len(messages) != 2 {
 			t.Errorf("expected 2 messages, got %d", len(messages))
@@ -278,7 +278,7 @@ func TestApprovalPolicy(t *testing.T) {
 		session := NewSession(SessionConfig{Provider: provider})
 
 		var errorEvents []ErrorEvent
-		for event, _ := range session.Stream(context.Background(), "List files") {
+		for event, _ := range session.Stream(t.Context(), "List files") {
 			if ee, ok := event.(ErrorEvent); ok {
 				errorEvents = append(errorEvents, ee)
 			}
@@ -307,7 +307,7 @@ func TestApprovalPolicy(t *testing.T) {
 		})
 
 		var commandEvents []CommandEvent
-		for event, _ := range session.Stream(context.Background(), "List files") {
+		for event, _ := range session.Stream(t.Context(), "List files") {
 			if ce, ok := event.(CommandEvent); ok {
 				commandEvents = append(commandEvents, ce)
 			}
@@ -340,7 +340,7 @@ func TestApprovalPolicy(t *testing.T) {
 			},
 		})
 
-		for range session.Stream(context.Background(), "List files") {
+		for range session.Stream(t.Context(), "List files") {
 		}
 
 		if !approved {
@@ -369,7 +369,7 @@ func TestApprovalPolicy(t *testing.T) {
 		})
 
 		var errorEvents []ErrorEvent
-		for event, _ := range session.Stream(context.Background(), "List files") {
+		for event, _ := range session.Stream(t.Context(), "List files") {
 			if ee, ok := event.(ErrorEvent); ok {
 				errorEvents = append(errorEvents, ee)
 			}
@@ -397,7 +397,7 @@ func TestApprovalPolicy(t *testing.T) {
 		})
 
 		var errorEvents []ErrorEvent
-		for event, _ := range session.Stream(context.Background(), "List files") {
+		for event, _ := range session.Stream(t.Context(), "List files") {
 			if ee, ok := event.(ErrorEvent); ok {
 				errorEvents = append(errorEvents, ee)
 			}
@@ -500,7 +500,7 @@ func TestHighRiskDetection(t *testing.T) {
 		})
 
 		var errorEvents []ErrorEvent
-		for event, _ := range session.Stream(context.Background(), "Delete tmp") {
+		for event, _ := range session.Stream(t.Context(), "Delete tmp") {
 			if ee, ok := event.(ErrorEvent); ok {
 				errorEvents = append(errorEvents, ee)
 			}
@@ -531,7 +531,7 @@ func TestStreamToWriter(t *testing.T) {
 	out := &bytes.Buffer{}
 	errOut := &bytes.Buffer{}
 
-	result, err := StreamToWriter(context.Background(), session, "Test", out, errOut)
+	result, err := StreamToWriter(t.Context(), session, "Test", out, errOut)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/analysis/advisorysource/advisorysource_test.go
+++ b/internal/analysis/advisorysource/advisorysource_test.go
@@ -62,7 +62,7 @@ func TestRegistryRoutesAndReportsCoverage(t *testing.T) {
 	reg := NewRegistry(src)
 
 	dockerPkg := &dependencyv1.Package{Name: "alpine", Version: "3.19", Ecosystem: "docker", Purl: "pkg:docker/library/alpine@3.19"}
-	got, err := reg.Query(context.Background(), []*dependencyv1.Package{goPkg("github.com/foo/bar", "1.0.0"), dockerPkg})
+	got, err := reg.Query(t.Context(), []*dependencyv1.Package{goPkg("github.com/foo/bar", "1.0.0"), dockerPkg})
 	if err != nil {
 		t.Fatalf("Query error = %v, want nil (uncovered package must not fail the scan)", err)
 	}
@@ -92,7 +92,7 @@ func TestRegistryUnionWithProvenance(t *testing.T) {
 	}
 	reg := NewRegistry(a, b)
 
-	got, err := reg.Query(context.Background(), []*dependencyv1.Package{goPkg("github.com/foo/bar", "1.0.0")})
+	got, err := reg.Query(t.Context(), []*dependencyv1.Package{goPkg("github.com/foo/bar", "1.0.0")})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/analysis/advisorysource/plugin_test.go
+++ b/internal/analysis/advisorysource/plugin_test.go
@@ -48,7 +48,7 @@ func TestPluginSourceQueryIsProtoOneToOne(t *testing.T) {
 	}
 
 	pkgs := []*dependencyv1.Package{{Name: "lodash", Version: "4.17.20", Ecosystem: "npm", Purl: "pkg:npm/lodash@4.17.20", Direct: true}}
-	res, err := src.Query(context.Background(), pkgs)
+	res, err := src.Query(t.Context(), pkgs)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/analysis/osv/aws_integration_test.go
+++ b/internal/analysis/osv/aws_integration_test.go
@@ -1,7 +1,6 @@
 package osv
 
 import (
-	"context"
 	"slices"
 	"testing"
 
@@ -12,7 +11,7 @@ import (
 // TestAWSV1Integration ensures real OSV data marks fixed versions correctly.
 func TestAWSV1Integration(t *testing.T) {
 	t.Skip("network access required")
-	ctx := context.Background()
+	ctx := t.Context()
 	client := osvdev.DefaultClient()
 	vulns, err := QueryRaw(ctx, client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/aws/aws-sdk-go", Version: "1.55.6", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
 	if err != nil {

--- a/internal/analysis/osv/gha_bucket_test.go
+++ b/internal/analysis/osv/gha_bucket_test.go
@@ -328,7 +328,7 @@ func TestResolveGitHubActionsVersion_Table(t *testing.T) {
 				}
 				return tc.refsWithHashes, nil
 			}
-			got := resolveGitHubActionsVersion(context.Background(), &sync.Map{}, tc.repo, tc.version)
+			got := resolveGitHubActionsVersion(t.Context(), &sync.Map{}, tc.repo, tc.version)
 			if got != tc.want {
 				t.Fatalf("resolveGitHubActionsVersion(%q,%q)=%q want %q", tc.repo, tc.version, got, tc.want)
 			}
@@ -392,7 +392,7 @@ func TestQueryOSVGHABucketBatch_MajorTagResolutionAvoidsFalsePositive(t *testing
 	}
 	t.Cleanup(func() { ghaListRemoteRefs = origList })
 
-	got, err := queryOSVGHABucketBatch(context.Background(), nil, []PkgInput{
+	got, err := queryOSVGHABucketBatch(t.Context(), nil, []PkgInput{
 		{QueryKey: QueryKey{Name: "actions/download-artifact", Version: "v4", Ecosystem: "GitHub Actions"}},
 	})
 	if err != nil {
@@ -449,7 +449,7 @@ func TestQueryOSVGHABucketBatch_UnresolvedFloatingTagDoesNotDefaultToAffected(t 
 	}
 	t.Cleanup(func() { ghaListRemoteRefs = origList })
 
-	got, err := queryOSVGHABucketBatch(context.Background(), nil, []PkgInput{
+	got, err := queryOSVGHABucketBatch(t.Context(), nil, []PkgInput{
 		{QueryKey: QueryKey{Name: "actions/download-artifact", Version: "v4.1", Ecosystem: "GitHub Actions"}},
 	})
 	if err != nil {
@@ -507,7 +507,7 @@ func TestQueryOSVGHABucketBatch_MajorTagResolutionReportsEffectiveVersion(t *tes
 	}
 	t.Cleanup(func() { ghaListRemoteRefs = origList })
 
-	got, err := queryOSVGHABucketBatch(context.Background(), nil, []PkgInput{
+	got, err := queryOSVGHABucketBatch(t.Context(), nil, []PkgInput{
 		{QueryKey: QueryKey{Name: "actions/download-artifact", Version: "v4", Ecosystem: "GitHub Actions"}},
 	})
 	if err != nil {
@@ -572,7 +572,7 @@ func TestQueryOSVGHABucketBatch_SHAResolutionAvoidsFalsePositive(t *testing.T) {
 	}
 	t.Cleanup(func() { ghaListRemoteRefsWithHashes = origListWithHashes })
 
-	got, err := queryOSVGHABucketBatch(context.Background(), nil, []PkgInput{
+	got, err := queryOSVGHABucketBatch(t.Context(), nil, []PkgInput{
 		{QueryKey: QueryKey{Name: "anthropics/claude-code-action", Version: sha, Ecosystem: "GitHub Actions"}},
 	})
 	if err != nil {
@@ -630,7 +630,7 @@ func TestQueryRaw_GitHubActionsPURLOnlySHAResolutionAvoidsFalsePositive(t *testi
 	}
 	t.Cleanup(func() { ghaListRemoteRefsWithHashes = origListWithHashes })
 
-	got, err := QueryRaw(context.Background(), nil, []PkgInput{
+	got, err := QueryRaw(t.Context(), nil, []PkgInput{
 		{QueryKey: QueryKey{PURL: "pkg:githubactions/anthropics/claude-code-action@" + sha + "#sub/action.yml"}},
 	})
 	if err != nil {
@@ -687,7 +687,7 @@ func TestQueryOSVGHABucketBatch_SHAResolutionReportsEffectiveVersion(t *testing.
 	}
 	t.Cleanup(func() { ghaListRemoteRefsWithHashes = origListWithHashes })
 
-	got, err := queryOSVGHABucketBatch(context.Background(), nil, []PkgInput{
+	got, err := queryOSVGHABucketBatch(t.Context(), nil, []PkgInput{
 		{QueryKey: QueryKey{Name: "owner/repo", Version: sha, Ecosystem: "GitHub Actions"}},
 	})
 	if err != nil {
@@ -746,7 +746,7 @@ func TestQueryOSVGHABucketBatch_UnresolvedSHADoesNotDefaultToAffected(t *testing
 	}
 	t.Cleanup(func() { ghaListRemoteRefsWithHashes = origListWithHashes })
 
-	got, err := queryOSVGHABucketBatch(context.Background(), nil, []PkgInput{
+	got, err := queryOSVGHABucketBatch(t.Context(), nil, []PkgInput{
 		{QueryKey: QueryKey{Name: "owner/repo", Version: "1111111111111111111111111111111111111111", Ecosystem: "GitHub Actions"}},
 	})
 	if err != nil {
@@ -791,7 +791,7 @@ func TestBuildGHAVulnIndex_UsesCacheZip(t *testing.T) {
 	now := time.Now()
 	_ = os.Chtimes(zipPath, now, now)
 
-	idx, err := buildGHAVulnIndex(context.Background())
+	idx, err := buildGHAVulnIndex(t.Context())
 	if err != nil {
 		t.Fatalf("buildGHAVulnIndex: %v", err)
 	}
@@ -856,7 +856,7 @@ func TestEnsureGHACacheZip_UsesETagConditionalRequest(t *testing.T) {
 		ghaDownloadTTL = origTTL
 	})
 
-	p1, err := ensureGHACacheZip(context.Background())
+	p1, err := ensureGHACacheZip(t.Context())
 	if err != nil {
 		t.Fatalf("ensureGHACacheZip (first): %v", err)
 	}
@@ -868,7 +868,7 @@ func TestEnsureGHACacheZip_UsesETagConditionalRequest(t *testing.T) {
 	}
 
 	// Second call should send If-None-Match and receive 304.
-	p2, err := ensureGHACacheZip(context.Background())
+	p2, err := ensureGHACacheZip(t.Context())
 	if err != nil {
 		t.Fatalf("ensureGHACacheZip (second): %v", err)
 	}
@@ -994,7 +994,7 @@ func TestLoadGHAVulnIndex_RefreshesAfterTTL(t *testing.T) {
 	ghaDownloadTTL = 0
 
 	ghaIndexTTL = time.Hour
-	idx1, err := loadGHAVulnIndex(context.Background())
+	idx1, err := loadGHAVulnIndex(t.Context())
 	if err != nil {
 		t.Fatalf("loadGHAVulnIndex (v1): %v", err)
 	}
@@ -1006,7 +1006,7 @@ func TestLoadGHAVulnIndex_RefreshesAfterTTL(t *testing.T) {
 	body = zipV2
 	etag = `W/"v2"`
 
-	idx2, err := loadGHAVulnIndex(context.Background())
+	idx2, err := loadGHAVulnIndex(t.Context())
 	if err != nil {
 		t.Fatalf("loadGHAVulnIndex (still cached): %v", err)
 	}
@@ -1019,7 +1019,7 @@ func TestLoadGHAVulnIndex_RefreshesAfterTTL(t *testing.T) {
 
 	// Force refresh and confirm new content appears.
 	ghaIndexTTL = 0
-	idx3, err := loadGHAVulnIndex(context.Background())
+	idx3, err := loadGHAVulnIndex(t.Context())
 	if err != nil {
 		t.Fatalf("loadGHAVulnIndex (refresh): %v", err)
 	}

--- a/internal/analysis/osv/gha_malicious_test.go
+++ b/internal/analysis/osv/gha_malicious_test.go
@@ -68,7 +68,7 @@ func TestGitHubActionsMALDetection(t *testing.T) {
 	now := time.Now()
 	_ = os.Chtimes(zipPath, now, now)
 
-	got, err := queryOSVGHABucketBatch(context.Background(), nil, []PkgInput{
+	got, err := queryOSVGHABucketBatch(t.Context(), nil, []PkgInput{
 		{QueryKey: QueryKey{Name: "malicious-actor/evil-action", Version: "1.0.0", Ecosystem: "GitHub Actions"}},
 	})
 	if err != nil {
@@ -140,7 +140,7 @@ func TestGitHubActionsMALMultipleVersions(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.version, func(t *testing.T) {
-			got, err := queryOSVGHABucketBatch(context.Background(), nil, []PkgInput{
+			got, err := queryOSVGHABucketBatch(t.Context(), nil, []PkgInput{
 				{QueryKey: QueryKey{Name: "crypto-miner/hidden-action", Version: tc.version, Ecosystem: "GitHub Actions"}},
 			})
 			if err != nil {
@@ -193,7 +193,7 @@ func TestGitHubActionsTyposquattingDetection(t *testing.T) {
 	_ = os.Chtimes(zipPath, now, now)
 
 	// Test the malicious typosquat is detected
-	got, err := queryOSVGHABucketBatch(context.Background(), nil, []PkgInput{
+	got, err := queryOSVGHABucketBatch(t.Context(), nil, []PkgInput{
 		{QueryKey: QueryKey{Name: "action/checkout", Version: "v4", Ecosystem: "GitHub Actions"}},
 	})
 	if err != nil {
@@ -204,7 +204,7 @@ func TestGitHubActionsTyposquattingDetection(t *testing.T) {
 	}
 
 	// The legitimate action should not match
-	got2, err := queryOSVGHABucketBatch(context.Background(), nil, []PkgInput{
+	got2, err := queryOSVGHABucketBatch(t.Context(), nil, []PkgInput{
 		{QueryKey: QueryKey{Name: "actions/checkout", Version: "v4", Ecosystem: "GitHub Actions"}},
 	})
 	if err != nil {
@@ -285,7 +285,7 @@ func TestGitHubActionsSHAPinnedVersions(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := queryOSVGHABucketBatch(context.Background(), nil, []PkgInput{
+			got, err := queryOSVGHABucketBatch(t.Context(), nil, []PkgInput{
 				{QueryKey: QueryKey{Name: "owner/vulnerable-action", Version: tc.version, Ecosystem: "GitHub Actions"}},
 			})
 			if err != nil {
@@ -362,7 +362,7 @@ func TestGitHubActionsMultipleVulnerabilities(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.version, func(t *testing.T) {
-			got, err := queryOSVGHABucketBatch(context.Background(), nil, []PkgInput{
+			got, err := queryOSVGHABucketBatch(t.Context(), nil, []PkgInput{
 				{QueryKey: QueryKey{Name: "owner/multi-vuln-action", Version: tc.version, Ecosystem: "GitHub Actions"}},
 			})
 			if err != nil {
@@ -420,7 +420,7 @@ func TestGitHubActionsReusableWorkflowDetection(t *testing.T) {
 	_ = os.Chtimes(zipPath, now, now)
 
 	// The workflow name includes subpath but OSV matches on owner/repo
-	got, err := queryOSVGHABucketBatch(context.Background(), nil, []PkgInput{
+	got, err := queryOSVGHABucketBatch(t.Context(), nil, []PkgInput{
 		{QueryKey: QueryKey{Name: "org/shared-workflows", Version: "1.5.0", Ecosystem: "GitHub Actions"}},
 	})
 	if err != nil {
@@ -475,7 +475,7 @@ func TestGitHubActionsCaseInsensitiveMatching(t *testing.T) {
 
 	for _, name := range cases {
 		t.Run(name, func(t *testing.T) {
-			got, err := queryOSVGHABucketBatch(context.Background(), nil, []PkgInput{
+			got, err := queryOSVGHABucketBatch(t.Context(), nil, []PkgInput{
 				{QueryKey: QueryKey{Name: name, Version: "1.0.0", Ecosystem: "GitHub Actions"}},
 			})
 			if err != nil {
@@ -545,7 +545,7 @@ func TestGitHubActionsGHSAIDFormats(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := queryOSVGHABucketBatch(context.Background(), nil, []PkgInput{
+			got, err := queryOSVGHABucketBatch(t.Context(), nil, []PkgInput{
 				{QueryKey: QueryKey{Name: tc.action, Version: "1.0.0", Ecosystem: "GitHub Actions"}},
 			})
 			if err != nil {
@@ -618,7 +618,7 @@ func TestGitHubActionsKnownVulnerableVersions(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.version, func(t *testing.T) {
-			got, err := queryOSVGHABucketBatch(context.Background(), nil, []PkgInput{
+			got, err := queryOSVGHABucketBatch(t.Context(), nil, []PkgInput{
 				{QueryKey: QueryKey{Name: "actions/download-artifact", Version: tc.version, Ecosystem: "GitHub Actions"}},
 			})
 			if err != nil {
@@ -739,7 +739,7 @@ func TestGitHubActionsWithZipRefresh(t *testing.T) {
 	ghaIndexTTL = time.Hour
 
 	// First query should see v1 only
-	idx1, err := loadGHAVulnIndex(context.Background())
+	idx1, err := loadGHAVulnIndex(t.Context())
 	if err != nil {
 		t.Fatalf("loadGHAVulnIndex v1: %v", err)
 	}
@@ -758,7 +758,7 @@ func TestGitHubActionsWithZipRefresh(t *testing.T) {
 
 	// Force index refresh
 	ghaIndexTTL = 0
-	idx2, err := loadGHAVulnIndex(context.Background())
+	idx2, err := loadGHAVulnIndex(t.Context())
 	if err != nil {
 		t.Fatalf("loadGHAVulnIndex v2: %v", err)
 	}
@@ -825,7 +825,7 @@ func TestGitHubActionsIntroducedZeroOpenEnded(t *testing.T) {
 	versions := []string{"0.0.1", "1.0.0", "2.5.3", "10.0.0", "v1", "v2", "v99"}
 	for _, ver := range versions {
 		t.Run(ver, func(t *testing.T) {
-			got, err := queryOSVGHABucketBatch(context.Background(), nil, []PkgInput{
+			got, err := queryOSVGHABucketBatch(t.Context(), nil, []PkgInput{
 				{QueryKey: QueryKey{Name: "malicious/package", Version: ver, Ecosystem: "GitHub Actions"}},
 			})
 			if err != nil {

--- a/internal/analysis/osv/osv_test.go
+++ b/internal/analysis/osv/osv_test.go
@@ -110,7 +110,7 @@ func TestQueryRaw_SkipsOSVUnsupportedEcosystems(t *testing.T) {
 func Test_QueryRaw_ok(t *testing.T) {
 	resetDiskCache(t)
 	client := &fakeClient{}
-	vulns, err := QueryRaw(context.Background(), client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/example/pkg", Version: "1.2.3", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
+	vulns, err := QueryRaw(t.Context(), client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/example/pkg", Version: "1.2.3", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -184,7 +184,7 @@ func (f *fakeClientQueryErr) GetVulnByID(ctx context.Context, id string) (*osvsc
 func Test_QueryRaw_query_error(t *testing.T) {
 	resetDiskCache(t)
 	client := &fakeClientQueryErr{}
-	_, err := QueryRaw(context.Background(), client, []PkgInput{{QueryKey: QueryKey{Name: "n", Version: "1", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
+	_, err := QueryRaw(t.Context(), client, []PkgInput{{QueryKey: QueryKey{Name: "n", Version: "1", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
 	if err == nil {
 		t.Fatalf("expected error")
 	}
@@ -202,7 +202,7 @@ func (f *fakeClientGetErr) GetVulnByID(ctx context.Context, id string) (*osvsche
 func Test_QueryRaw_getvuln_error(t *testing.T) {
 	resetDiskCache(t)
 	client := &fakeClientGetErr{}
-	_, err := QueryRaw(context.Background(), client, []PkgInput{{QueryKey: QueryKey{Name: "n", Version: "1", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
+	_, err := QueryRaw(t.Context(), client, []PkgInput{{QueryKey: QueryKey{Name: "n", Version: "1", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
 	if err == nil {
 		t.Fatalf("expected error when GetVulnByID fails")
 	}
@@ -230,7 +230,7 @@ func (f *fakeClientFixed) GetVulnByID(ctx context.Context, id string) (*osvschem
 func Test_QueryRaw_skips_fixed_version(t *testing.T) {
 	resetDiskCache(t)
 	client := &fakeClientFixed{}
-	vulns, err := QueryRaw(context.Background(), client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/example/pkg", Version: "1.55.6", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
+	vulns, err := QueryRaw(t.Context(), client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/example/pkg", Version: "1.55.6", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -273,7 +273,7 @@ func (f *fakeClientAWS) GetVulnByID(ctx context.Context, id string) (*osvschema.
 func Test_QueryRaw_awssdkv1(t *testing.T) {
 	resetDiskCache(t)
 	client := &fakeClientAWS{}
-	vulns, err := QueryRaw(context.Background(), client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/aws/aws-sdk-go", Version: "1.55.6", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
+	vulns, err := QueryRaw(t.Context(), client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/aws/aws-sdk-go", Version: "1.55.6", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -281,7 +281,7 @@ func Test_QueryRaw_awssdkv1(t *testing.T) {
 		t.Fatalf("expected no vulns for fixed version, got %d", len(vulns))
 	}
 
-	vulns, err = QueryRaw(context.Background(), client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/aws/aws-sdk-go", Version: "1.33.0", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
+	vulns, err = QueryRaw(t.Context(), client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/aws/aws-sdk-go", Version: "1.33.0", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -332,7 +332,7 @@ func (f *fakeClientAlias) GetVulnByID(ctx context.Context, id string) (*osvschem
 func Test_QueryRaw_aliasWithoutRange(t *testing.T) {
 	resetDiskCache(t)
 	client := &fakeClientAlias{}
-	vulns, err := QueryRaw(context.Background(), client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/example/pkg", Version: "1.2.3", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
+	vulns, err := QueryRaw(t.Context(), client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/example/pkg", Version: "1.2.3", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -375,7 +375,7 @@ func (f *fakeClientAliasUnmatchedPackage) GetVulnByID(ctx context.Context, id st
 func Test_QueryRaw_ignoresAliasWithoutPackageIdentity(t *testing.T) {
 	resetDiskCache(t)
 	client := &fakeClientAliasUnmatchedPackage{}
-	vulns, err := QueryRaw(context.Background(), client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/example/pkg", Version: "1.2.3", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
+	vulns, err := QueryRaw(t.Context(), client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/example/pkg", Version: "1.2.3", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -408,10 +408,10 @@ func Test_QueryRaw_cache(t *testing.T) {
 	resetDiskCache(t)
 	client := &countingClient{}
 	pkgs := []PkgInput{{QueryKey: QueryKey{Name: "github.com/example/pkg", Version: "1.0.0", Ecosystem: "Go"}}}
-	if _, err := QueryRaw(context.Background(), client, pkgs); err != nil {
+	if _, err := QueryRaw(t.Context(), client, pkgs); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if _, err := QueryRaw(context.Background(), client, pkgs); err != nil {
+	if _, err := QueryRaw(t.Context(), client, pkgs); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if client.calls != 1 {

--- a/internal/auth/adapters_test.go
+++ b/internal/auth/adapters_test.go
@@ -14,7 +14,7 @@ func TestTokenSource(t *testing.T) {
 		&TokenCredential{Token: "gh_token", AllowedHosts: []string{"api.github.com"}},
 	)
 	store := NewStore(WithProvider(provider))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("returns token source for valid host", func(t *testing.T) {
 		ts, err := store.TokenSource(ctx, "api.github.com")
@@ -57,7 +57,7 @@ func TestTokenSourceWithBasicCredential(t *testing.T) {
 		},
 	)
 	store := NewStore(WithProvider(provider))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ts, err := store.TokenSource(ctx, "custom.registry.io")
 	if err != nil {
@@ -104,7 +104,7 @@ func TestTokenSourceExpiredNonRefreshable(t *testing.T) {
 		&TokenCredential{Token: "old", AllowedHosts: []string{"api.github.com"}, Expiry: &past},
 	)
 	store := NewStore(WithProvider(provider))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ts, err := store.TokenSource(ctx, "api.github.com")
 	if err != nil {
@@ -130,7 +130,7 @@ func TestTokenSourceExpiredRefreshable(t *testing.T) {
 	}
 	provider := NewStaticProvider(ref)
 	store := NewStore(WithProvider(provider))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ts, err := store.TokenSource(ctx, "api.github.com")
 	if err != nil {
@@ -161,7 +161,7 @@ func TestTokenSourceRejectsSSHCredential(t *testing.T) {
 		},
 	)
 	store := NewStore(WithProvider(provider))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	ts, err := store.TokenSource(ctx, "github.com")
 	if err != nil {

--- a/internal/auth/env_provider_test.go
+++ b/internal/auth/env_provider_test.go
@@ -1,7 +1,6 @@
 package auth
 
 import (
-	"context"
 	"testing"
 )
 
@@ -13,7 +12,7 @@ func TestEnvProvider_GitHub(t *testing.T) {
 		getenv: func(key string) string { return env[key] },
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	scope := Scope{Host: "github.com", Hint: "git"}
 
 	cred, err := p.Lookup(ctx, scope)
@@ -54,7 +53,7 @@ func TestEnvProvider_GitLab(t *testing.T) {
 		getenv: func(key string) string { return env[key] },
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	scope := Scope{Host: "gitlab.com", Hint: "git"}
 
 	cred, err := p.Lookup(ctx, scope)
@@ -82,7 +81,7 @@ func TestEnvProvider_Anthropic(t *testing.T) {
 		getenv: func(key string) string { return env[key] },
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	scope := Scope{Host: "api.anthropic.com", Hint: "llm"}
 
 	cred, err := p.Lookup(ctx, scope)
@@ -117,7 +116,7 @@ func TestEnvProvider_NoToken(t *testing.T) {
 		getenv: func(key string) string { return "" },
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	scope := Scope{Host: "github.com", Hint: "git"}
 
 	cred, err := p.Lookup(ctx, scope)
@@ -138,7 +137,7 @@ func TestEnvProvider_Prefix(t *testing.T) {
 		getenv: func(key string) string { return env[key] },
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	scope := Scope{Host: "github.com", Hint: "git"}
 
 	cred, err := p.Lookup(ctx, scope)
@@ -159,7 +158,7 @@ func TestEnvProvider_GitHubEnterprise(t *testing.T) {
 		getenv: func(key string) string { return env[key] },
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	scope := Scope{Host: "github.mycompany.com", Hint: "git"}
 
 	cred, err := p.Lookup(ctx, scope)
@@ -190,7 +189,7 @@ func TestEnvProvider_NPM(t *testing.T) {
 		getenv: func(key string) string { return env[key] },
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	scope := Scope{Host: "registry.npmjs.org", Hint: "registry"}
 
 	cred, err := p.Lookup(ctx, scope)
@@ -211,7 +210,7 @@ func TestEnvProvider_DockerHub(t *testing.T) {
 		getenv: func(key string) string { return env[key] },
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	scope := Scope{Host: "index.docker.io", Hint: "container"}
 
 	cred, err := p.Lookup(ctx, scope)
@@ -239,7 +238,7 @@ func TestEnvProvider_GHCR(t *testing.T) {
 		getenv: func(key string) string { return env[key] },
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	scope := Scope{Host: "ghcr.io", Hint: "container"}
 
 	cred, err := p.Lookup(ctx, scope)
@@ -261,7 +260,7 @@ func TestEnvProvider_GHCR(t *testing.T) {
 
 func TestEnvProvider_InvalidScope(t *testing.T) {
 	p := NewEnvProvider()
-	ctx := context.Background()
+	ctx := t.Context()
 	scope := Scope{} // missing Host
 
 	_, err := p.Lookup(ctx, scope)
@@ -279,7 +278,7 @@ func TestEnvProvider_GHToken(t *testing.T) {
 		getenv: func(key string) string { return env[key] },
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	scope := Scope{Host: "github.com", Hint: "git"}
 
 	cred, err := p.Lookup(ctx, scope)
@@ -309,7 +308,7 @@ func TestEnvProvider_GitHubTokenPrecedence(t *testing.T) {
 		getenv: func(key string) string { return env[key] },
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	scope := Scope{Host: "github.com", Hint: "git"}
 
 	cred, err := p.Lookup(ctx, scope)

--- a/internal/auth/integration_test.go
+++ b/internal/auth/integration_test.go
@@ -1,7 +1,6 @@
 package auth_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -20,7 +19,7 @@ func TestIntegration_ConfusedDeputyPrevention(t *testing.T) {
 	}
 
 	store := auth.NewStore(auth.WithProvider(auth.NewStaticProvider(githubCred)))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tests := []struct {
 		name     string
@@ -108,7 +107,7 @@ func TestIntegration_ServiceIsolation(t *testing.T) {
 	)
 
 	store := auth.NewStore(auth.WithProvider(chain))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Anthropic API key should only go to api.anthropic.com
 	t.Run("anthropic key isolation", func(t *testing.T) {
@@ -160,7 +159,7 @@ func TestIntegration_HTTPSRequirement(t *testing.T) {
 	}
 
 	store := auth.NewStore(auth.WithProvider(auth.NewStaticProvider(cred)))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("HTTPS gets credentials", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "https://api.example.com/data", nil)
@@ -195,7 +194,7 @@ func TestIntegration_WildcardHostMatching(t *testing.T) {
 	}
 
 	store := auth.NewStore(auth.WithProvider(auth.NewStaticProvider(cred)))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tests := []struct {
 		host     string

--- a/internal/auth/jwt/authn_test.go
+++ b/internal/auth/jwt/authn_test.go
@@ -35,7 +35,7 @@ func TestAuthnFunc_Required_WithValidToken(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("Authorization", "Bearer valid-token")
 
-	info, err := authFunc(context.Background(), req)
+	info, err := authFunc(t.Context(), req)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -57,7 +57,7 @@ func TestAuthnFunc_Required_NoToken(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 
-	_, err := authFunc(context.Background(), req)
+	_, err := authFunc(t.Context(), req)
 	if err == nil {
 		t.Fatal("expected error for missing token in required mode")
 	}
@@ -73,7 +73,7 @@ func TestAuthnFunc_Optional_NoToken(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 
-	info, err := authFunc(context.Background(), req)
+	info, err := authFunc(t.Context(), req)
 	if err != nil {
 		t.Fatalf("expected no error in optional mode, got %v", err)
 	}
@@ -93,7 +93,7 @@ func TestAuthnFunc_Disabled(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 
-	info, err := authFunc(context.Background(), req)
+	info, err := authFunc(t.Context(), req)
 	if err != nil {
 		t.Fatalf("expected no error in disabled mode, got %v", err)
 	}
@@ -109,7 +109,7 @@ func TestAuthnFunc_NilAuthenticator(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 
-	info, err := authFunc(context.Background(), req)
+	info, err := authFunc(t.Context(), req)
 	if err != nil {
 		t.Fatalf("expected no error with nil authenticator, got %v", err)
 	}
@@ -130,7 +130,7 @@ func TestAuthnFunc_AuthError(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("Authorization", "Bearer expired-token")
 
-	_, err := authFunc(context.Background(), req)
+	_, err := authFunc(t.Context(), req)
 	if err == nil {
 		t.Fatal("expected error for expired token")
 	}
@@ -148,7 +148,7 @@ func TestClaimsFromAuthn(t *testing.T) {
 	}
 
 	// Set up context with authn info
-	ctx := authn.SetInfo(context.Background(), claims)
+	ctx := authn.SetInfo(t.Context(), claims)
 
 	// Retrieve claims using our helper
 	result := jwt.ClaimsFromAuthn(ctx)
@@ -162,7 +162,7 @@ func TestClaimsFromAuthn(t *testing.T) {
 }
 
 func TestClaimsFromAuthn_NoInfo(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	result := jwt.ClaimsFromAuthn(ctx)
 	if result != nil {
@@ -172,7 +172,7 @@ func TestClaimsFromAuthn_NoInfo(t *testing.T) {
 
 func TestClaimsFromAuthn_WrongType(t *testing.T) {
 	// Set up context with non-Claims info
-	ctx := authn.SetInfo(context.Background(), "not-claims")
+	ctx := authn.SetInfo(t.Context(), "not-claims")
 
 	result := jwt.ClaimsFromAuthn(ctx)
 	if result != nil {
@@ -188,17 +188,17 @@ func TestIsAnonymousAuthn(t *testing.T) {
 	}{
 		{
 			name:     "no info",
-			ctx:      context.Background(),
+			ctx:      t.Context(),
 			expected: true,
 		},
 		{
 			name:     "with claims",
-			ctx:      authn.SetInfo(context.Background(), &jwt.Claims{Subject: "user:alice"}),
+			ctx:      authn.SetInfo(t.Context(), &jwt.Claims{Subject: "user:alice"}),
 			expected: false,
 		},
 		{
 			name:     "with nil info explicitly set",
-			ctx:      authn.SetInfo(context.Background(), nil),
+			ctx:      authn.SetInfo(t.Context(), nil),
 			expected: true, // nil is treated as anonymous
 		},
 	}

--- a/internal/auth/jwt/jwks_test.go
+++ b/internal/auth/jwt/jwks_test.go
@@ -1,7 +1,6 @@
 package jwt
 
 import (
-	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -58,7 +57,7 @@ func TestJWKSCache_BasicFetch(t *testing.T) {
 	defer cache.Close()
 
 	// Get key from cache
-	key, err := cache.GetKey(context.Background(), "test-key-1")
+	key, err := cache.GetKey(t.Context(), "test-key-1")
 	if err != nil {
 		t.Fatalf("failed to get key: %v", err)
 	}
@@ -106,7 +105,7 @@ func TestJWKSCache_RSAKey(t *testing.T) {
 	}
 	defer cache.Close()
 
-	key, err := cache.GetKey(context.Background(), "rsa-key-1")
+	key, err := cache.GetKey(t.Context(), "rsa-key-1")
 	if err != nil {
 		t.Fatalf("failed to get key: %v", err)
 	}
@@ -138,7 +137,7 @@ func TestJWKSCache_KeyNotFound(t *testing.T) {
 	defer cache.Close()
 
 	// Try to get a non-existent key
-	_, err = cache.GetKey(context.Background(), "non-existent-key")
+	_, err = cache.GetKey(t.Context(), "non-existent-key")
 	if err == nil {
 		t.Error("expected error for non-existent key")
 	}
@@ -209,7 +208,7 @@ func TestJWKSCache_ConcurrentAccess(t *testing.T) {
 
 	for range 100 {
 		wg.Go(func() {
-			_, err := cache.GetKey(context.Background(), "concurrent-key")
+			_, err := cache.GetKey(t.Context(), "concurrent-key")
 			if err != nil {
 				errors <- err
 			}
@@ -259,7 +258,7 @@ func TestJWKSCache_OIDCDiscovery(t *testing.T) {
 	defer cache.Close()
 
 	// Should be able to get key
-	_, err = cache.GetKey(context.Background(), "oidc-key")
+	_, err = cache.GetKey(t.Context(), "oidc-key")
 	if err != nil {
 		t.Errorf("failed to get key via OIDC discovery: %v", err)
 	}
@@ -339,7 +338,7 @@ func TestJWKSCache_ForceRefresh(t *testing.T) {
 	initialCount := refreshCount.Load()
 
 	// Force refresh should be rate-limited (within minJWKSRefreshInterval)
-	err = cache.ForceRefresh(context.Background())
+	err = cache.ForceRefresh(t.Context())
 	if err != nil {
 		t.Errorf("ForceRefresh returned error: %v", err)
 	}
@@ -389,13 +388,13 @@ func TestJWKSCache_WithMetrics(t *testing.T) {
 	}
 
 	// Key lookup
-	_, _ = cache.GetKey(context.Background(), "metrics-key")
+	_, _ = cache.GetKey(t.Context(), "metrics-key")
 	if keyLookups.Load() < 1 {
 		t.Error("expected key lookup to be recorded")
 	}
 
 	// Key miss
-	_, _ = cache.GetKey(context.Background(), "non-existent")
+	_, _ = cache.GetKey(t.Context(), "non-existent")
 	if keyMisses.Load() < 1 {
 		t.Error("expected key miss to be recorded")
 	}

--- a/internal/auth/jwt/jwt_test.go
+++ b/internal/auth/jwt/jwt_test.go
@@ -1,7 +1,6 @@
 package jwt
 
 import (
-	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -237,7 +236,7 @@ func TestClaimsFromContext(t *testing.T) {
 	})
 
 	t.Run("context without claims", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		claims := ClaimsFromContext(ctx)
 		if claims != nil {
 			t.Error("expected nil claims")
@@ -246,7 +245,7 @@ func TestClaimsFromContext(t *testing.T) {
 
 	t.Run("context with claims", func(t *testing.T) {
 		expected := &Claims{Subject: "user123"}
-		ctx := ContextWithClaims(context.Background(), expected)
+		ctx := ContextWithClaims(t.Context(), expected)
 		claims := ClaimsFromContext(ctx)
 		if claims == nil {
 			t.Fatal("expected non-nil claims")
@@ -357,7 +356,7 @@ func TestAuthenticator_StaticKeys(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 
-		claims, err := auth.Authenticate(context.Background(), req)
+		claims, err := auth.Authenticate(t.Context(), req)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -371,7 +370,7 @@ func TestAuthenticator_StaticKeys(t *testing.T) {
 	t.Run("no token - returns nil", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 
-		claims, err := auth.Authenticate(context.Background(), req)
+		claims, err := auth.Authenticate(t.Context(), req)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -389,7 +388,7 @@ func TestAuthenticator_StaticKeys(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 
-		_, err := auth.Authenticate(context.Background(), req)
+		_, err := auth.Authenticate(t.Context(), req)
 		if err == nil {
 			t.Error("expected error for expired token")
 		}
@@ -465,7 +464,7 @@ func TestAuthenticator_RejectsNoneAlgorithm(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("Authorization", "Bearer "+noneToken)
 
-	_, err = auth.Authenticate(context.Background(), req)
+	_, err = auth.Authenticate(t.Context(), req)
 	if err == nil {
 		t.Fatal("expected error for 'none' algorithm token, got nil - SECURITY VULNERABILITY")
 	}
@@ -508,7 +507,7 @@ func TestAuthenticator_RejectsSymmetricAlgorithms(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	req.Header.Set("Authorization", "Bearer "+hs256Token)
 
-	_, err = auth.Authenticate(context.Background(), req)
+	_, err = auth.Authenticate(t.Context(), req)
 	if err == nil {
 		t.Fatal("expected error for HS256 algorithm token, got nil - SECURITY VULNERABILITY")
 	}
@@ -577,7 +576,7 @@ func TestAuthenticator_IssuerValidation(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 
-		claims, err := auth.Authenticate(context.Background(), req)
+		claims, err := auth.Authenticate(t.Context(), req)
 		if err != nil {
 			t.Errorf("unexpected error for trusted issuer: %v", err)
 		}
@@ -596,7 +595,7 @@ func TestAuthenticator_IssuerValidation(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 
-		_, err := auth.Authenticate(context.Background(), req)
+		_, err := auth.Authenticate(t.Context(), req)
 		if err == nil {
 			t.Fatal("expected error for untrusted issuer")
 		}
@@ -619,7 +618,7 @@ func TestAuthenticator_IssuerValidation(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 
-		_, err := auth.Authenticate(context.Background(), req)
+		_, err := auth.Authenticate(t.Context(), req)
 		if err == nil {
 			t.Fatal("expected error for missing issuer when issuers configured")
 		}
@@ -661,7 +660,7 @@ func TestAuthenticator_AudienceValidation(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 
-		claims, err := auth.Authenticate(context.Background(), req)
+		claims, err := auth.Authenticate(t.Context(), req)
 		if err != nil {
 			t.Errorf("unexpected error for matching audience: %v", err)
 		}
@@ -680,7 +679,7 @@ func TestAuthenticator_AudienceValidation(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 
-		claims, err := auth.Authenticate(context.Background(), req)
+		claims, err := auth.Authenticate(t.Context(), req)
 		if err != nil {
 			t.Errorf("unexpected error when one audience matches: %v", err)
 		}
@@ -699,7 +698,7 @@ func TestAuthenticator_AudienceValidation(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 
-		_, err := auth.Authenticate(context.Background(), req)
+		_, err := auth.Authenticate(t.Context(), req)
 		if err == nil {
 			t.Fatal("expected error for wrong audience")
 		}
@@ -722,7 +721,7 @@ func TestAuthenticator_AudienceValidation(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 
-		_, err := auth.Authenticate(context.Background(), req)
+		_, err := auth.Authenticate(t.Context(), req)
 		if err == nil {
 			t.Fatal("expected error for missing audience when audiences configured")
 		}
@@ -765,7 +764,7 @@ func TestAuthenticator_RequiredClaims(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 
-		claims, err := auth.Authenticate(context.Background(), req)
+		claims, err := auth.Authenticate(t.Context(), req)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -785,7 +784,7 @@ func TestAuthenticator_RequiredClaims(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 
-		_, err := auth.Authenticate(context.Background(), req)
+		_, err := auth.Authenticate(t.Context(), req)
 		if err == nil {
 			t.Fatal("expected error for missing required claim")
 		}
@@ -829,7 +828,7 @@ func TestAuthenticator_TokenSizeLimit(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 
-		_, err := auth.Authenticate(context.Background(), req)
+		_, err := auth.Authenticate(t.Context(), req)
 		if err == nil {
 			t.Fatal("expected error for oversized token")
 		}
@@ -924,7 +923,7 @@ func TestAuthenticator_NotBeforeValidation(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 
-		_, err := auth.Authenticate(context.Background(), req)
+		_, err := auth.Authenticate(t.Context(), req)
 		if err == nil {
 			t.Fatal("expected error for token not yet valid")
 		}
@@ -951,7 +950,7 @@ func TestAuthenticator_NotBeforeValidation(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 
-		claims, err := auth.Authenticate(context.Background(), req)
+		claims, err := auth.Authenticate(t.Context(), req)
 		if err != nil {
 			t.Errorf("token with past nbf should be accepted: %v", err)
 		}
@@ -971,7 +970,7 @@ func TestTenantFromContext(t *testing.T) {
 	})
 
 	t.Run("context without claims (anonymous)", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		tenant := TenantFromContext(ctx)
 		if tenant != "" {
 			t.Errorf("expected empty string for context without claims, got %q", tenant)
@@ -983,7 +982,7 @@ func TestTenantFromContext(t *testing.T) {
 			Subject: "user123",
 			Custom:  map[string]any{},
 		}
-		ctx := ContextWithClaims(context.Background(), claims)
+		ctx := ContextWithClaims(t.Context(), claims)
 		tenant := TenantFromContext(ctx)
 		if tenant != "" {
 			t.Errorf("expected empty string for claims without tenant, got %q", tenant)
@@ -997,7 +996,7 @@ func TestTenantFromContext(t *testing.T) {
 				"tenant": "acme-corp",
 			},
 		}
-		ctx := ContextWithClaims(context.Background(), claims)
+		ctx := ContextWithClaims(t.Context(), claims)
 		tenant := TenantFromContext(ctx)
 		if tenant != "acme-corp" {
 			t.Errorf("expected tenant 'acme-corp', got %q", tenant)
@@ -1011,7 +1010,7 @@ func TestTenantFromContext(t *testing.T) {
 				"tenant": []byte("byte-tenant"),
 			},
 		}
-		ctx := ContextWithClaims(context.Background(), claims)
+		ctx := ContextWithClaims(t.Context(), claims)
 		tenant := TenantFromContext(ctx)
 		if tenant != "byte-tenant" {
 			t.Errorf("expected tenant 'byte-tenant', got %q", tenant)
@@ -1025,7 +1024,7 @@ func TestTenantFromContext(t *testing.T) {
 				"tenant": 12345, // integer, not string
 			},
 		}
-		ctx := ContextWithClaims(context.Background(), claims)
+		ctx := ContextWithClaims(t.Context(), claims)
 		tenant := TenantFromContext(ctx)
 		if tenant != "" {
 			t.Errorf("expected empty string for non-string tenant, got %q", tenant)
@@ -1039,7 +1038,7 @@ func TestTenantFromContext(t *testing.T) {
 				"tenant": nil,
 			},
 		}
-		ctx := ContextWithClaims(context.Background(), claims)
+		ctx := ContextWithClaims(t.Context(), claims)
 		tenant := TenantFromContext(ctx)
 		if tenant != "" {
 			t.Errorf("expected empty string for nil tenant value, got %q", tenant)
@@ -1063,7 +1062,7 @@ func TestTenantFromContextWithKey(t *testing.T) {
 				"org_id": "organization-456",
 			},
 		}
-		ctx := ContextWithClaims(context.Background(), claims)
+		ctx := ContextWithClaims(t.Context(), claims)
 		tenant := TenantFromContextWithKey(ctx, "org_id")
 		if tenant != "organization-456" {
 			t.Errorf("expected tenant 'organization-456', got %q", tenant)
@@ -1077,7 +1076,7 @@ func TestTenantFromContextWithKey(t *testing.T) {
 				"tenant": "acme-corp",
 			},
 		}
-		ctx := ContextWithClaims(context.Background(), claims)
+		ctx := ContextWithClaims(t.Context(), claims)
 		tenant := TenantFromContextWithKey(ctx, "org_id")
 		if tenant != "" {
 			t.Errorf("expected empty string for missing key, got %q", tenant)
@@ -1091,7 +1090,7 @@ func TestTenantFromContextWithKey(t *testing.T) {
 				"tenant": "acme-corp",
 			},
 		}
-		ctx := ContextWithClaims(context.Background(), claims)
+		ctx := ContextWithClaims(t.Context(), claims)
 		tenant := TenantFromContextWithKey(ctx, "")
 		if tenant != "" {
 			t.Errorf("expected empty string for empty key, got %q", tenant)
@@ -1104,7 +1103,7 @@ func TestTenantFromContextWithKey(t *testing.T) {
 			Subject: "tenant-from-subject",
 			Custom:  map[string]any{},
 		}
-		ctx := ContextWithClaims(context.Background(), claims)
+		ctx := ContextWithClaims(t.Context(), claims)
 		tenant := TenantFromContextWithKey(ctx, "sub")
 		if tenant != "tenant-from-subject" {
 			t.Errorf("expected tenant 'tenant-from-subject', got %q", tenant)
@@ -1118,7 +1117,7 @@ func TestTenantFromContextWithKey(t *testing.T) {
 			Issuer:  "https://acme.auth.com",
 			Custom:  map[string]any{},
 		}
-		ctx := ContextWithClaims(context.Background(), claims)
+		ctx := ContextWithClaims(t.Context(), claims)
 		tenant := TenantFromContextWithKey(ctx, "iss")
 		if tenant != "https://acme.auth.com" {
 			t.Errorf("expected tenant 'https://acme.auth.com', got %q", tenant)

--- a/internal/auth/provider_test.go
+++ b/internal/auth/provider_test.go
@@ -177,7 +177,7 @@ func TestChainProvider_Lookup_Error(t *testing.T) {
 		errorProvider{err: testErr},
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := chain.Lookup(ctx, Scope{Host: "github.com"})
 	if err == nil {
 		t.Fatal("expected error")
@@ -195,7 +195,7 @@ func TestChainProvider_Lookup_SkipsErrNoCredential(t *testing.T) {
 
 	chain := NewChainProvider(noCredProvider, staticProvider)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	cred, err := chain.Lookup(ctx, Scope{Host: "github.com"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -208,7 +208,7 @@ func TestChainProvider_Lookup_SkipsErrNoCredential(t *testing.T) {
 func TestStaticProvider_NilCredential(t *testing.T) {
 	p := NewStaticProvider(nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	cred, err := p.Lookup(ctx, Scope{Host: "github.com"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/cache/context_test.go
+++ b/internal/cache/context_test.go
@@ -77,17 +77,17 @@ func TestShouldBypass(t *testing.T) {
 	}{
 		{
 			name: "default context",
-			ctx:  context.Background(),
+			ctx:  t.Context(),
 			want: false,
 		},
 		{
 			name: "bypass all",
-			ctx:  WithBypassAll(context.Background()),
+			ctx:  WithBypassAll(t.Context()),
 			want: true,
 		},
 		{
 			name: "bypass sources does not set bypass all",
-			ctx:  WithBypassSources(context.Background(), []string{"osv"}),
+			ctx:  WithBypassSources(t.Context(), []string{"osv"}),
 			want: false,
 		},
 	}
@@ -110,25 +110,25 @@ func TestShouldBypassSource(t *testing.T) {
 	}{
 		{
 			name:   "default context",
-			ctx:    context.Background(),
+			ctx:    t.Context(),
 			source: "osv",
 			want:   false,
 		},
 		{
 			name:   "bypass all affects any source",
-			ctx:    WithBypassAll(context.Background()),
+			ctx:    WithBypassAll(t.Context()),
 			source: "osv",
 			want:   true,
 		},
 		{
 			name:   "bypass specific source matches",
-			ctx:    WithBypassSources(context.Background(), []string{"osv", "kev"}),
+			ctx:    WithBypassSources(t.Context(), []string{"osv", "kev"}),
 			source: "osv",
 			want:   true,
 		},
 		{
 			name:   "bypass specific source does not match other",
-			ctx:    WithBypassSources(context.Background(), []string{"osv", "kev"}),
+			ctx:    WithBypassSources(t.Context(), []string{"osv", "kev"}),
 			source: "epss",
 			want:   false,
 		},
@@ -185,7 +185,7 @@ func TestApplyNoCacheFlag(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := ApplyNoCacheFlag(context.Background(), tt.value)
+			ctx := ApplyNoCacheFlag(t.Context(), tt.value)
 			var got bool
 			if tt.checkBypass {
 				got = ShouldBypass(ctx)

--- a/internal/cache/registry_test.go
+++ b/internal/cache/registry_test.go
@@ -150,7 +150,7 @@ func TestRegistry_Status(t *testing.T) {
 	reg.Register(s1)
 	reg.Register(s2)
 
-	statuses, err := reg.Status(context.Background())
+	statuses, err := reg.Status(t.Context())
 	if err != nil {
 		t.Fatalf("Status() error = %v", err)
 	}
@@ -181,7 +181,7 @@ func TestRegistry_PopulateAll(t *testing.T) {
 	reg.Register(s2)
 	reg.Register(s3)
 
-	err := reg.PopulateAll(context.Background(), PopulateOptions{})
+	err := reg.PopulateAll(t.Context(), PopulateOptions{})
 
 	// Should have error from s2
 	if err == nil {
@@ -204,7 +204,7 @@ func TestRegistry_Populate(t *testing.T) {
 	reg.Register(s2)
 
 	// Populate only s1
-	err := reg.Populate(context.Background(), []string{"s1"}, PopulateOptions{})
+	err := reg.Populate(t.Context(), []string{"s1"}, PopulateOptions{})
 	if err != nil {
 		t.Fatalf("Populate() error = %v", err)
 	}
@@ -221,7 +221,7 @@ func TestRegistry_Populate_UnknownSource(t *testing.T) {
 	reg := NewRegistry()
 	reg.Register(&mockSource{name: "known"})
 
-	err := reg.Populate(context.Background(), []string{"unknown"}, PopulateOptions{})
+	err := reg.Populate(t.Context(), []string{"unknown"}, PopulateOptions{})
 	if err == nil {
 		t.Error("Populate() with unknown source should return error")
 	}
@@ -236,7 +236,7 @@ func TestRegistry_ClearAll(t *testing.T) {
 	reg.Register(s1)
 	reg.Register(s2)
 
-	err := reg.ClearAll(context.Background())
+	err := reg.ClearAll(t.Context())
 	if err != nil {
 		t.Fatalf("ClearAll() error = %v", err)
 	}
@@ -255,7 +255,7 @@ func TestRegistry_Clear(t *testing.T) {
 	reg.Register(s1)
 	reg.Register(s2)
 
-	err := reg.Clear(context.Background(), []string{"s1"})
+	err := reg.Clear(t.Context(), []string{"s1"})
 	if err != nil {
 		t.Fatalf("Clear() error = %v", err)
 	}
@@ -280,7 +280,7 @@ func TestRegistry_TotalSize(t *testing.T) {
 		status: &SourceStatus{Size: 2000},
 	})
 
-	total, err := reg.TotalSize(context.Background())
+	total, err := reg.TotalSize(t.Context())
 	if err != nil {
 		t.Fatalf("TotalSize() error = %v", err)
 	}

--- a/internal/cli/cmd/context_cancel_test.go
+++ b/internal/cli/cmd/context_cancel_test.go
@@ -44,7 +44,7 @@ listeners:
 		t.Fatalf("load config: %v", err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
 
 	done := make(chan error, 1)

--- a/internal/cli/cmd/diff_container_test.go
+++ b/internal/cli/cmd/diff_container_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -191,7 +190,7 @@ func TestDiffCommandRejectsMixedContainerAndGitRefs(t *testing.T) {
 	AddDiffCommand(root, nil)
 	root.SetArgs([]string{"diff", "--repo", repo, "docker://nginx:1.24", "main"})
 
-	err := root.ExecuteContext(context.Background())
+	err := root.ExecuteContext(t.Context())
 	if err == nil {
 		t.Fatal("expected mixed ref error")
 	}

--- a/internal/cli/cmd/diff_display_test.go
+++ b/internal/cli/cmd/diff_display_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -41,7 +40,7 @@ func TestDisplayDetailedDependencyChanges_ScanUsesBestEffortLicenses(t *testing.
 	}}
 
 	var buf bytes.Buffer
-	displayDetailedDependencyChanges(context.Background(), nil, changes, true, "scan", &buf, io.Discard)
+	displayDetailedDependencyChanges(t.Context(), nil, changes, true, "scan", &buf, io.Discard)
 
 	out := buf.String()
 	if !strings.Contains(out, "MIT") {

--- a/internal/cli/cmd/explain_test.go
+++ b/internal/cli/cmd/explain_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"context"
 	"strings"
 	"testing"
 	"time"
@@ -12,7 +11,7 @@ import (
 )
 
 func TestExplainRenderer_Text(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("renders basic vulnerability", func(t *testing.T) {
 		out := &bytes.Buffer{}
@@ -189,7 +188,7 @@ func TestExplainRenderer_Text(t *testing.T) {
 }
 
 func TestExplainRenderer_JSON(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("renders valid JSON with core fields", func(t *testing.T) {
 		out := &bytes.Buffer{}

--- a/internal/cli/cmd/output_integration_test.go
+++ b/internal/cli/cmd/output_integration_test.go
@@ -2,18 +2,17 @@ package cmd
 
 import (
 	"bytes"
-	"context"
 	"os"
 	"strings"
 	"testing"
 
 	"google.golang.org/protobuf/encoding/protojson"
 
+	"github.com/spf13/cobra"
 	dependencyv1 "github.com/temporalio/deputy/gen/deputy/dependency/v1"
 	scanv1 "github.com/temporalio/deputy/gen/deputy/scan/v1"
 	targetv1 "github.com/temporalio/deputy/gen/deputy/target/v1"
 	vulnerabilityv1 "github.com/temporalio/deputy/gen/deputy/vulnerability/v1"
-	"github.com/spf13/cobra"
 )
 
 func newTestRoot(out, errW *bytes.Buffer) *cobra.Command {
@@ -90,7 +89,7 @@ func TestCLIOutput_TriageFromReport_WritesToCommandOut(t *testing.T) {
 	var out, errBuf bytes.Buffer
 	root := newTestRoot(&out, &errBuf)
 	root.SetArgs([]string{"triage", "--report", path, "--format", "text"})
-	if err := root.ExecuteContext(context.Background()); err != nil {
+	if err := root.ExecuteContext(t.Context()); err != nil {
 		t.Fatalf("execute: %v", err)
 	}
 
@@ -142,7 +141,7 @@ func TestCLIOutput_FixFromReport_WritesToCommandOut(t *testing.T) {
 	var out, errBuf bytes.Buffer
 	root := newTestRoot(&out, &errBuf)
 	root.SetArgs([]string{"fix", "--report", path, "--format", "text"})
-	if err := root.ExecuteContext(context.Background()); err != nil {
+	if err := root.ExecuteContext(t.Context()); err != nil {
 		t.Fatalf("execute: %v", err)
 	}
 
@@ -154,4 +153,3 @@ func TestCLIOutput_FixFromReport_WritesToCommandOut(t *testing.T) {
 		t.Fatalf("expected stdout to contain remediation header, got %q", got)
 	}
 }
-

--- a/internal/cli/cmd/pin_test.go
+++ b/internal/cli/cmd/pin_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"context"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -243,7 +242,7 @@ func TestBuildPinStrategies(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			strategies, err := buildPinStrategies(context.Background(), tc.ecosystems, false, tc.allowedHostBins)
+			strategies, err := buildPinStrategies(t.Context(), tc.ecosystems, false, tc.allowedHostBins)
 			if tc.wantErr != "" {
 				if err == nil {
 					t.Fatalf("expected error containing %q, got nil", tc.wantErr)

--- a/internal/cli/cmd/policy_helpers_test.go
+++ b/internal/cli/cmd/policy_helpers_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"context"
 	"path/filepath"
 	"testing"
 
@@ -22,7 +21,7 @@ func TestEvaluatePoliciesForCommand_SbomComponentLicenses(t *testing.T) {
 			"licenses": []any{"GPL-3.0"},
 		},
 	}
-	_, err := evaluatePoliciesForCommand(context.Background(), []string{pol}, payload, "sbom", policy.EntrypointSBOMComponent, &bytes.Buffer{})
+	_, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, payload, "sbom", policy.EntrypointSBOMComponent, &bytes.Buffer{})
 	if err == nil {
 		t.Fatalf("expected policy denial error, got nil")
 	}
@@ -36,7 +35,7 @@ func TestEvaluatePoliciesForCommand_Scan_NoPanic(t *testing.T) {
 			"licenses": []any{}, // empty licenses - should trigger warn, not deny
 		},
 	}
-	actions, err := evaluatePoliciesForCommand(context.Background(), []string{pol}, payload, "scan", policy.EntrypointScanReport, &bytes.Buffer{})
+	actions, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, payload, "scan", policy.EntrypointScanReport, &bytes.Buffer{})
 	if err != nil {
 		t.Fatalf("evaluatePoliciesForCommand: %v", err)
 	}

--- a/internal/cli/cmd/policy_integration_test.go
+++ b/internal/cli/cmd/policy_integration_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"context"
 	"os"
 	"path/filepath"
 	"slices"
@@ -23,7 +22,7 @@ func TestPolicyIntegration_ComposedBundleSbomComponent(t *testing.T) {
 			"licenses": []any{"AgPl-3.0-only", "MIT"},
 		},
 	}
-	_, err := evaluatePoliciesForCommand(context.Background(), []string{bundlePath}, payload, "sbom", policy.EntrypointSBOMComponent, &bytes.Buffer{})
+	_, err := evaluatePoliciesForCommand(t.Context(), []string{bundlePath}, payload, "sbom", policy.EntrypointSBOMComponent, &bytes.Buffer{})
 	if err == nil {
 		t.Fatalf("expected denial error from composed bundle, got nil")
 	}
@@ -37,7 +36,7 @@ func TestPolicyIntegration_ComposedBundleSbomComponent_AllowsPermissive(t *testi
 			"licenses": []any{"MIT"},
 		},
 	}
-	actions, err := evaluatePoliciesForCommand(context.Background(), []string{bundlePath}, payload, "sbom", policy.EntrypointSBOMComponent, &bytes.Buffer{})
+	actions, err := evaluatePoliciesForCommand(t.Context(), []string{bundlePath}, payload, "sbom", policy.EntrypointSBOMComponent, &bytes.Buffer{})
 	if err != nil {
 		t.Fatalf("evaluatePoliciesForCommand: %v", err)
 	}
@@ -58,7 +57,7 @@ func TestPolicyIntegration_ComposedBundleScanReport_NoDeny(t *testing.T) {
 			"licenses": []any{}, // empty licenses, but scan command is not in_scope
 		},
 	}
-	actions, err := evaluatePoliciesForCommand(context.Background(), []string{bundlePath}, payload, "scan", policy.EntrypointScanReport, &bytes.Buffer{})
+	actions, err := evaluatePoliciesForCommand(t.Context(), []string{bundlePath}, payload, "scan", policy.EntrypointScanReport, &bytes.Buffer{})
 	if err != nil {
 		t.Fatalf("evaluatePoliciesForCommand: %v", err)
 	}
@@ -77,7 +76,7 @@ func TestPolicyIntegration_FixStepCommandAllowlist_Deny(t *testing.T) {
 			"executable": true,
 		},
 	}
-	if _, err := evaluatePoliciesForCommand(context.Background(), []string{pol}, payload, "fix", policy.EntrypointFixPlanStep, &bytes.Buffer{}); err == nil {
+	if _, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, payload, "fix", policy.EntrypointFixPlanStep, &bytes.Buffer{}); err == nil {
 		t.Fatalf("expected denial error for unsafe fix step")
 	}
 }
@@ -90,7 +89,7 @@ func TestPolicyIntegration_NewDependencyReview_Deny(t *testing.T) {
 			"name": "github.com/unknown/mod",
 		},
 	}
-	if _, err := evaluatePoliciesForCommand(context.Background(), []string{pol}, payload, "diff", policy.EntrypointDiffDependencyChange, &bytes.Buffer{}); err == nil {
+	if _, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, payload, "diff", policy.EntrypointDiffDependencyChange, &bytes.Buffer{}); err == nil {
 		t.Fatalf("expected denial error for unapproved dependency addition")
 	}
 }
@@ -107,7 +106,7 @@ func TestPolicyIntegration_PypiPrefixAllowlist(t *testing.T) {
 			"name": "randompkg",
 		},
 	}
-	if _, err := evaluatePoliciesForCommand(context.Background(), []string{pol}, denyPayload, "proxy", policy.EntrypointPypiArtifactRequest, &bytes.Buffer{}); err == nil {
+	if _, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, denyPayload, "proxy", policy.EntrypointPypiArtifactRequest, &bytes.Buffer{}); err == nil {
 		t.Fatalf("expected denial error for unapproved pypi package")
 	}
 
@@ -120,7 +119,7 @@ func TestPolicyIntegration_PypiPrefixAllowlist(t *testing.T) {
 			"name": "acme_toolkit",
 		},
 	}
-	if actions, err := evaluatePoliciesForCommand(context.Background(), []string{pol}, allowPayload, "proxy", policy.EntrypointPypiArtifactRequest, &bytes.Buffer{}); err != nil {
+	if actions, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, allowPayload, "proxy", policy.EntrypointPypiArtifactRequest, &bytes.Buffer{}); err != nil {
 		t.Fatalf("unexpected error for approved pypi package: %v", err)
 	} else {
 		for _, a := range actions {
@@ -139,14 +138,14 @@ func TestPolicyIntegration_RuntimeCriticalBaseline(t *testing.T) {
 			"name": "github.com/sirupsen/logrus",
 		},
 	}
-	if _, err := evaluatePoliciesForCommand(context.Background(), []string{pol}, payload, "diff", policy.EntrypointDiffDependencyChange, &bytes.Buffer{}); err == nil {
+	if _, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, payload, "diff", policy.EntrypointDiffDependencyChange, &bytes.Buffer{}); err == nil {
 		t.Fatalf("expected denial error for removing critical module")
 	}
 }
 
 func TestPolicyIntegration_ExploitAvailableBlocker(t *testing.T) {
 	pol := filepath.Clean(filepath.Join("..", "..", "..", "policy", "examples", "exploit-available-blocker.yaml"))
-	
+
 	payload := map[string]any{
 		"vulnerability": &vulnerabilityv1.Finding{
 			Advisory: &vulnerabilityv1.Advisory{
@@ -157,14 +156,14 @@ func TestPolicyIntegration_ExploitAvailableBlocker(t *testing.T) {
 			},
 		},
 	}
-	if _, err := evaluatePoliciesForCommand(context.Background(), []string{pol}, payload, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{}); err == nil {
+	if _, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, payload, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{}); err == nil {
 		t.Fatalf("expected denial error for exploit-available vulnerability")
 	}
 }
 
 func TestPolicyIntegration_DeprecatedModuleBlock(t *testing.T) {
 	pol := filepath.Clean(filepath.Join("..", "..", "..", "policy", "examples", "deprecated-module-block.yaml"))
-	
+
 	payload := map[string]any{
 		"vulnerability": &vulnerabilityv1.Finding{
 			Advisory: &vulnerabilityv1.Advisory{
@@ -172,7 +171,7 @@ func TestPolicyIntegration_DeprecatedModuleBlock(t *testing.T) {
 			},
 		},
 	}
-	if _, err := evaluatePoliciesForCommand(context.Background(), []string{pol}, payload, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{}); err == nil {
+	if _, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, payload, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{}); err == nil {
 		t.Fatalf("expected denial error for deprecated module")
 	}
 }
@@ -182,27 +181,27 @@ func TestPolicyIntegration_DependencyCountGuard(t *testing.T) {
 	payload := map[string]any{
 		"changes": make([]any, 80),
 	}
-	if _, err := evaluatePoliciesForCommand(context.Background(), []string{pol}, payload, "diff", policy.EntrypointDiffReport, &bytes.Buffer{}); err == nil {
+	if _, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, payload, "diff", policy.EntrypointDiffReport, &bytes.Buffer{}); err == nil {
 		t.Fatalf("expected denial for oversized diff change set")
 	}
 }
 
 func TestPolicyIntegration_LicensePresentBlocker(t *testing.T) {
 	pol := filepath.Clean(filepath.Join("..", "..", "..", "policy", "examples", "license-present-blocker.yaml"))
-	
+
 	payload := map[string]any{
 		"pkg": &dependencyv1.Package{
 			Licenses: []string{}, // Empty licenses
 		},
 	}
-	if _, err := evaluatePoliciesForCommand(context.Background(), []string{pol}, payload, "proxy", policy.EntrypointGoArtifactRequest, &bytes.Buffer{}); err == nil {
+	if _, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, payload, "proxy", policy.EntrypointGoArtifactRequest, &bytes.Buffer{}); err == nil {
 		t.Fatalf("expected denial for missing license metadata")
 	}
 }
 
 func TestPolicyIntegration_NoFixEscalator(t *testing.T) {
 	pol := filepath.Clean(filepath.Join("..", "..", "..", "policy", "examples", "no-fix-escalator.yaml"))
-	
+
 	payload := map[string]any{
 		"vulnerability": &vulnerabilityv1.Finding{
 			Package: &dependencyv1.Package{
@@ -216,7 +215,7 @@ func TestPolicyIntegration_NoFixEscalator(t *testing.T) {
 			},
 		},
 	}
-	actions, err := evaluatePoliciesForCommand(context.Background(), []string{pol}, payload, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{})
+	actions, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, payload, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -227,7 +226,7 @@ func TestPolicyIntegration_NoFixEscalator(t *testing.T) {
 
 func TestPolicyIntegration_ProdManifestGate(t *testing.T) {
 	pol := filepath.Clean(filepath.Join("..", "..", "..", "policy", "examples", "prod-manifest-gate.yaml"))
-	
+
 	payload := map[string]any{
 		"vulnerability": &vulnerabilityv1.Finding{
 			Advisory: &vulnerabilityv1.Advisory{
@@ -242,20 +241,20 @@ func TestPolicyIntegration_ProdManifestGate(t *testing.T) {
 			},
 		},
 	}
-	if _, err := evaluatePoliciesForCommand(context.Background(), []string{pol}, payload, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{}); err == nil {
+	if _, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, payload, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{}); err == nil {
 		t.Fatalf("expected denial for prod manifest vuln")
 	}
 }
 
 func TestPolicyIntegration_DomainBrandedPackageGuard(t *testing.T) {
 	pol := filepath.Clean(filepath.Join("..", "..", "..", "policy", "examples", "domain-branded-package-guard.yaml"))
-	
+
 	payload := map[string]any{
 		"request": &policyv1.ProxyRequest{
 			Package: "aws-helper",
 		},
 	}
-	if _, err := evaluatePoliciesForCommand(context.Background(), []string{pol}, payload, "proxy", policy.EntrypointNpmArtifactRequest, &bytes.Buffer{}); err == nil {
+	if _, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, payload, "proxy", policy.EntrypointNpmArtifactRequest, &bytes.Buffer{}); err == nil {
 		t.Fatalf("expected denial for branded package name")
 	}
 }
@@ -269,7 +268,7 @@ func TestPolicyIntegration_CriticalRuntimePinning(t *testing.T) {
 		},
 		"pkg": &dependencyv1.Package{Name: "golang.org/x/crypto", Version: "v0.24.0", Ecosystem: "go"},
 	}
-	actions, err := evaluatePoliciesForCommand(context.Background(), []string{pol}, payload, "diff", policy.EntrypointDiffDependencyChange, &bytes.Buffer{})
+	actions, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, payload, "diff", policy.EntrypointDiffDependencyChange, &bytes.Buffer{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -284,7 +283,7 @@ func TestPolicyIntegration_SbomSizeShapeSanity(t *testing.T) {
 	payload := map[string]any{
 		"packages": packages,
 	}
-	actions, err := evaluatePoliciesForCommand(context.Background(), []string{pol}, payload, "sbom", policy.EntrypointSBOMReport, &bytes.Buffer{})
+	actions, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, payload, "sbom", policy.EntrypointSBOMReport, &bytes.Buffer{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -295,7 +294,7 @@ func TestPolicyIntegration_SbomSizeShapeSanity(t *testing.T) {
 
 func TestPolicyIntegration_CriticalTransitiveSpotlight(t *testing.T) {
 	pol := filepath.Clean(filepath.Join("..", "..", "..", "policy", "examples", "critical-transitive-spotlight.yaml"))
-	
+
 	payload := map[string]any{
 		"vulnerability": &vulnerabilityv1.Finding{
 			Advisory: &vulnerabilityv1.Advisory{
@@ -311,7 +310,7 @@ func TestPolicyIntegration_CriticalTransitiveSpotlight(t *testing.T) {
 		},
 		"env": &policyv1.Environment{Command: "scan", Entrypoint: "scan_vulnerability"},
 	}
-	if actions, err := evaluatePoliciesForCommand(context.Background(), []string{pol}, payload, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{}); err != nil {
+	if actions, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, payload, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	} else {
 		if !slices.ContainsFunc(actions, func(a policy.Action) bool { return a.Type == "warn" }) {
@@ -333,7 +332,7 @@ func TestPolicyIntegration_TyposquatLevenshteinGuard(t *testing.T) {
 			Name: "lodas",
 		},
 	}
-	if _, err := evaluatePoliciesForCommand(context.Background(), []string{pol}, payload, "proxy", policy.EntrypointNpmArtifactRequest, &bytes.Buffer{}); err == nil {
+	if _, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, payload, "proxy", policy.EntrypointNpmArtifactRequest, &bytes.Buffer{}); err == nil {
 		t.Fatalf("expected denial for typosquat package")
 	}
 
@@ -346,7 +345,7 @@ func TestPolicyIntegration_TyposquatLevenshteinGuard(t *testing.T) {
 			Name: "teamlib",
 		},
 	}
-	if actions, err := evaluatePoliciesForCommand(context.Background(), []string{pol}, allowPayload, "proxy", policy.EntrypointNpmArtifactRequest, &bytes.Buffer{}); err != nil {
+	if actions, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, allowPayload, "proxy", policy.EntrypointNpmArtifactRequest, &bytes.Buffer{}); err != nil {
 		t.Fatalf("did not expect error for safe package: %v", err)
 	} else {
 		for _, a := range actions {
@@ -359,7 +358,7 @@ func TestPolicyIntegration_TyposquatLevenshteinGuard(t *testing.T) {
 
 func TestPolicyIntegration_CWEBlocker(t *testing.T) {
 	// Test that CWEs are accessible in vulnerability policies
-	
+
 	polContent := `
 policies:
   - name: block-injection-cwes
@@ -377,7 +376,6 @@ policies:
 		t.Fatalf("failed to write policy file: %v", err)
 	}
 
-	
 	payloadWithCWE := map[string]any{
 		"vulnerability": &vulnerabilityv1.Finding{
 			Advisory: &vulnerabilityv1.Advisory{
@@ -389,11 +387,10 @@ policies:
 			},
 		},
 	}
-	if _, err := evaluatePoliciesForCommand(context.Background(), []string{pol}, payloadWithCWE, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{}); err == nil {
+	if _, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, payloadWithCWE, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{}); err == nil {
 		t.Fatal("expected denial for vulnerability with injection CWE")
 	}
 
-	
 	payloadSafeCWE := map[string]any{
 		"vulnerability": &vulnerabilityv1.Finding{
 			Advisory: &vulnerabilityv1.Advisory{
@@ -405,7 +402,7 @@ policies:
 			},
 		},
 	}
-	actions, err := evaluatePoliciesForCommand(context.Background(), []string{pol}, payloadSafeCWE, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{})
+	actions, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, payloadSafeCWE, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{})
 	if err != nil {
 		t.Fatalf("unexpected error for safe CWEs: %v", err)
 	}
@@ -415,7 +412,6 @@ policies:
 		}
 	}
 
-	
 	payloadNoCWE := map[string]any{
 		"vulnerability": &vulnerabilityv1.Finding{
 			Advisory: &vulnerabilityv1.Advisory{
@@ -426,7 +422,7 @@ policies:
 			},
 		},
 	}
-	actions, err = evaluatePoliciesForCommand(context.Background(), []string{pol}, payloadNoCWE, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{})
+	actions, err = evaluatePoliciesForCommand(t.Context(), []string{pol}, payloadNoCWE, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{})
 	if err != nil {
 		t.Fatalf("unexpected error for vulnerability without CWEs: %v", err)
 	}
@@ -439,7 +435,7 @@ policies:
 
 func TestPolicyIntegration_KEVBlocker(t *testing.T) {
 	// Test that KEV status is accessible in vulnerability policies
-	
+
 	polContent := `
 policies:
   - name: block-kev
@@ -456,7 +452,6 @@ policies:
 		t.Fatalf("failed to write policy file: %v", err)
 	}
 
-	
 	inKEV := true
 	payloadInKEV := map[string]any{
 		"vulnerability": &vulnerabilityv1.Finding{
@@ -469,11 +464,10 @@ policies:
 			InKev: &inKEV,
 		},
 	}
-	if _, err := evaluatePoliciesForCommand(context.Background(), []string{pol}, payloadInKEV, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{}); err == nil {
+	if _, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, payloadInKEV, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{}); err == nil {
 		t.Fatal("expected denial for vulnerability in KEV")
 	}
 
-	
 	notInKEV := false
 	payloadNotInKEV := map[string]any{
 		"vulnerability": &vulnerabilityv1.Finding{
@@ -486,7 +480,7 @@ policies:
 			InKev: &notInKEV,
 		},
 	}
-	actions, err := evaluatePoliciesForCommand(context.Background(), []string{pol}, payloadNotInKEV, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{})
+	actions, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, payloadNotInKEV, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{})
 	if err != nil {
 		t.Fatalf("unexpected error for vulnerability not in KEV: %v", err)
 	}
@@ -496,7 +490,6 @@ policies:
 		}
 	}
 
-	
 	payloadNoKEV := map[string]any{
 		"vulnerability": &vulnerabilityv1.Finding{
 			Advisory: &vulnerabilityv1.Advisory{
@@ -508,7 +501,7 @@ policies:
 			// InKev is nil (not set)
 		},
 	}
-	actions, err = evaluatePoliciesForCommand(context.Background(), []string{pol}, payloadNoKEV, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{})
+	actions, err = evaluatePoliciesForCommand(t.Context(), []string{pol}, payloadNoKEV, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{})
 	if err != nil {
 		t.Fatalf("unexpected error for vulnerability without KEV status: %v", err)
 	}
@@ -521,7 +514,7 @@ policies:
 
 func TestPolicyIntegration_EPSSThreshold(t *testing.T) {
 	// Test that EPSS scores are accessible in vulnerability policies
-	
+
 	polContent := `
 policies:
   - name: block-high-epss
@@ -547,7 +540,6 @@ policies:
 		t.Fatalf("failed to write policy file: %v", err)
 	}
 
-	
 	highEPSS := 0.15 // 15% exploitation probability
 	payloadHighEPSS := map[string]any{
 		"vulnerability": &vulnerabilityv1.Finding{
@@ -560,11 +552,10 @@ policies:
 			Epss: &highEPSS,
 		},
 	}
-	if _, err := evaluatePoliciesForCommand(context.Background(), []string{pol}, payloadHighEPSS, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{}); err == nil {
+	if _, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, payloadHighEPSS, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{}); err == nil {
 		t.Fatal("expected denial for vulnerability with high EPSS")
 	}
 
-	
 	mediumEPSS := 0.07 // 7% exploitation probability
 	payloadMediumEPSS := map[string]any{
 		"vulnerability": &vulnerabilityv1.Finding{
@@ -577,7 +568,7 @@ policies:
 			Epss: &mediumEPSS,
 		},
 	}
-	actions, err := evaluatePoliciesForCommand(context.Background(), []string{pol}, payloadMediumEPSS, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{})
+	actions, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, payloadMediumEPSS, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{})
 	if err != nil {
 		t.Fatalf("unexpected error for vulnerability with medium EPSS: %v", err)
 	}
@@ -585,7 +576,6 @@ policies:
 		t.Fatalf("expected warn for vulnerability with medium EPSS, got %+v", actions)
 	}
 
-	
 	lowEPSS := 0.01 // 1% exploitation probability
 	payloadLowEPSS := map[string]any{
 		"vulnerability": &vulnerabilityv1.Finding{
@@ -598,7 +588,7 @@ policies:
 			Epss: &lowEPSS,
 		},
 	}
-	actions, err = evaluatePoliciesForCommand(context.Background(), []string{pol}, payloadLowEPSS, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{})
+	actions, err = evaluatePoliciesForCommand(t.Context(), []string{pol}, payloadLowEPSS, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{})
 	if err != nil {
 		t.Fatalf("unexpected error for vulnerability with low EPSS: %v", err)
 	}
@@ -608,7 +598,6 @@ policies:
 		}
 	}
 
-	
 	payloadNoEPSS := map[string]any{
 		"vulnerability": &vulnerabilityv1.Finding{
 			Advisory: &vulnerabilityv1.Advisory{
@@ -620,7 +609,7 @@ policies:
 			// Epss is nil (not set)
 		},
 	}
-	actions, err = evaluatePoliciesForCommand(context.Background(), []string{pol}, payloadNoEPSS, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{})
+	actions, err = evaluatePoliciesForCommand(t.Context(), []string{pol}, payloadNoEPSS, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{})
 	if err != nil {
 		t.Fatalf("unexpected error for vulnerability without EPSS: %v", err)
 	}
@@ -633,7 +622,7 @@ policies:
 
 func TestPolicyIntegration_CompositeRiskScore(t *testing.T) {
 	// Test composite risk scoring using multiple factors (KEV, EPSS, severity)
-	
+
 	polContent := `
 policies:
   - name: composite-risk
@@ -659,7 +648,6 @@ policies:
 		t.Fatalf("failed to write policy file: %v", err)
 	}
 
-	
 	inKEV := true
 	epss03 := 0.3
 	payloadCriticalKEV := map[string]any{
@@ -674,11 +662,10 @@ policies:
 			Epss:  &epss03,
 		},
 	}
-	if _, err := evaluatePoliciesForCommand(context.Background(), []string{pol}, payloadCriticalKEV, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{}); err == nil {
+	if _, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, payloadCriticalKEV, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{}); err == nil {
 		t.Fatal("expected denial for Critical + KEV vulnerability")
 	}
 
-	
 	notInKEV := false
 	epss06 := 0.6
 	payloadHighEPSS := map[string]any{
@@ -693,11 +680,10 @@ policies:
 			Epss:  &epss06,
 		},
 	}
-	if _, err := evaluatePoliciesForCommand(context.Background(), []string{pol}, payloadHighEPSS, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{}); err == nil {
+	if _, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, payloadHighEPSS, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{}); err == nil {
 		t.Fatal("expected denial for High severity + very high EPSS")
 	}
 
-	
 	payloadMediumHighEPSS := map[string]any{
 		"vulnerability": &vulnerabilityv1.Finding{
 			Advisory: &vulnerabilityv1.Advisory{
@@ -710,7 +696,7 @@ policies:
 			Epss:  &epss06,
 		},
 	}
-	actions, err := evaluatePoliciesForCommand(context.Background(), []string{pol}, payloadMediumHighEPSS, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{})
+	actions, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, payloadMediumHighEPSS, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{})
 	if err != nil {
 		t.Fatalf("unexpected error for Medium + high EPSS: %v", err)
 	}

--- a/internal/cli/cmd/policy_repl_test.go
+++ b/internal/cli/cmd/policy_repl_test.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"context"
 	"slices"
 	"strings"
 	"testing"
@@ -28,7 +27,7 @@ func TestPolicyREPLCommands(t *testing.T) {
 	}, "\n")
 	in := strings.NewReader(script)
 	var out bytes.Buffer
-	if err := runPolicyREPL(context.Background(), in, &out); err != nil {
+	if err := runPolicyREPL(t.Context(), in, &out); err != nil {
 		t.Fatalf("runPolicyREPL error: %v", err)
 	}
 	text := out.String()

--- a/internal/cli/cmd/proxy_exec_test.go
+++ b/internal/cli/cmd/proxy_exec_test.go
@@ -202,7 +202,7 @@ func TestRunProxyExecSetsEnv(t *testing.T) {
 		upstream:  "https://proxy.golang.org",
 		envPrep:   prepareGoEnv,
 	}
-	if err := runProxyExec(context.Background(), cfg, []string{"echo"}, nil, io.Discard, io.Discard); err != nil {
+	if err := runProxyExec(t.Context(), cfg, []string{"echo"}, nil, io.Discard, io.Discard); err != nil {
 		t.Fatalf("runProxyExec error: %v", err)
 	}
 	if !containsEnv(captured, "GOPROXY=http://127.0.0.1:5555,direct") {
@@ -224,7 +224,7 @@ func TestStartProxyInstance(t *testing.T) {
 		t.Fatalf("http get: %v", err)
 	}
 	resp.Body.Close()
-	if err := inst.stop(context.Background()); err != nil {
+	if err := inst.stop(t.Context()); err != nil {
 		t.Fatalf("stop error: %v", err)
 	}
 }

--- a/internal/cli/cmd/scan_sbom_roundtrip_test.go
+++ b/internal/cli/cmd/scan_sbom_roundtrip_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"archive/tar"
 	"bytes"
-	"context"
 	"os"
 	"path/filepath"
 	"slices"
@@ -27,7 +26,7 @@ func TestSBOMImageRoundTrip(t *testing.T) {
 	target := "tarball://" + tarPath
 
 	// Generate SBOM from image
-	result, err := sbomx.GenerateImage(context.Background(), target, nil, sbomx.Options{
+	result, err := sbomx.GenerateImage(t.Context(), target, nil, sbomx.Options{
 		Ecosystems: []string{"go"},
 	})
 	if err != nil {
@@ -166,7 +165,7 @@ func TestSBOMLayerDetailsRoundTrip(t *testing.T) {
 	tarPath := buildMultiLayerTestImage(t)
 	target := "tarball://" + tarPath
 
-	result, err := sbomx.GenerateImage(context.Background(), target, nil, sbomx.Options{
+	result, err := sbomx.GenerateImage(t.Context(), target, nil, sbomx.Options{
 		Ecosystems: []string{"go"},
 	})
 	if err != nil {

--- a/internal/cli/cmd/triage_test.go
+++ b/internal/cli/cmd/triage_test.go
@@ -305,7 +305,7 @@ func newTriageTestCommand(t *testing.T) *cobra.Command {
 			return nil
 		},
 	}
-	cmd.SetContext(context.Background())
+	cmd.SetContext(t.Context())
 	cmd.SetIn(strings.NewReader(""))
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})

--- a/internal/demo/github-org-inventory/main_test.go
+++ b/internal/demo/github-org-inventory/main_test.go
@@ -14,7 +14,7 @@ import (
 func TestCollectRowsFromPackages(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	pkgs := []*extractor.Package{
 		{
 			Name:      "github.com/example/foo",
@@ -93,7 +93,7 @@ func main() {}
 		return []string{"Test-License"}
 	}
 
-	rows, err := inventoryFromWorkspace(context.Background(), "demo-repo", ws, []string{"go"}, resolve)
+	rows, err := inventoryFromWorkspace(t.Context(), "demo-repo", ws, []string{"go"}, resolve)
 	if err != nil {
 		t.Fatalf("inventoryFromWorkspace: %v", err)
 	}
@@ -263,7 +263,7 @@ func TestLooksLikeSHA(t *testing.T) {
 		{"v2.0.0", false},
 		{"main", false},
 		{"master", false},
-		{"b62528385c34dbc9f38e5f4225ac829252d1ea9", false},  // 39 chars
+		{"b62528385c34dbc9f38e5f4225ac829252d1ea9", false},   // 39 chars
 		{"b62528385c34dbc9f38e5f4225ac829252d1ea921", false}, // 41 chars
 		{"g62528385c34dbc9f38e5f4225ac829252d1ea92", false},  // non-hex char
 	}
@@ -289,12 +289,12 @@ func TestLooksLikeShortSHA(t *testing.T) {
 		{"abcdef1", true},
 
 		// Not short SHA
-		{"v4", false},        // starts with v + digit
-		{"v2.0.0", false},    // version with dots
-		{"1.2.3", false},     // has dots
-		{"abc", false},       // too short
-		{"abcdefg", false},   // has 'g' (non-hex)
-		{"main", false},      // has non-hex
+		{"v4", false},          // starts with v + digit
+		{"v2.0.0", false},      // version with dots
+		{"1.2.3", false},       // has dots
+		{"abc", false},         // too short
+		{"abcdefg", false},     // has 'g' (non-hex)
+		{"main", false},        // has non-hex
 		{"releases/v1", false}, // has slash
 	}
 

--- a/internal/demo/github-org-inventory/output_validation_test.go
+++ b/internal/demo/github-org-inventory/output_validation_test.go
@@ -145,7 +145,7 @@ func sampleStrings(in []string, n int) []string {
 func TestPackagistLookup(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	cases := []struct {
 		name    string
 		version string
@@ -171,7 +171,7 @@ func TestPackagistLookup(t *testing.T) {
 func TestPubLookup(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	cases := []struct {
 		name    string
 		version string
@@ -196,7 +196,7 @@ func TestPubLookup(t *testing.T) {
 func TestCocoaPodsLookup(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	cases := []struct {
 		name    string
 		version string
@@ -220,7 +220,7 @@ func TestCocoaPodsLookup(t *testing.T) {
 func TestHexLookup(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	cases := []struct {
 		name    string
 		version string
@@ -246,7 +246,7 @@ func TestHexLookup(t *testing.T) {
 func TestCratesLookup(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	cases := []struct {
 		name    string
 		version string
@@ -303,7 +303,7 @@ func TestLicenseVerificationSample(t *testing.T) {
 			if len(rows) == 0 {
 				t.Skip("no rows to verify")
 			}
-			ctx := context.Background()
+			ctx := t.Context()
 			checked := 0
 			for _, r := range rows {
 				if r.License == "" || r.License == "?" {

--- a/internal/dependency/graph/resolve_cargo_test.go
+++ b/internal/dependency/graph/resolve_cargo_test.go
@@ -1,7 +1,6 @@
 package graph
 
 import (
-	"context"
 	"testing"
 )
 
@@ -93,7 +92,7 @@ tokio = "1.32"
 	})
 
 	resolver := NewCargoResolver()
-	err := resolver.ResolveEdges(context.Background(), g, files)
+	err := resolver.ResolveEdges(t.Context(), g, files)
 	if err != nil {
 		t.Fatalf("ResolveEdges failed: %v", err)
 	}

--- a/internal/dependency/graph/resolve_go_test.go
+++ b/internal/dependency/graph/resolve_go_test.go
@@ -1,7 +1,6 @@
 package graph
 
 import (
-	"context"
 	"testing"
 )
 
@@ -70,7 +69,7 @@ require (
 	})
 
 	resolver := NewGoResolver()
-	err := resolver.ResolveEdges(context.Background(), g, files)
+	err := resolver.ResolveEdges(t.Context(), g, files)
 	if err != nil {
 		t.Fatalf("ResolveEdges failed: %v", err)
 	}
@@ -144,7 +143,7 @@ require github.com/pkg/errors v0.9.1
 	})
 
 	resolver := NewGoResolver()
-	err := resolver.ResolveEdges(context.Background(), g, files)
+	err := resolver.ResolveEdges(t.Context(), g, files)
 	if err != nil {
 		t.Fatalf("ResolveEdges failed: %v", err)
 	}

--- a/internal/dependency/graph/resolve_hex_test.go
+++ b/internal/dependency/graph/resolve_hex_test.go
@@ -1,7 +1,6 @@
 package graph
 
 import (
-	"context"
 	"testing"
 )
 
@@ -32,7 +31,7 @@ func TestHexResolver_ResolveEdges_MixLock(t *testing.T) {
 	g := New()
 	r := NewHexResolver()
 
-	err := r.ResolveEdges(context.Background(), g, files)
+	err := r.ResolveEdges(t.Context(), g, files)
 	if err != nil {
 		t.Fatalf("ResolveEdges() error = %v", err)
 	}
@@ -94,7 +93,7 @@ func TestHexResolver_ResolveEdges_GitDependency(t *testing.T) {
 	g := New()
 	r := NewHexResolver()
 
-	err := r.ResolveEdges(context.Background(), g, files)
+	err := r.ResolveEdges(t.Context(), g, files)
 	if err != nil {
 		t.Fatalf("ResolveEdges() error = %v", err)
 	}
@@ -129,7 +128,7 @@ func TestHexResolver_ResolveEdges_NoFiles(t *testing.T) {
 	g := New()
 	r := NewHexResolver()
 
-	err := r.ResolveEdges(context.Background(), g, files)
+	err := r.ResolveEdges(t.Context(), g, files)
 	if err != nil {
 		t.Fatalf("ResolveEdges() error = %v", err)
 	}

--- a/internal/dependency/graph/resolve_maven_test.go
+++ b/internal/dependency/graph/resolve_maven_test.go
@@ -1,7 +1,6 @@
 package graph
 
 import (
-	"context"
 	"testing"
 )
 
@@ -53,7 +52,7 @@ func TestMavenResolver_ResolveEdges_PomXML(t *testing.T) {
 	g := New()
 	r := NewMavenResolver()
 
-	err := r.ResolveEdges(context.Background(), g, files)
+	err := r.ResolveEdges(t.Context(), g, files)
 	if err != nil {
 		t.Fatalf("ResolveEdges() error = %v", err)
 	}
@@ -115,7 +114,7 @@ empty=`
 	g := New()
 	r := NewMavenResolver()
 
-	err := r.ResolveEdges(context.Background(), g, files)
+	err := r.ResolveEdges(t.Context(), g, files)
 	if err != nil {
 		t.Fatalf("ResolveEdges() error = %v", err)
 	}
@@ -181,7 +180,7 @@ func TestMavenResolver_ResolveEdges_ParentInheritance(t *testing.T) {
 	g := New()
 	r := NewMavenResolver()
 
-	err := r.ResolveEdges(context.Background(), g, files)
+	err := r.ResolveEdges(t.Context(), g, files)
 	if err != nil {
 		t.Fatalf("ResolveEdges() error = %v", err)
 	}
@@ -234,7 +233,7 @@ func TestMavenResolver_ResolveEdges_DependencyManagement(t *testing.T) {
 	g := New()
 	r := NewMavenResolver()
 
-	err := r.ResolveEdges(context.Background(), g, files)
+	err := r.ResolveEdges(t.Context(), g, files)
 	if err != nil {
 		t.Fatalf("ResolveEdges() error = %v", err)
 	}
@@ -254,7 +253,7 @@ func TestMavenResolver_ResolveEdges_NoFiles(t *testing.T) {
 	g := New()
 	r := NewMavenResolver()
 
-	err := r.ResolveEdges(context.Background(), g, files)
+	err := r.ResolveEdges(t.Context(), g, files)
 	if err != nil {
 		t.Fatalf("ResolveEdges() error = %v", err)
 	}

--- a/internal/dependency/graph/resolve_npm_test.go
+++ b/internal/dependency/graph/resolve_npm_test.go
@@ -1,7 +1,6 @@
 package graph
 
 import (
-	"context"
 	"testing"
 )
 
@@ -72,7 +71,7 @@ func TestNpmResolver_ResolveEdges_PackageLockV3(t *testing.T) {
 	})
 
 	resolver := NewNpmResolver()
-	err := resolver.ResolveEdges(context.Background(), g, files)
+	err := resolver.ResolveEdges(t.Context(), g, files)
 	if err != nil {
 		t.Fatalf("ResolveEdges failed: %v", err)
 	}
@@ -156,7 +155,7 @@ func TestNpmResolver_ResolveEdges_PackageLockV1(t *testing.T) {
 	})
 
 	resolver := NewNpmResolver()
-	err := resolver.ResolveEdges(context.Background(), g, files)
+	err := resolver.ResolveEdges(t.Context(), g, files)
 	if err != nil {
 		t.Fatalf("ResolveEdges failed: %v", err)
 	}
@@ -216,7 +215,7 @@ func TestNpmResolver_ScopedPackages(t *testing.T) {
 	})
 
 	resolver := NewNpmResolver()
-	err := resolver.ResolveEdges(context.Background(), g, files)
+	err := resolver.ResolveEdges(t.Context(), g, files)
 	if err != nil {
 		t.Fatalf("ResolveEdges failed: %v", err)
 	}
@@ -364,7 +363,7 @@ inherits@^2.0.3:
 	})
 
 	resolver := NewNpmResolver()
-	err := resolver.ResolveEdges(context.Background(), g, files)
+	err := resolver.ResolveEdges(t.Context(), g, files)
 	if err != nil {
 		t.Fatalf("ResolveEdges failed: %v", err)
 	}
@@ -544,7 +543,7 @@ packages:
 	})
 
 	resolver := NewNpmResolver()
-	err := resolver.ResolveEdges(context.Background(), g, files)
+	err := resolver.ResolveEdges(t.Context(), g, files)
 	if err != nil {
 		t.Fatalf("ResolveEdges failed: %v", err)
 	}

--- a/internal/dependency/graph/resolve_nuget_test.go
+++ b/internal/dependency/graph/resolve_nuget_test.go
@@ -1,7 +1,6 @@
 package graph
 
 import (
-	"context"
 	"testing"
 )
 
@@ -71,7 +70,7 @@ func TestNuGetResolver_ResolveEdges_PackagesLockJSON(t *testing.T) {
 	g := New()
 	r := NewNuGetResolver()
 
-	err := r.ResolveEdges(context.Background(), g, files)
+	err := r.ResolveEdges(t.Context(), g, files)
 	if err != nil {
 		t.Fatalf("ResolveEdges() error = %v", err)
 	}
@@ -135,7 +134,7 @@ func TestNuGetResolver_ResolveEdges_PackagesConfig(t *testing.T) {
 	g := New()
 	r := NewNuGetResolver()
 
-	err := r.ResolveEdges(context.Background(), g, files)
+	err := r.ResolveEdges(t.Context(), g, files)
 	if err != nil {
 		t.Fatalf("ResolveEdges() error = %v", err)
 	}
@@ -183,7 +182,7 @@ func TestNuGetResolver_ResolveEdges_NoFiles(t *testing.T) {
 	g := New()
 	r := NewNuGetResolver()
 
-	err := r.ResolveEdges(context.Background(), g, files)
+	err := r.ResolveEdges(t.Context(), g, files)
 	if err != nil {
 		t.Fatalf("ResolveEdges() error = %v", err)
 	}

--- a/internal/dependency/graph/resolve_pub_test.go
+++ b/internal/dependency/graph/resolve_pub_test.go
@@ -1,7 +1,6 @@
 package graph
 
 import (
-	"context"
 	"testing"
 )
 
@@ -80,7 +79,7 @@ sdks:
 	g := New()
 	r := NewPubResolver()
 
-	err := r.ResolveEdges(context.Background(), g, files)
+	err := r.ResolveEdges(t.Context(), g, files)
 	if err != nil {
 		t.Fatalf("ResolveEdges() error = %v", err)
 	}
@@ -159,7 +158,7 @@ sdks:
 	g := New()
 	r := NewPubResolver()
 
-	err := r.ResolveEdges(context.Background(), g, files)
+	err := r.ResolveEdges(t.Context(), g, files)
 	if err != nil {
 		t.Fatalf("ResolveEdges() error = %v", err)
 	}
@@ -196,7 +195,7 @@ func TestPubResolver_ResolveEdges_NoFiles(t *testing.T) {
 	g := New()
 	r := NewPubResolver()
 
-	err := r.ResolveEdges(context.Background(), g, files)
+	err := r.ResolveEdges(t.Context(), g, files)
 	if err != nil {
 		t.Fatalf("ResolveEdges() error = %v", err)
 	}
@@ -287,7 +286,7 @@ sdks:
 	g := New()
 	r := NewPubResolver()
 
-	err := r.ResolveEdges(context.Background(), g, files)
+	err := r.ResolveEdges(t.Context(), g, files)
 	if err != nil {
 		t.Fatalf("ResolveEdges() error = %v", err)
 	}

--- a/internal/dependency/graph/resolve_pypi_test.go
+++ b/internal/dependency/graph/resolve_pypi_test.go
@@ -1,7 +1,6 @@
 package graph
 
 import (
-	"context"
 	"testing"
 )
 
@@ -42,8 +41,8 @@ requests = "^2.28"
 
 	files := &mockFileReader{
 		files: map[string][]byte{
-			"poetry.lock":     []byte(poetryLock),
-			"pyproject.toml":  []byte(pyprojectToml),
+			"poetry.lock":    []byte(poetryLock),
+			"pyproject.toml": []byte(pyprojectToml),
 		},
 	}
 
@@ -68,7 +67,7 @@ requests = "^2.28"
 	})
 
 	resolver := NewPyPIResolver()
-	err := resolver.ResolveEdges(context.Background(), g, files)
+	err := resolver.ResolveEdges(t.Context(), g, files)
 	if err != nil {
 		t.Fatalf("ResolveEdges failed: %v", err)
 	}
@@ -146,7 +145,7 @@ pytest>=7.0.0
 	})
 
 	resolver := NewPyPIResolver()
-	err := resolver.ResolveEdges(context.Background(), g, files)
+	err := resolver.ResolveEdges(t.Context(), g, files)
 	if err != nil {
 		t.Fatalf("ResolveEdges failed: %v", err)
 	}

--- a/internal/dependency/graph/resolve_rubygems_test.go
+++ b/internal/dependency/graph/resolve_rubygems_test.go
@@ -1,7 +1,6 @@
 package graph
 
 import (
-	"context"
 	"testing"
 )
 
@@ -77,7 +76,7 @@ BUNDLED WITH
 	})
 
 	resolver := NewRubyGemsResolver()
-	err := resolver.ResolveEdges(context.Background(), g, files)
+	err := resolver.ResolveEdges(t.Context(), g, files)
 	if err != nil {
 		t.Fatalf("ResolveEdges failed: %v", err)
 	}

--- a/internal/dependency/graph/resolver_test.go
+++ b/internal/dependency/graph/resolver_test.go
@@ -1,7 +1,6 @@
 package graph
 
 import (
-	"context"
 	"testing"
 )
 
@@ -110,7 +109,7 @@ require github.com/pkg/errors v0.9.1
 		Ecosystem: "Go",
 	})
 
-	err := registry.ResolveAll(context.Background(), g, files)
+	err := registry.ResolveAll(t.Context(), g, files)
 	if err != nil {
 		t.Fatalf("ResolveAll failed: %v", err)
 	}

--- a/internal/explain/renderer_test.go
+++ b/internal/explain/renderer_test.go
@@ -2,7 +2,6 @@ package explain
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -202,7 +201,7 @@ func TestRenderJSON_GoldenShape(t *testing.T) {
 
 	r := NewRenderer(Config{Enrich: false})
 	var buf bytes.Buffer
-	if err := r.RenderJSON(context.Background(), &buf, vuln); err != nil {
+	if err := r.RenderJSON(t.Context(), &buf, vuln); err != nil {
 		t.Fatalf("RenderJSON: %v", err)
 	}
 
@@ -227,7 +226,7 @@ func TestRenderJSON_GoldenShape(t *testing.T) {
 func TestRender_NilVulnIsNoOp(t *testing.T) {
 	r := NewRenderer(Config{})
 	var buf bytes.Buffer
-	if err := r.Render(context.Background(), &buf, nil); err != nil {
+	if err := r.Render(t.Context(), &buf, nil); err != nil {
 		t.Fatalf("Render(nil): %v", err)
 	}
 	if buf.Len() != 0 {
@@ -249,7 +248,7 @@ func TestRender_TextSmoke(t *testing.T) {
 
 	r := NewRenderer(Config{Enrich: false})
 	var buf bytes.Buffer
-	if err := r.Render(context.Background(), &buf, vuln); err != nil {
+	if err := r.Render(t.Context(), &buf, vuln); err != nil {
 		t.Fatalf("Render: %v", err)
 	}
 	out := buf.String()

--- a/internal/forge/github/client_test.go
+++ b/internal/forge/github/client_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestCheckRetry(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tests := []struct {
 		name       string
@@ -51,7 +51,7 @@ func TestCheckRetry(t *testing.T) {
 }
 
 func TestCheckRetryNilResp(t *testing.T) {
-	got, err := checkRetry(context.Background(), nil, nil)
+	got, err := checkRetry(t.Context(), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +61,7 @@ func TestCheckRetryNilResp(t *testing.T) {
 }
 
 func TestCheckRetryConnectionError(t *testing.T) {
-	got, err := checkRetry(context.Background(), nil, &net.DNSError{})
+	got, err := checkRetry(t.Context(), nil, &net.DNSError{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +71,7 @@ func TestCheckRetryConnectionError(t *testing.T) {
 }
 
 func TestCheckRetryContextCancelled(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
 	got, err := checkRetry(ctx, nil, nil)

--- a/internal/gitutil/clone_test.go
+++ b/internal/gitutil/clone_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestCloneContext_InvalidURL(t *testing.T) {
 	dir := t.TempDir()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	_, cleanup, err := CloneContext(ctx, dir, &git.CloneOptions{
@@ -27,7 +27,7 @@ func TestCloneContext_InvalidURL(t *testing.T) {
 
 func TestCloneContext_CancelledContext(t *testing.T) {
 	dir := t.TempDir()
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // Cancel immediately
 
 	_, cleanup, err := CloneContext(ctx, dir, &git.CloneOptions{
@@ -65,7 +65,7 @@ func TestCloneContext_LocalRepo(t *testing.T) {
 
 	// Clone to a new directory
 	destDir := t.TempDir()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	clonedRepo, cleanup, err := CloneContext(ctx, destDir, &git.CloneOptions{
 		URL: srcDir,

--- a/internal/inventory/collector_ref_test.go
+++ b/internal/inventory/collector_ref_test.go
@@ -1,7 +1,6 @@
 package inventory_test
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -64,7 +63,7 @@ func TestCollectRepositoryHonorsRef(t *testing.T) {
 	}
 	firstCommit := commitGoMod(t, dir, repo, "github.com/pkg/errors v0.8.1", "initial")
 	secondCommit := commitGoMod(t, dir, repo, "github.com/pkg/errors v0.9.1", "bump errors")
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("HEAD~1 reads the previous commit's tree", func(t *testing.T) {
 		exec, err := inventory.CollectRepository(ctx, dir, "HEAD~1", true, inventory.Options{})
@@ -149,7 +148,7 @@ func TestCollectRepositoryAtRefDetectsMultiEcosystemDirects(t *testing.T) {
 		"requirements.txt": "flask==2.3.0\n",
 	}, "multi-ecosystem manifests")
 
-	exec, err := inventory.CollectRepository(context.Background(), dir, hash, true, inventory.Options{})
+	exec, err := inventory.CollectRepository(t.Context(), dir, hash, true, inventory.Options{})
 	if err != nil {
 		t.Fatalf("CollectRepository: %v", err)
 	}

--- a/internal/inventory/plugins/asdf/asdfx/asdfx_test.go
+++ b/internal/inventory/plugins/asdf/asdfx/asdfx_test.go
@@ -1,7 +1,6 @@
 package asdfx
 
 import (
-	"context"
 	"io/fs"
 	"strings"
 	"testing"
@@ -49,7 +48,7 @@ func TestFileRequired(t *testing.T) {
 func TestExtract(t *testing.T) {
 	content := "nodejs 22.5.0\npython 3.11 3.12\nruby system\ngolang ref:abc\n"
 	ext := New()
-	inv, err := ext.Extract(context.Background(), &filesystem.ScanInput{
+	inv, err := ext.Extract(t.Context(), &filesystem.ScanInput{
 		Path:   ".tool-versions",
 		Reader: strings.NewReader(content),
 	})

--- a/internal/inventory/plugins/docker/dockerfilex/dockerfile_test.go
+++ b/internal/inventory/plugins/docker/dockerfilex/dockerfile_test.go
@@ -1,7 +1,6 @@
 package dockerfilex
 
 import (
-	"context"
 	"io/fs"
 	"strings"
 	"testing"
@@ -156,7 +155,7 @@ CMD ["/app"]
 				Reader: strings.NewReader(tt.content),
 			}
 
-			inv, err := ext.Extract(context.Background(), input)
+			inv, err := ext.Extract(t.Context(), input)
 			if err != nil {
 				t.Fatalf("Extract() error = %v", err)
 			}
@@ -193,7 +192,7 @@ func TestExtract_BaseImageMetadata(t *testing.T) {
 			Path:   "Dockerfile",
 			Reader: strings.NewReader("ARG ALPINE_TAG\nFROM alpine:${ALPINE_TAG}\n"),
 		}
-		inv, err := ext.Extract(context.Background(), input)
+		inv, err := ext.Extract(t.Context(), input)
 		if err != nil {
 			t.Fatalf("Extract() error = %v", err)
 		}
@@ -217,7 +216,7 @@ func TestExtract_BaseImageMetadata(t *testing.T) {
 			Path:   "Dockerfile",
 			Reader: strings.NewReader("FROM alpine:3.19\n"),
 		}
-		inv, err := ext.Extract(context.Background(), input)
+		inv, err := ext.Extract(t.Context(), input)
 		if err != nil {
 			t.Fatalf("Extract() error = %v", err)
 		}

--- a/internal/inventory/plugins/github/actionsx/actions_test.go
+++ b/internal/inventory/plugins/github/actionsx/actions_test.go
@@ -1,7 +1,6 @@
 package actionsx
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"slices"
@@ -105,7 +104,7 @@ jobs:
 			}
 			defer f.Close()
 			ext := &Extractor{}
-			inv, err := ext.Extract(context.Background(), &filesystem.ScanInput{
+			inv, err := ext.Extract(t.Context(), &filesystem.ScanInput{
 				FS:     fs,
 				Path:   filepath.ToSlash(tc.entry),
 				Reader: f,
@@ -145,7 +144,7 @@ jobs:
 	defer f.Close()
 
 	ext := &Extractor{}
-	inv, err := ext.Extract(context.Background(), &filesystem.ScanInput{
+	inv, err := ext.Extract(t.Context(), &filesystem.ScanInput{
 		FS:     fs,
 		Path:   ".github/workflows/c.yml",
 		Reader: f,

--- a/internal/inventory/plugins/java/gradlex/gradle_project_test.go
+++ b/internal/inventory/plugins/java/gradlex/gradle_project_test.go
@@ -1,7 +1,6 @@
 package gradlex
 
 import (
-	"context"
 	"io"
 	"io/fs"
 	"slices"
@@ -75,7 +74,7 @@ dependencies {
 		Reader: newBytesReader(memFS["settings.gradle"].Data),
 	}
 
-	inv, err := e.Extract(context.Background(), input)
+	inv, err := e.Extract(t.Context(), input)
 	if err != nil {
 		t.Fatalf("Extract failed: %v", err)
 	}
@@ -141,7 +140,7 @@ dependencies {
 		Reader: newBytesReader(memFS["settings.gradle"].Data),
 	}
 
-	inv, err := e.Extract(context.Background(), input)
+	inv, err := e.Extract(t.Context(), input)
 	if err != nil {
 		t.Fatalf("Extract failed: %v", err)
 	}
@@ -205,7 +204,7 @@ dependencies {
 		Reader: newBytesReader(memFS["settings.gradle"].Data),
 	}
 
-	inv, err := e.Extract(context.Background(), input)
+	inv, err := e.Extract(t.Context(), input)
 	if err != nil {
 		t.Fatalf("Extract failed: %v", err)
 	}
@@ -267,7 +266,7 @@ dependencies {
 		Reader: newBytesReader(memFS["settings.gradle"].Data),
 	}
 
-	inv, err := e.Extract(context.Background(), input)
+	inv, err := e.Extract(t.Context(), input)
 	if err != nil {
 		t.Fatalf("Extract failed: %v", err)
 	}

--- a/internal/inventory/plugins/java/gradlex/verification_metadata_test.go
+++ b/internal/inventory/plugins/java/gradlex/verification_metadata_test.go
@@ -1,7 +1,6 @@
 package gradlex
 
 import (
-	"context"
 	"io"
 	"testing"
 
@@ -142,7 +141,7 @@ func TestVerificationMetadataExtractor_Extract(t *testing.T) {
 		Reader: newBytesReader(content),
 	}
 
-	inv, err := e.Extract(context.Background(), input)
+	inv, err := e.Extract(t.Context(), input)
 	if err != nil {
 		t.Fatalf("Extract failed: %v", err)
 	}

--- a/internal/inventory/plugins/mise/misex/misex_test.go
+++ b/internal/inventory/plugins/mise/misex/misex_test.go
@@ -1,7 +1,6 @@
 package misex
 
 import (
-	"context"
 	"io/fs"
 	"strings"
 	"testing"
@@ -61,7 +60,7 @@ python = ["3.11", "3.12"]
 terraform = "1.9"
 `
 	ext := New()
-	inv, err := ext.Extract(context.Background(), &filesystem.ScanInput{
+	inv, err := ext.Extract(t.Context(), &filesystem.ScanInput{
 		Path:   "mise.toml",
 		Reader: strings.NewReader(content),
 	})
@@ -133,7 +132,7 @@ checksum = "sha256:abc123"
 	if err != nil {
 		t.Fatal(err)
 	}
-	inv, err := ext.Extract(context.Background(), &filesystem.ScanInput{
+	inv, err := ext.Extract(t.Context(), &filesystem.ScanInput{
 		Path:   "mise.toml",
 		Reader: f,
 		FS:     fsys,

--- a/internal/license/license_test.go
+++ b/internal/license/license_test.go
@@ -25,7 +25,7 @@ func (f *fakeDepsClientErr) GetVersion(ctx context.Context, req *pb.GetVersionRe
 func Test_FetchLicensesForPackage_success(t *testing.T) {
 	ResetLicenseCachesForTest(t)
 	client := &fakeDepsClientOK{}
-	got := FetchLicensesForPackage(context.Background(), client, "github.com/example/pkg", "1.2.3")
+	got := FetchLicensesForPackage(t.Context(), client, "github.com/example/pkg", "1.2.3")
 	if len(got) != 1 || got[0] != "MIT" {
 		t.Fatalf("unexpected licenses: %v", got)
 	}
@@ -34,7 +34,7 @@ func Test_FetchLicensesForPackage_success(t *testing.T) {
 func Test_FetchLicensesForPackage_error_returns_unknown(t *testing.T) {
 	ResetLicenseCachesForTest(t)
 	client := &fakeDepsClientErr{}
-	got := FetchLicensesForPackage(context.Background(), client, "github.com/example/pkg", "1.2.3")
+	got := FetchLicensesForPackage(t.Context(), client, "github.com/example/pkg", "1.2.3")
 	if len(got) != 1 || got[0] != "?" {
 		t.Fatalf("expected unknown license on error, got %v", got)
 	}
@@ -51,8 +51,8 @@ func (c *countingDepsClient) GetVersion(ctx context.Context, req *pb.GetVersionR
 func Test_FetchLicensesForPackage_cache(t *testing.T) {
 	ResetLicenseCachesForTest(t)
 	client := &countingDepsClient{}
-	FetchLicensesForPackage(context.Background(), client, "github.com/example/pkg", "1.2.3")
-	FetchLicensesForPackage(context.Background(), client, "github.com/example/pkg", "1.2.3")
+	FetchLicensesForPackage(t.Context(), client, "github.com/example/pkg", "1.2.3")
+	FetchLicensesForPackage(t.Context(), client, "github.com/example/pkg", "1.2.3")
 	if client.calls != 1 {
 		t.Fatalf("expected 1 call, got %d", client.calls)
 	}

--- a/internal/license/licenses_fallback_test.go
+++ b/internal/license/licenses_fallback_test.go
@@ -53,14 +53,14 @@ func TestFetchLicensesForEcosystem_NormalizesAndCaches(t *testing.T) {
 	resetLicenseTestState(t)
 
 	client := &countingDepsClientEcosystem{}
-	got := FetchLicensesForEcosystem(context.Background(), client, "python", "Requests", "2.31.0")
+	got := FetchLicensesForEcosystem(t.Context(), client, "python", "Requests", "2.31.0")
 	if want := []string{"Apache-2.0"}; !slices.Equal(got, want) {
 		t.Fatalf("unexpected licenses: %v", got)
 	}
 	if client.sys != pb.System_PYPI {
 		t.Fatalf("expected PYPI system, got %v", client.sys)
 	}
-	FetchLicensesForEcosystem(context.Background(), client, "python", "Requests", "2.31.0")
+	FetchLicensesForEcosystem(t.Context(), client, "python", "Requests", "2.31.0")
 	if client.calls != 1 {
 		t.Fatalf("expected cache hit to avoid second call, got %d calls", client.calls)
 	}
@@ -99,11 +99,11 @@ SOFTWARE.`
 	restoreBases := WithLicenseEndpoints(server.URL, cratesBase, packagistBase, pubBase, cocoapodsBase, hexpmBase)
 	defer restoreBases()
 
-	if got := GoProxyLicenseScan(context.Background(), "example.com/mod", "v1.2.3"); !slices.Equal(got, []string{"MIT"}) {
+	if got := GoProxyLicenseScan(t.Context(), "example.com/mod", "v1.2.3"); !slices.Equal(got, []string{"MIT"}) {
 		t.Fatalf("expected go proxy direct scan to return MIT, got %v", got)
 	}
 
-	licenses := LookupLicensesBestEffort(context.Background(), "go", "example.com/mod", "v1.2.3")
+	licenses := LookupLicensesBestEffort(t.Context(), "go", "example.com/mod", "v1.2.3")
 	if want := []string{"MIT"}; !slices.Equal(licenses, want) {
 		t.Fatalf("expected go proxy license, got %v", licenses)
 	}
@@ -128,7 +128,7 @@ func TestLookupLicensesBestEffort_Crates(t *testing.T) {
 	restoreBases := WithLicenseEndpoints(goProxyBase, server.URL, packagistBase, pubBase, cocoapodsBase, hexpmBase)
 	defer restoreBases()
 
-	got := LookupLicensesBestEffort(context.Background(), "rust", "serde", "1.0.0")
+	got := LookupLicensesBestEffort(t.Context(), "rust", "serde", "1.0.0")
 	if want := []string{"MIT"}; !slices.Equal(got, want) {
 		t.Fatalf("expected crates.io license, got %v", got)
 	}
@@ -159,7 +159,7 @@ func TestLookupLicensesBestEffort_Packagist(t *testing.T) {
 		restoreBases := WithLicenseEndpoints(goProxyBase, cratesBase, server.URL, pubBase, cocoapodsBase, hexpmBase)
 		defer restoreBases()
 
-		got := LookupLicensesBestEffort(context.Background(), "php", "laravel/framework", "10.0.0")
+		got := LookupLicensesBestEffort(t.Context(), "php", "laravel/framework", "10.0.0")
 		if want := []string{"BSD-3-Clause"}; !slices.Equal(got, want) {
 			t.Fatalf("expected packagist license, got %v", got)
 		}
@@ -189,7 +189,7 @@ func TestLookupLicensesBestEffort_Packagist(t *testing.T) {
 		restoreBases := WithLicenseEndpoints(goProxyBase, cratesBase, server.URL, pubBase, cocoapodsBase, hexpmBase)
 		defer restoreBases()
 
-		got := LookupLicensesBestEffort(context.Background(), "composer", "vendor/name", "1.2.3")
+		got := LookupLicensesBestEffort(t.Context(), "composer", "vendor/name", "1.2.3")
 		if want := []string{"Apache-2.0"}; !slices.Equal(got, want) {
 			t.Fatalf("expected packagist legacy license, got %v", got)
 		}
@@ -241,7 +241,7 @@ SOFTWARE.`
 	restoreBases := WithLicenseEndpoints(goProxyBase, cratesBase, packagistBase, server.URL, cocoapodsBase, hexpmBase)
 	defer restoreBases()
 
-	got := LookupLicensesBestEffort(context.Background(), "dart", "riverpod", "1.0.0")
+	got := LookupLicensesBestEffort(t.Context(), "dart", "riverpod", "1.0.0")
 	if want := []string{"MIT"}; !slices.Equal(got, want) {
 		t.Fatalf("expected pub license, got %v", got)
 	}
@@ -268,7 +268,7 @@ func TestLookupLicensesBestEffort_CocoaPods(t *testing.T) {
 	restoreBases := WithLicenseEndpoints(goProxyBase, cratesBase, packagistBase, pubBase, server.URL, hexpmBase)
 	defer restoreBases()
 
-	got := LookupLicensesBestEffort(context.Background(), "cocoapods", "Alamofire", "5.9.1")
+	got := LookupLicensesBestEffort(t.Context(), "cocoapods", "Alamofire", "5.9.1")
 	if want := []string{"MIT"}; !slices.Equal(got, want) {
 		t.Fatalf("expected cocoapods license, got %v", got)
 	}
@@ -289,7 +289,7 @@ func TestLookupLicensesBestEffort_Hex(t *testing.T) {
 	restoreBases := WithLicenseEndpoints(goProxyBase, cratesBase, packagistBase, pubBase, cocoapodsBase, server.URL)
 	defer restoreBases()
 
-	got := LookupLicensesBestEffort(context.Background(), "hex", "plug", "1.12.0")
+	got := LookupLicensesBestEffort(t.Context(), "hex", "plug", "1.12.0")
 	if want := []string{"Apache-2.0"}; !slices.Equal(got, want) {
 		t.Fatalf("expected hex license, got %v", got)
 	}
@@ -336,13 +336,13 @@ func TestLookupLicensesBestEffort_WellKnown(t *testing.T) {
 	resetLicenseTestState(t)
 
 	// Go stdlib should return BSD-3-Clause without any network calls
-	got := LookupLicensesBestEffort(context.Background(), "go", "stdlib", "")
+	got := LookupLicensesBestEffort(t.Context(), "go", "stdlib", "")
 	if want := []string{"BSD-3-Clause"}; !slices.Equal(got, want) {
 		t.Fatalf("expected Go stdlib license %v, got %v", want, got)
 	}
 
 	// toolchain should also work
-	got = LookupLicensesBestEffort(context.Background(), "golang", "toolchain", "go1.21.0")
+	got = LookupLicensesBestEffort(t.Context(), "golang", "toolchain", "go1.21.0")
 	if want := []string{"BSD-3-Clause"}; !slices.Equal(got, want) {
 		t.Fatalf("expected toolchain license %v, got %v", want, got)
 	}
@@ -371,7 +371,7 @@ func TestLookupLicensesBestEffort_GitHubWithoutVersion(t *testing.T) {
 	defer restoreClient()
 
 	// GitHub Actions without version should still work
-	got := LookupLicensesBestEffort(context.Background(), "github", "actions/checkout", "")
+	got := LookupLicensesBestEffort(t.Context(), "github", "actions/checkout", "")
 	if want := []string{"MIT"}; !slices.Equal(got, want) {
 		t.Fatalf("expected GitHub Actions license %v without version, got %v", want, got)
 	}
@@ -415,7 +415,7 @@ func TestRemoteModuleLicenseScan_GitHubVersionedUsesRequestedRef(t *testing.T) {
 	restoreBases := WithLicenseEndpoints(server.URL, cratesBase, packagistBase, pubBase, cocoapodsBase, hexpmBase)
 	defer restoreBases()
 
-	got := RemoteModuleLicenseScan(context.Background(), "github.com/owner/repo", version)
+	got := RemoteModuleLicenseScan(t.Context(), "github.com/owner/repo", version)
 	if want := []string{"MIT"}; !slices.Equal(got, want) {
 		t.Fatalf("expected requested-ref license %v, got %v", want, got)
 	}
@@ -460,7 +460,7 @@ func TestRemoteModuleLicenseScan_GitHubVersionedDoesNotFallBackToDefaultBranchLi
 	restoreBases := WithLicenseEndpoints(server.URL, cratesBase, packagistBase, pubBase, cocoapodsBase, hexpmBase)
 	defer restoreBases()
 
-	got := RemoteModuleLicenseScan(context.Background(), "github.com/owner/repo", version)
+	got := RemoteModuleLicenseScan(t.Context(), "github.com/owner/repo", version)
 	if len(got) != 0 {
 		t.Fatalf("expected no license when requested ref has no license file, got %v", got)
 	}
@@ -492,7 +492,7 @@ func TestFetchLicensesFromGitHubRawUsesSHAWithoutVPrefix(t *testing.T) {
 	restoreClient := swapGitHubHTTPClient(server)
 	defer restoreClient()
 
-	got, err := fetchLicensesFromGitHubRaw(context.Background(), "owner", "repo", sha)
+	got, err := fetchLicensesFromGitHubRaw(t.Context(), "owner", "repo", sha)
 	if err != nil {
 		t.Fatalf("fetchLicensesFromGitHubRaw returned error: %v", err)
 	}
@@ -581,7 +581,7 @@ func TestLookupLicensesBestEffort_GitHubRefCandidatesAreGitHubOnly(t *testing.T)
 	pypiBase = server.URL
 	defer func() { pypiBase = oldPyPIBase }()
 
-	got := LookupLicensesBestEffort(context.Background(), "pypi", "requests", shaLikeVersion)
+	got := LookupLicensesBestEffort(t.Context(), "pypi", "requests", shaLikeVersion)
 	if want := []string{"Apache-2.0"}; !slices.Equal(got, want) {
 		t.Fatalf("expected PyPI license %v, got %v", want, got)
 	}
@@ -616,7 +616,7 @@ func TestLookupLicensesBestEffort_PyPI(t *testing.T) {
 		pypiBase = server.URL
 		defer func() { pypiBase = oldPyPIBase }()
 
-		got := LookupLicensesBestEffort(context.Background(), "pypi", "requests", "2.31.0")
+		got := LookupLicensesBestEffort(t.Context(), "pypi", "requests", "2.31.0")
 		if want := []string{"Apache-2.0"}; !slices.Equal(got, want) {
 			t.Fatalf("expected PyPI license_expression %v, got %v", want, got)
 		}
@@ -640,7 +640,7 @@ func TestLookupLicensesBestEffort_PyPI(t *testing.T) {
 		pypiBase = server.URL
 		defer func() { pypiBase = oldPyPIBase }()
 
-		got := LookupLicensesBestEffort(context.Background(), "python", "flask", "3.0.0")
+		got := LookupLicensesBestEffort(t.Context(), "python", "flask", "3.0.0")
 		if want := []string{"MIT"}; !slices.Equal(got, want) {
 			t.Fatalf("expected PyPI license field %v, got %v", want, got)
 		}
@@ -669,7 +669,7 @@ func TestLookupLicensesBestEffort_PyPI(t *testing.T) {
 		pypiBase = server.URL
 		defer func() { pypiBase = oldPyPIBase }()
 
-		got := LookupLicensesBestEffort(context.Background(), "pypi", "numpy", "1.26.0")
+		got := LookupLicensesBestEffort(t.Context(), "pypi", "numpy", "1.26.0")
 		if want := []string{"BSD-3-Clause"}; !slices.Equal(got, want) {
 			t.Fatalf("expected PyPI classifier license %v, got %v", want, got)
 		}
@@ -748,7 +748,7 @@ func TestFetchLicenseFromGitHubAPI(t *testing.T) {
 		restoreClient := swapGitHubHTTPClient(server)
 		defer restoreClient()
 
-		got := fetchLicenseFromGitHubAPI(context.Background(), "owner", "repo")
+		got := fetchLicenseFromGitHubAPI(t.Context(), "owner", "repo")
 		if want := []string{"MIT"}; !slices.Equal(got, want) {
 			t.Fatalf("expected %v, got %v", want, got)
 		}
@@ -769,7 +769,7 @@ func TestFetchLicenseFromGitHubAPI(t *testing.T) {
 		restoreClient := swapGitHubHTTPClient(server)
 		defer restoreClient()
 
-		got := fetchLicenseFromGitHubAPI(context.Background(), "owner", "repo")
+		got := fetchLicenseFromGitHubAPI(t.Context(), "owner", "repo")
 		if want := []string{"APACHE-2.0"}; !slices.Equal(got, want) {
 			t.Fatalf("expected %v, got %v", want, got)
 		}
@@ -790,7 +790,7 @@ func TestFetchLicenseFromGitHubAPI(t *testing.T) {
 		restoreClient := swapGitHubHTTPClient(server)
 		defer restoreClient()
 
-		got := fetchLicenseFromGitHubAPI(context.Background(), "owner", "repo")
+		got := fetchLicenseFromGitHubAPI(t.Context(), "owner", "repo")
 		if got != nil {
 			t.Fatalf("expected nil for NOASSERTION, got %v", got)
 		}

--- a/internal/logs/logs_test.go
+++ b/internal/logs/logs_test.go
@@ -12,7 +12,7 @@ func TestWithContextAndFromContext(t *testing.T) {
 	buf := &bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(buf, nil))
 
-	ctx := WithContext(context.Background(), logger)
+	ctx := WithContext(t.Context(), logger)
 	retrieved := FromContext(ctx)
 
 	if retrieved != logger {
@@ -32,7 +32,7 @@ func TestWithContextAndFromContext(t *testing.T) {
 
 func TestFromContextDefault(t *testing.T) {
 	// Test that FromContext returns default logger when none is set
-	ctx := context.Background()
+	ctx := t.Context()
 	logger := FromContext(ctx)
 	if logger == nil {
 		t.Error("FromContext should never return nil")
@@ -43,7 +43,7 @@ func TestWithField(t *testing.T) {
 	buf := &bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(buf, nil))
 
-	ctx := WithContext(context.Background(), logger)
+	ctx := WithContext(t.Context(), logger)
 	ctx = WithField(ctx, "request_id", "12345")
 
 	Info(ctx, "operation")
@@ -60,7 +60,7 @@ func TestWithFields(t *testing.T) {
 	buf := &bytes.Buffer{}
 	logger := slog.New(slog.NewTextHandler(buf, nil))
 
-	ctx := WithContext(context.Background(), logger)
+	ctx := WithContext(t.Context(), logger)
 	ctx = WithFields(ctx, map[string]any{
 		"user":   "alice",
 		"action": "scan",
@@ -95,7 +95,7 @@ func TestLogLevels(t *testing.T) {
 			logger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{
 				Level: slog.LevelDebug,
 			}))
-			ctx := WithContext(context.Background(), logger)
+			ctx := WithContext(t.Context(), logger)
 
 			tt.logFunc(ctx, "test message")
 			output := buf.String()
@@ -157,7 +157,7 @@ func TestColorHandler(t *testing.T) {
 	})
 	logger := slog.New(handler)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Test different levels produce different colors
 	logger.DebugContext(ctx, "debug message")
@@ -218,7 +218,7 @@ func TestSetDefault(t *testing.T) {
 	SetDefault(customLogger)
 
 	// Use a fresh context with no logger
-	ctx := context.Background()
+	ctx := t.Context()
 	Info(ctx, "test with custom default")
 
 	if buf.Len() == 0 {

--- a/internal/mcp/auth_test.go
+++ b/internal/mcp/auth_test.go
@@ -1,7 +1,6 @@
 package mcp
 
 import (
-	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -246,7 +245,7 @@ func TestAuthMiddleware_OptionalMode(t *testing.T) {
 
 func TestClaimsFromContext(t *testing.T) {
 	t.Run("no claims", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		claims := ClaimsFromContext(ctx)
 		if claims != nil {
 			t.Error("expected nil claims")
@@ -255,7 +254,7 @@ func TestClaimsFromContext(t *testing.T) {
 
 	t.Run("with claims", func(t *testing.T) {
 		expected := &Claims{Subject: "test-user"}
-		ctx := jwt.ContextWithClaims(context.Background(), expected)
+		ctx := jwt.ContextWithClaims(t.Context(), expected)
 		claims := ClaimsFromContext(ctx)
 		if claims == nil {
 			t.Fatal("expected non-nil claims")

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -809,7 +809,7 @@ func TestMCPToolInputSchemasAvoidTopLevelComposition(t *testing.T) {
 
 func TestExplainVulnerabilityToolSchemas(t *testing.T) {
 	s := NewServer()
-	ctx := context.Background()
+	ctx := t.Context()
 	clientSession := connectMCPClientSession(t, ctx, s)
 
 	tools, err := clientSession.ListTools(ctx, nil)
@@ -915,7 +915,7 @@ func TestExplainVulnerabilitiesOmitsEmptyCollections(t *testing.T) {
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{
 		vulnerabilityHandler: &mockVulnerabilityHandler{osvClient: mockOSV},
 	})))
-	ctx := context.Background()
+	ctx := t.Context()
 	clientSession := connectMCPClientSession(t, ctx, s)
 
 	result, err := clientSession.CallTool(ctx, &mcpsdk.CallToolParams{
@@ -954,7 +954,7 @@ func TestExplainVulnerabilitiesOmitsEmptyCollections(t *testing.T) {
 func TestScanPackageToolSchema(t *testing.T) {
 	mockScan := &mockScanHandler{scanResponse: emptyScanResponse()}
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{scanHandler: mockScan})))
-	ctx := context.Background()
+	ctx := t.Context()
 	clientSession := connectMCPClientSession(t, ctx, s)
 
 	tools, err := clientSession.ListTools(ctx, nil)
@@ -1081,7 +1081,7 @@ func TestScanPackageToolSchema(t *testing.T) {
 func TestScanContainerToolSchema(t *testing.T) {
 	mockScan := &mockScanHandler{scanResponse: emptyScanResponse()}
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{scanHandler: mockScan})))
-	ctx := context.Background()
+	ctx := t.Context()
 	clientSession := connectMCPClientSession(t, ctx, s)
 
 	tools, err := clientSession.ListTools(ctx, nil)
@@ -1175,7 +1175,7 @@ func TestDiffRefsToolSchema(t *testing.T) {
 		},
 	}
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{scanHandler: mockScan})))
-	ctx := context.Background()
+	ctx := t.Context()
 	clientSession := connectMCPClientSession(t, ctx, s)
 
 	tools, err := clientSession.ListTools(ctx, nil)
@@ -1276,7 +1276,7 @@ func TestDiffRefsToolSchema(t *testing.T) {
 
 func TestLocalPathToolSchemasExposeAgentControls(t *testing.T) {
 	s := NewServer()
-	ctx := context.Background()
+	ctx := t.Context()
 	clientSession := connectMCPClientSession(t, ctx, s)
 
 	tools, err := clientSession.ListTools(ctx, nil)
@@ -1525,7 +1525,7 @@ func TestGraphToolsReturnStableEmptyCollections(t *testing.T) {
 		scanHandler:  mockScan,
 		graphHandler: mockGraph,
 	})))
-	ctx := context.Background()
+	ctx := t.Context()
 	clientSession := connectMCPClientSession(t, ctx, s)
 
 	tools, err := clientSession.ListTools(ctx, nil)
@@ -1596,7 +1596,7 @@ func TestGraphWhyCallToolReturnsMatchedNodeForPathlessPackage(t *testing.T) {
 		Stats: &graphv1.GraphStats{TotalNodes: 1, DisconnectedNodes: 1},
 	}}
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{graphHandler: mockGraph})))
-	ctx := context.Background()
+	ctx := t.Context()
 	clientSession := connectMCPClientSession(t, ctx, s)
 
 	result, err := clientSession.CallTool(ctx, &mcpsdk.CallToolParams{
@@ -1645,7 +1645,7 @@ func TestGraphWhyCallToolReturnsMatchedNodeForPathlessPackage(t *testing.T) {
 
 func TestToolAnnotationsExposeReadOnlySafetyHints(t *testing.T) {
 	s := NewServer()
-	ctx := context.Background()
+	ctx := t.Context()
 	clientSession := connectMCPClientSession(t, ctx, s)
 
 	tools, err := clientSession.ListTools(ctx, nil)
@@ -1691,7 +1691,7 @@ func TestLocalPathToolSchemasRejectInvalidRequiredStrings(t *testing.T) {
 		listHandler:  mockList,
 		graphHandler: mockGraph,
 	})))
-	ctx := context.Background()
+	ctx := t.Context()
 	clientSession := connectMCPClientSession(t, ctx, s)
 
 	tests := []struct {
@@ -1739,7 +1739,7 @@ func TestStringArrayToolSchemasRejectBlankItems(t *testing.T) {
 		listResponse: &listv1.ListPackagesResponse{Stats: &listv1.ListStats{}},
 	}
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{listHandler: mockList})))
-	ctx := context.Background()
+	ctx := t.Context()
 	clientSession := connectMCPClientSession(t, ctx, s)
 
 	tests := []struct {
@@ -1772,7 +1772,7 @@ func TestGeneratedToolSchemasRejectUnknownArguments(t *testing.T) {
 		listResponse: &listv1.ListPackagesResponse{Stats: &listv1.ListStats{}},
 	}
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{listHandler: mockList})))
-	ctx := context.Background()
+	ctx := t.Context()
 	clientSession := connectMCPClientSession(t, ctx, s)
 
 	result, err := clientSession.CallTool(ctx, &mcpsdk.CallToolParams{
@@ -1796,7 +1796,7 @@ func TestGeneratedToolSchemasRejectUnknownArguments(t *testing.T) {
 
 func TestGenerateSBOMToolContractRequiresLocalPath(t *testing.T) {
 	s := NewServer()
-	ctx := context.Background()
+	ctx := t.Context()
 	clientSession := connectMCPClientSession(t, ctx, s)
 
 	tools, err := clientSession.ListTools(ctx, nil)
@@ -2082,7 +2082,7 @@ func TestExplainVulnerability(t *testing.T) {
 		vulnerabilityHandler: &mockVulnerabilityHandler{osvClient: mockOSV},
 	})
 	s := NewServer(WithClients(mockClients))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("valid vulnerability", func(t *testing.T) {
 		result, err := callProtoTool(t, ctx, s.explainVulnerability,
@@ -2228,7 +2228,7 @@ func TestExplainVulnerabilities(t *testing.T) {
 		vulnerabilityHandler: &mockVulnerabilityHandler{osvClient: mockOSV},
 	})
 	s := NewServer(WithClients(mockClients))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("multiple vulnerabilities", func(t *testing.T) {
 		result, err := callProtoTool(t, ctx, s.explainVulnerabilities, &mcpv1.ExplainVulnerabilitiesRequest{
@@ -2387,7 +2387,7 @@ func TestExplainVulnerabilitiesUsesBatchAdvisoryLookup(t *testing.T) {
 func TestScanPackage(t *testing.T) {
 	mockScan := &mockScanHandler{scanResponse: emptyScanResponse()}
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{scanHandler: mockScan})))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("missing name", func(t *testing.T) {
 		_, err := callProtoTool(t, ctx, s.scanPackage, &mcpv1.ScanPackageRequest{
@@ -2725,7 +2725,7 @@ func TestScanDirectory(t *testing.T) {
 	}
 
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{scanHandler: mockScan})))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("missing path", func(t *testing.T) {
 		_, err := callProtoTool(t, ctx, s.scanDirectory, &mcpv1.ScanDirectoryRequest{}, &mcpv1.ScanDirectoryResult{})
@@ -2953,7 +2953,7 @@ func TestScanContainerDeduplicatesAdvisoryAliases(t *testing.T) {
 	}
 
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{scanHandler: mockScan})))
-	result, err := callProtoTool(t, context.Background(), s.scanContainer, &mcpv1.ScanContainerRequest{Image: "debian:bookworm"}, &mcpv1.ScanContainerResult{})
+	result, err := callProtoTool(t, t.Context(), s.scanContainer, &mcpv1.ScanContainerRequest{Image: "debian:bookworm"}, &mcpv1.ScanContainerResult{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2976,7 +2976,7 @@ func TestScanContainerNormalizesImageAndPlatform(t *testing.T) {
 	mockScan := &mockScanHandler{scanResponse: emptyScanResponse()}
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{scanHandler: mockScan})))
 
-	result, err := callProtoTool(t, context.Background(), s.scanContainer, &mcpv1.ScanContainerRequest{
+	result, err := callProtoTool(t, t.Context(), s.scanContainer, &mcpv1.ScanContainerRequest{
 		Image:    " debian:bookworm ",
 		Platform: " linux/amd64\t",
 	}, &mcpv1.ScanContainerResult{})
@@ -3027,7 +3027,7 @@ func TestListDependencies(t *testing.T) {
 	}
 
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{listHandler: mockList})))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("missing path", func(t *testing.T) {
 		_, err := callProtoTool(t, ctx, s.listDependencies, &mcpv1.ListDependenciesRequest{}, &mcpv1.ListDependenciesResult{})
@@ -3141,7 +3141,7 @@ func TestListDependencies(t *testing.T) {
 
 func TestGenerateSBOM(t *testing.T) {
 	s := NewServer()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("missing path", func(t *testing.T) {
 		_, err := callProtoTool(t, ctx, s.generateSBOM, &mcpv1.GenerateSBOMRequest{}, &mcpv1.GenerateSBOMResult{})
@@ -3250,7 +3250,7 @@ func TestGetRemediation(t *testing.T) {
 	}
 
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{scanHandler: mockScan})))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("missing path", func(t *testing.T) {
 		_, err := callProtoTool(t, ctx, s.getRemediation, &mcpv1.GetRemediationRequest{}, &mcpv1.GetRemediationResult{})
@@ -3489,7 +3489,7 @@ func TestGetRemediation(t *testing.T) {
 func TestTriageVulnerabilitiesMigrationFix(t *testing.T) {
 	mockScan := &mockScanHandler{scanResponse: migrationOnlyScanResponse()}
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{scanHandler: mockScan})))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	result, err := callProtoTool(t, ctx, s.triageVulnerabilities, &mcpv1.TriageRequest{Path: "/test/path"}, &mcpv1.TriageResult{})
 	if err != nil {
@@ -3700,7 +3700,7 @@ func TestAnalyzeDependencyGraph(t *testing.T) {
 	}
 
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{scanHandler: mockScan, graphHandler: mockGraph})))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("missing path", func(t *testing.T) {
 		_, err := callProtoTool(t, ctx, s.analyzeDependencyGraph, &mcpv1.AnalyzeGraphRequest{}, &mcpv1.AnalyzeGraphResult{})
@@ -4070,7 +4070,7 @@ func TestAnalyzeDependencyGraph(t *testing.T) {
 func TestGraphWhyUsesGraphService(t *testing.T) {
 	mockGraph := &mockGraphHandler{buildResponse: testBuildGraphResponse()}
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{graphHandler: mockGraph})))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	result, err := callProtoTool(t, ctx, s.graphWhy, &mcpv1.GraphWhyRequest{
 		Path:         "/test/path",
@@ -4167,7 +4167,7 @@ func TestGraphWhyReturnsDirectPath(t *testing.T) {
 	mockGraph := &mockGraphHandler{buildResponse: testBuildGraphResponse()}
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{graphHandler: mockGraph})))
 
-	result, err := callProtoTool(t, context.Background(), s.graphWhy, &mcpv1.GraphWhyRequest{
+	result, err := callProtoTool(t, t.Context(), s.graphWhy, &mcpv1.GraphWhyRequest{
 		Path:    "/test/path",
 		Package: "github.com/example/root",
 	}, &mcpv1.GraphWhyResult{})
@@ -4232,7 +4232,7 @@ require github.com/pkg/errors v0.9.1
 	}
 	s := NewServer(WithClients(clients))
 
-	result, err := callProtoTool(t, context.Background(), s.graphWhy, &mcpv1.GraphWhyRequest{
+	result, err := callProtoTool(t, t.Context(), s.graphWhy, &mcpv1.GraphWhyRequest{
 		Path:       tmpDir,
 		Package:    "github.com/pkg/errors",
 		Ecosystems: []string{"go"},
@@ -4264,7 +4264,7 @@ func TestGraphWhyAcceptsPURLQuery(t *testing.T) {
 	mockGraph := &mockGraphHandler{buildResponse: testBuildGraphResponse()}
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{graphHandler: mockGraph})))
 
-	result, err := callProtoTool(t, context.Background(), s.graphWhy, &mcpv1.GraphWhyRequest{
+	result, err := callProtoTool(t, t.Context(), s.graphWhy, &mcpv1.GraphWhyRequest{
 		Path:    "/test/path",
 		Package: " " + testChildPURL + " ",
 	}, &mcpv1.GraphWhyResult{})
@@ -4299,7 +4299,7 @@ func TestGraphWhyAcceptsScanEmittedPURLWithEscapedVersion(t *testing.T) {
 	}}
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{graphHandler: mockGraph})))
 
-	result, err := callProtoTool(t, context.Background(), s.graphWhy, &mcpv1.GraphWhyRequest{
+	result, err := callProtoTool(t, t.Context(), s.graphWhy, &mcpv1.GraphWhyRequest{
 		Path:    "/test/path",
 		Package: dockerPURL,
 	}, &mcpv1.GraphWhyResult{})
@@ -4335,7 +4335,7 @@ func TestGraphWhyExplainsDisconnectedMatchedNode(t *testing.T) {
 	}}
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{graphHandler: mockGraph})))
 
-	result, err := callProtoTool(t, context.Background(), s.graphWhy, &mcpv1.GraphWhyRequest{
+	result, err := callProtoTool(t, t.Context(), s.graphWhy, &mcpv1.GraphWhyRequest{
 		Path:               "/test/path",
 		Package:            dockerPURL,
 		ResolveTransitives: true,
@@ -4373,7 +4373,7 @@ func TestGraphWhyExplainsDisconnectedMatchedNode(t *testing.T) {
 func TestGraphNeedsUsesGraphService(t *testing.T) {
 	mockGraph := &mockGraphHandler{buildResponse: testBuildGraphResponse()}
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{graphHandler: mockGraph})))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	result, err := callProtoTool(t, ctx, s.graphNeeds, &mcpv1.GraphNeedsRequest{
 		Path:         "/test/path",
@@ -4434,7 +4434,7 @@ func TestGraphNeedsSortsDependentsDeterministically(t *testing.T) {
 	}}
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{graphHandler: mockGraph})))
 
-	result, err := callProtoTool(t, context.Background(), s.graphNeeds, &mcpv1.GraphNeedsRequest{
+	result, err := callProtoTool(t, t.Context(), s.graphNeeds, &mcpv1.GraphNeedsRequest{
 		Path:    "/test/path",
 		Package: targetPURL,
 	}, &mcpv1.GraphNeedsResult{})
@@ -4458,7 +4458,7 @@ func TestGraphNeedsPassesExtendedGraphOption(t *testing.T) {
 	mockGraph := &mockGraphHandler{buildResponse: testBuildGraphResponse()}
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{graphHandler: mockGraph})))
 
-	_, err := callProtoTool(t, context.Background(), s.graphNeeds, &mcpv1.GraphNeedsRequest{
+	_, err := callProtoTool(t, t.Context(), s.graphNeeds, &mcpv1.GraphNeedsRequest{
 		Path:     "/test/path",
 		Package:  "github.com/example/child",
 		Extended: true,
@@ -4518,7 +4518,7 @@ func TestGraphNeedsExplainsEmptyDependents(t *testing.T) {
 			}}
 			s := NewServer(WithClients(newMockClients(mockClientsConfig{graphHandler: mockGraph})))
 
-			result, err := callProtoTool(t, context.Background(), s.graphNeeds, &mcpv1.GraphNeedsRequest{
+			result, err := callProtoTool(t, t.Context(), s.graphNeeds, &mcpv1.GraphNeedsRequest{
 				Path:    "/test/path",
 				Package: tt.node.Purl,
 			}, &mcpv1.GraphNeedsResult{})
@@ -4547,7 +4547,7 @@ func TestGraphNeedsAcceptsVersionedPackageQuery(t *testing.T) {
 	mockGraph := &mockGraphHandler{buildResponse: testBuildGraphResponse()}
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{graphHandler: mockGraph})))
 
-	result, err := callProtoTool(t, context.Background(), s.graphNeeds, &mcpv1.GraphNeedsRequest{
+	result, err := callProtoTool(t, t.Context(), s.graphNeeds, &mcpv1.GraphNeedsRequest{
 		Path:    "/test/path",
 		Package: "child@v2.0.0",
 	}, &mcpv1.GraphNeedsResult{})
@@ -4564,7 +4564,7 @@ func TestGraphNeedsAcceptsVersionedPackageQuery(t *testing.T) {
 		t.Fatalf("expected 1 direct dependent, got %d", result.GetDirectCount())
 	}
 
-	result, err = callProtoTool(t, context.Background(), s.graphNeeds, &mcpv1.GraphNeedsRequest{
+	result, err = callProtoTool(t, t.Context(), s.graphNeeds, &mcpv1.GraphNeedsRequest{
 		Path:    "/test/path",
 		Package: "child@v9.0.0",
 	}, &mcpv1.GraphNeedsResult{})
@@ -4871,7 +4871,7 @@ func TestDefaultExcludePathsApplyToMCPScans(t *testing.T) {
 		WithDefaultExcludePaths([]string{" .bin/** ", "", "**/testdata"}),
 	)
 
-	_, err := callProtoTool(t, context.Background(), s.scanDirectory, &mcpv1.ScanDirectoryRequest{
+	_, err := callProtoTool(t, t.Context(), s.scanDirectory, &mcpv1.ScanDirectoryRequest{
 		Path:         "/test/path",
 		ExcludePaths: []string{"**/testdata", "node_modules"},
 	}, &mcpv1.ScanDirectoryResult{})
@@ -4909,7 +4909,7 @@ func TestDiffGitRefsPreservesDirectness(t *testing.T) {
 	}
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{scanHandler: mockScan})))
 
-	result, err := s.diffGitRefs(context.Background(), &mcpv1.DiffRefsRequest{
+	result, err := s.diffGitRefs(t.Context(), &mcpv1.DiffRefsRequest{
 		Path:         "/test/path",
 		BaseRef:      "base",
 		TargetRef:    "target",
@@ -4955,7 +4955,7 @@ func TestDiffGitRefsNormalizesPath(t *testing.T) {
 	}
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{scanHandler: mockScan})))
 
-	result, err := s.diffGitRefs(context.Background(), &mcpv1.DiffRefsRequest{
+	result, err := s.diffGitRefs(t.Context(), &mcpv1.DiffRefsRequest{
 		Path:      " /test/path ",
 		BaseRef:   " base ",
 		TargetRef: "\ttarget ",
@@ -5009,7 +5009,7 @@ func TestDiffGitRefsUsesPURLIdentity(t *testing.T) {
 	}
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{scanHandler: mockScan})))
 
-	result, err := s.diffGitRefs(context.Background(), &mcpv1.DiffRefsRequest{
+	result, err := s.diffGitRefs(t.Context(), &mcpv1.DiffRefsRequest{
 		Path:      "/test/path",
 		BaseRef:   "base",
 		TargetRef: "target",
@@ -5071,7 +5071,7 @@ func TestDiffGitRefsDeduplicatesTargetVulnerabilities(t *testing.T) {
 	}
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{scanHandler: mockScan})))
 
-	result, err := s.diffGitRefs(context.Background(), &mcpv1.DiffRefsRequest{
+	result, err := s.diffGitRefs(t.Context(), &mcpv1.DiffRefsRequest{
 		Path:      "/test/path",
 		BaseRef:   "base",
 		TargetRef: "target",
@@ -5099,7 +5099,7 @@ func TestDiffRefsRoutesLocalhostRegistryAsContainer(t *testing.T) {
 	}
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{scanHandler: mockScan})))
 
-	result, err := callProtoTool(t, context.Background(), s.diffRefs, &mcpv1.DiffRefsRequest{
+	result, err := callProtoTool(t, t.Context(), s.diffRefs, &mcpv1.DiffRefsRequest{
 		BaseRef:   " localhost:5000/app:v1 ",
 		TargetRef: "\tlocalhost:5000/app:v2",
 	}, &mcpv1.DiffRefsResult{})
@@ -5132,7 +5132,7 @@ func TestDiffRefsValidationRequiresRefs(t *testing.T) {
 	// In production the SDK rejects these against the input schema using JSON
 	// property names; protovalidate guards direct invocations and names the
 	// proto fields.
-	_, err := callProtoTool(t, context.Background(), s.diffRefs, &mcpv1.DiffRefsRequest{
+	_, err := callProtoTool(t, t.Context(), s.diffRefs, &mcpv1.DiffRefsRequest{
 		TargetRef: "main",
 	}, &mcpv1.DiffRefsResult{})
 	if err == nil {
@@ -5142,7 +5142,7 @@ func TestDiffRefsValidationRequiresRefs(t *testing.T) {
 		t.Fatalf("missing baseRef error = %q", err)
 	}
 
-	_, err = callProtoTool(t, context.Background(), s.diffRefs, &mcpv1.DiffRefsRequest{
+	_, err = callProtoTool(t, t.Context(), s.diffRefs, &mcpv1.DiffRefsRequest{
 		BaseRef: "main",
 	}, &mcpv1.DiffRefsResult{})
 	if err == nil {
@@ -5162,7 +5162,7 @@ func TestDiffRefsPathlessCommonGitRefsRequirePath(t *testing.T) {
 	}
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{scanHandler: mockScan})))
 
-	_, err := callProtoTool(t, context.Background(), s.diffRefs, &mcpv1.DiffRefsRequest{
+	_, err := callProtoTool(t, t.Context(), s.diffRefs, &mcpv1.DiffRefsRequest{
 		BaseRef:   "main",
 		TargetRef: "develop",
 	}, &mcpv1.DiffRefsResult{})
@@ -5193,7 +5193,7 @@ func TestDiffRefsRejectsMixedContainerAndGitRefs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.GetBaseRef()+" to "+tt.GetTargetRef(), func(t *testing.T) {
-			_, err := callProtoTool(t, context.Background(), s.diffRefs, tt, &mcpv1.DiffRefsResult{})
+			_, err := callProtoTool(t, t.Context(), s.diffRefs, tt, &mcpv1.DiffRefsResult{})
 			if err == nil {
 				t.Fatal("expected mixed ref error")
 			}
@@ -5250,7 +5250,7 @@ func TestDiffContainerImagesReportsDeduplicatedVulnerabilityChanges(t *testing.T
 	}
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{scanHandler: mockScan})))
 
-	result, err := s.diffContainerImages(context.Background(), &mcpv1.DiffRefsRequest{
+	result, err := s.diffContainerImages(t.Context(), &mcpv1.DiffRefsRequest{
 		BaseRef:   "example/app:v1",
 		TargetRef: "example/app:v2",
 	})
@@ -5296,7 +5296,7 @@ func TestDiffContainerImagesNormalizesAndForwardsPlatform(t *testing.T) {
 	}
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{scanHandler: mockScan})))
 
-	result, err := s.diffContainerImages(context.Background(), &mcpv1.DiffRefsRequest{
+	result, err := s.diffContainerImages(t.Context(), &mcpv1.DiffRefsRequest{
 		BaseRef:   " example/app:v1 ",
 		TargetRef: " example/app:v2 ",
 		Platform:  " linux/amd64\t",
@@ -5336,7 +5336,7 @@ func TestDiffRefsPrefersGitRefsInRepositoryContext(t *testing.T) {
 	}
 	s := NewServer(WithClients(newMockClients(mockClientsConfig{scanHandler: mockScan})))
 
-	result, err := callProtoTool(t, context.Background(), s.diffRefs, &mcpv1.DiffRefsRequest{
+	result, err := callProtoTool(t, t.Context(), s.diffRefs, &mcpv1.DiffRefsRequest{
 		Path:      repo,
 		BaseRef:   "main",
 		TargetRef: "develop",
@@ -5540,7 +5540,7 @@ require golang.org/x/text v0.3.0
 	}
 
 	s := NewServer()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	result, err := callProtoTool(t, ctx, s.scanDirectory, &mcpv1.ScanDirectoryRequest{Path: tmpDir}, &mcpv1.ScanDirectoryResult{})
 	if err != nil {
@@ -5571,7 +5571,7 @@ require golang.org/x/text v0.3.0
 	}
 
 	s := NewServer()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	result, err := callProtoTool(t, ctx, s.listDependencies, &mcpv1.ListDependenciesRequest{Path: tmpDir}, &mcpv1.ListDependenciesResult{})
 	if err != nil {

--- a/internal/network/safedialer_test.go
+++ b/internal/network/safedialer_test.go
@@ -183,7 +183,7 @@ func TestSafeDialer_DialContext_BlocksPrivateIPs(t *testing.T) {
 	t.Parallel()
 
 	d := NewSafeDialer()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// These should all be blocked (direct IP addresses)
 	blockedAddrs := []string{
@@ -213,7 +213,7 @@ func TestSafeDialer_DialContext_BlocksMetadataHostnames(t *testing.T) {
 	t.Parallel()
 
 	d := NewSafeDialer()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// These hostnames should be blocked before DNS resolution
 	blockedHosts := []string{

--- a/internal/otel/logs_test.go
+++ b/internal/otel/logs_test.go
@@ -2,7 +2,6 @@ package otel
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"log/slog"
 	"testing"
@@ -160,7 +159,7 @@ func TestMultiHandler_Enabled(t *testing.T) {
 	multi := NewMultiHandler(h1, h2)
 
 	// Should be enabled if any handler is enabled
-	if !multi.Enabled(context.Background(), slog.LevelInfo) {
+	if !multi.Enabled(t.Context(), slog.LevelInfo) {
 		t.Error("multi handler should be enabled for Info if any child is enabled")
 	}
 }

--- a/internal/otel/metrics_test.go
+++ b/internal/otel/metrics_test.go
@@ -101,7 +101,7 @@ func TestSeverityAttr(t *testing.T) {
 }
 
 func TestRecordScanMetrics_DoesNotPanic(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	severity := map[string]int{
 		"CRITICAL": 1,
 		"HIGH":     2,
@@ -152,7 +152,7 @@ func findMetric(rm *metricdata.ResourceMetrics, name string) *metricdata.Metrics
 
 func TestRecordScanMetrics_RecordsValues(t *testing.T) {
 	reader := setupTestMeterProvider(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	severity := map[string]int{
 		"CRITICAL": 2,
@@ -227,7 +227,7 @@ func TestRecordScanMetrics_RecordsValues(t *testing.T) {
 
 func TestRecordProxyRequest_RecordsValues(t *testing.T) {
 	reader := setupTestMeterProvider(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	RecordProxyRequest(ctx, 0.25, "npm", 200)
 	RecordProxyRequest(ctx, 0.15, "npm", 200)
@@ -279,7 +279,7 @@ func TestRecordProxyRequest_RecordsValues(t *testing.T) {
 
 func TestRecordPolicyEvaluation_RecordsValues(t *testing.T) {
 	reader := setupTestMeterProvider(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	RecordPolicyEvaluation(ctx, 0.05, "allow")
 	RecordPolicyEvaluation(ctx, 0.10, "allow")
@@ -337,7 +337,7 @@ func TestRecordPolicyEvaluation_RecordsValues(t *testing.T) {
 
 func TestRecordOSVCacheAccess_RecordsValues(t *testing.T) {
 	reader := setupTestMeterProvider(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	RecordOSVCacheAccess(ctx, true)
 	RecordOSVCacheAccess(ctx, true)
@@ -390,7 +390,7 @@ func TestRecordOSVCacheAccess_RecordsValues(t *testing.T) {
 
 func TestRecordProxyAuth_RecordsValues(t *testing.T) {
 	reader := setupTestMeterProvider(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	RecordProxyAuth(ctx, "success", "")
 	RecordProxyAuth(ctx, "success", "")
@@ -422,7 +422,7 @@ func TestRecordProxyAuth_RecordsValues(t *testing.T) {
 }
 
 func TestRecordOSVQuery_DoesNotPanic(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Should not panic
 	RecordOSVQuery(ctx, 0.5, "batch", true)
@@ -430,7 +430,7 @@ func TestRecordOSVQuery_DoesNotPanic(t *testing.T) {
 }
 
 func TestRecordOSVCacheAccess_DoesNotPanic(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Should not panic
 	RecordOSVCacheAccess(ctx, true)
@@ -438,7 +438,7 @@ func TestRecordOSVCacheAccess_DoesNotPanic(t *testing.T) {
 }
 
 func TestRecordPolicyEvaluation_DoesNotPanic(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Should not panic
 	RecordPolicyEvaluation(ctx, 0.1, "allow")
@@ -447,7 +447,7 @@ func TestRecordPolicyEvaluation_DoesNotPanic(t *testing.T) {
 }
 
 func TestRecordProxyRequest_DoesNotPanic(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Should not panic
 	RecordProxyRequest(ctx, 0.5, "go", 200)
@@ -455,7 +455,7 @@ func TestRecordProxyRequest_DoesNotPanic(t *testing.T) {
 }
 
 func TestRecordProxyAuth_DoesNotPanic(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Should not panic
 	RecordProxyAuth(ctx, "success", "")
@@ -464,7 +464,7 @@ func TestRecordProxyAuth_DoesNotPanic(t *testing.T) {
 }
 
 func TestRecordProxyPolicyDenial_DoesNotPanic(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Should not panic
 	RecordProxyPolicyDenial(ctx, "go", "block-critical")
@@ -525,7 +525,7 @@ func TestCacheTypeAttr(t *testing.T) {
 }
 
 func TestRecordCacheStats_DoesNotPanic(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	stats := CacheStats{
 		Hits:    100,
@@ -544,7 +544,7 @@ func TestRecordCacheStats_DoesNotPanic(t *testing.T) {
 
 func TestRecordCacheStats_RecordsValues(t *testing.T) {
 	reader := setupTestMeterProvider(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	stats := CacheStats{
 		Hits:    100,
@@ -584,7 +584,7 @@ func TestRecordCacheStats_RecordsValues(t *testing.T) {
 
 func TestRecordCacheHitMiss_RecordsValues(t *testing.T) {
 	reader := setupTestMeterProvider(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	RecordCacheHit(ctx, "depsdev")
 	RecordCacheHit(ctx, "depsdev")
@@ -637,7 +637,7 @@ func TestRecordCacheHitMiss_RecordsValues(t *testing.T) {
 
 func TestRecordCacheEvictionExpiration_RecordsValues(t *testing.T) {
 	reader := setupTestMeterProvider(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	RecordCacheEviction(ctx, "depsdev")
 	RecordCacheEviction(ctx, "depsdev")
@@ -688,25 +688,25 @@ func TestRecordCacheEvictionExpiration_RecordsValues(t *testing.T) {
 }
 
 func TestRecordCacheHit_DoesNotPanic(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	// Should not panic
 	RecordCacheHit(ctx, "test")
 }
 
 func TestRecordCacheMiss_DoesNotPanic(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	// Should not panic
 	RecordCacheMiss(ctx, "test")
 }
 
 func TestRecordCacheEviction_DoesNotPanic(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	// Should not panic
 	RecordCacheEviction(ctx, "test")
 }
 
 func TestRecordCacheExpiration_DoesNotPanic(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	// Should not panic
 	RecordCacheExpiration(ctx, "test")
 }

--- a/internal/otel/otel_test.go
+++ b/internal/otel/otel_test.go
@@ -12,11 +12,11 @@ func TestInit_DisabledByDefault(t *testing.T) {
 	resetGlobalProvider()
 
 	cfg := DefaultConfig()
-	provider, err := Init(context.Background(), cfg)
+	provider, err := Init(t.Context(), cfg)
 	if err != nil {
 		t.Fatalf("Init failed: %v", err)
 	}
-	defer provider.Shutdown(context.Background())
+	defer provider.Shutdown(t.Context())
 
 	if provider.Enabled() {
 		t.Error("expected provider to be disabled by default")
@@ -36,11 +36,11 @@ func TestInit_EnvOverride(t *testing.T) {
 	cfg.Exporter.Insecure = true
 
 	// Environment should override
-	provider, err := Init(context.Background(), cfg)
+	provider, err := Init(t.Context(), cfg)
 	if err != nil {
 		t.Fatalf("Init failed: %v", err)
 	}
-	defer provider.Shutdown(context.Background())
+	defer provider.Shutdown(t.Context())
 
 	// Note: The provider will be "enabled" from config perspective,
 	// but actual provider creation may fail without a collector.
@@ -61,11 +61,11 @@ func TestInit_EnvOverride_False(t *testing.T) {
 	cfg := DefaultConfig()
 	cfg.Enabled = true // Config says enabled
 
-	provider, err := Init(context.Background(), cfg)
+	provider, err := Init(t.Context(), cfg)
 	if err != nil {
 		t.Fatalf("Init failed: %v", err)
 	}
-	defer provider.Shutdown(context.Background())
+	defer provider.Shutdown(t.Context())
 
 	if provider.Enabled() {
 		t.Error("expected environment override to disable OTel")
@@ -78,12 +78,12 @@ func TestInit_MultipleCallsReturnSameProvider(t *testing.T) {
 
 	cfg := DefaultConfig()
 
-	p1, err := Init(context.Background(), cfg)
+	p1, err := Init(t.Context(), cfg)
 	if err != nil {
 		t.Fatalf("first Init failed: %v", err)
 	}
 
-	p2, err := Init(context.Background(), cfg)
+	p2, err := Init(t.Context(), cfg)
 	if err != nil {
 		t.Fatalf("second Init failed: %v", err)
 	}
@@ -92,20 +92,20 @@ func TestInit_MultipleCallsReturnSameProvider(t *testing.T) {
 		t.Error("expected same provider instance from multiple Init calls")
 	}
 
-	p1.Shutdown(context.Background())
+	p1.Shutdown(t.Context())
 }
 
 func TestProvider_Shutdown_NilSafe(t *testing.T) {
 	var p *Provider
 	// Should not panic
-	if err := p.Shutdown(context.Background()); err != nil {
+	if err := p.Shutdown(t.Context()); err != nil {
 		t.Errorf("nil provider shutdown should return nil, got: %v", err)
 	}
 }
 
 func TestProvider_Shutdown_DisabledSafe(t *testing.T) {
 	p := &Provider{enabled: false}
-	if err := p.Shutdown(context.Background()); err != nil {
+	if err := p.Shutdown(t.Context()); err != nil {
 		t.Errorf("disabled provider shutdown should return nil, got: %v", err)
 	}
 }
@@ -139,9 +139,9 @@ func TestIsEnabled(t *testing.T) {
 
 	// Test with disabled provider
 	cfg := DefaultConfig()
-	provider, _ := Init(context.Background(), cfg)
+	provider, _ := Init(t.Context(), cfg)
 	defer func() {
-		provider.Shutdown(context.Background())
+		provider.Shutdown(t.Context())
 		resetGlobalProvider()
 	}()
 

--- a/internal/otel/trace_test.go
+++ b/internal/otel/trace_test.go
@@ -1,7 +1,6 @@
 package otel
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -11,7 +10,7 @@ import (
 )
 
 func TestStartSpan(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	newCtx, span := StartSpan(ctx, "test.span")
 
 	if newCtx == nil {
@@ -25,7 +24,7 @@ func TestStartSpan(t *testing.T) {
 }
 
 func TestSpanFromContext_NoSpan(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	span := SpanFromContext(ctx)
 
 	if span == nil {
@@ -38,7 +37,7 @@ func TestSpanFromContext_NoSpan(t *testing.T) {
 }
 
 func TestSetSpanError_NilError(t *testing.T) {
-	_, span := StartSpan(context.Background(), "test")
+	_, span := StartSpan(t.Context(), "test")
 	defer span.End()
 
 	// Should not panic
@@ -47,7 +46,7 @@ func TestSetSpanError_NilError(t *testing.T) {
 
 func TestSetSpanError_WithError(t *testing.T) {
 	// Use a recording span to verify the error was set
-	_, span := StartSpan(context.Background(), "test")
+	_, span := StartSpan(t.Context(), "test")
 	defer span.End()
 
 	testErr := errors.New("test error")
@@ -59,7 +58,7 @@ func TestSetSpanError_WithError(t *testing.T) {
 }
 
 func TestSetSpanOK(t *testing.T) {
-	_, span := StartSpan(context.Background(), "test")
+	_, span := StartSpan(t.Context(), "test")
 	defer span.End()
 
 	// Should not panic
@@ -67,7 +66,7 @@ func TestSetSpanOK(t *testing.T) {
 }
 
 func TestAddSpanEvent(t *testing.T) {
-	_, span := StartSpan(context.Background(), "test")
+	_, span := StartSpan(t.Context(), "test")
 	defer span.End()
 
 	// Should not panic
@@ -139,7 +138,7 @@ func TestWithProxyAttrs(t *testing.T) {
 }
 
 func TestRecordScanResults(t *testing.T) {
-	_, span := StartSpan(context.Background(), "test")
+	_, span := StartSpan(t.Context(), "test")
 	defer span.End()
 
 	// Should not panic
@@ -147,7 +146,7 @@ func TestRecordScanResults(t *testing.T) {
 }
 
 func TestRecordCacheAccess(t *testing.T) {
-	_, span := StartSpan(context.Background(), "test")
+	_, span := StartSpan(t.Context(), "test")
 	defer span.End()
 
 	// Should not panic
@@ -156,7 +155,7 @@ func TestRecordCacheAccess(t *testing.T) {
 }
 
 func TestRecordPolicyResult(t *testing.T) {
-	_, span := StartSpan(context.Background(), "test")
+	_, span := StartSpan(t.Context(), "test")
 	defer span.End()
 
 	// Should not panic
@@ -206,7 +205,7 @@ func TestSetSpanOK_SetsStatus(t *testing.T) {
 }
 
 func TestRecordScanCompletion_DoesNotPanic(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, span := StartSpan(ctx, "test")
 	defer span.End()
 

--- a/internal/otel/tracetest_test.go
+++ b/internal/otel/tracetest_test.go
@@ -36,7 +36,7 @@ func setupTracetestProvider(t *testing.T) *tracetest.SpanRecorder {
 func TestStartSpan_RecordsSpan(t *testing.T) {
 	recorder := setupTracetestProvider(t)
 
-	ctx, span := StartSpan(context.Background(), "test.operation")
+	ctx, span := StartSpan(t.Context(), "test.operation")
 	span.End()
 
 	spans := recorder.Ended()
@@ -64,7 +64,7 @@ func TestStartSpan_RecordsSpan(t *testing.T) {
 func TestSetSpanErrorRecordsErrorStatus(t *testing.T) {
 	recorder := setupTracetestProvider(t)
 
-	ctx, span := StartSpan(context.Background(), "test.error")
+	ctx, span := StartSpan(t.Context(), "test.error")
 	_ = ctx // ctx unused in this test
 	testErr := errors.New("something went wrong")
 	SetSpanError(span, testErr)
@@ -102,7 +102,7 @@ func TestSetSpanErrorRecordsErrorStatus(t *testing.T) {
 func TestSetSpanOK_RecordsOKStatus(t *testing.T) {
 	recorder := setupTracetestProvider(t)
 
-	_, span := StartSpan(context.Background(), "test.success")
+	_, span := StartSpan(t.Context(), "test.success")
 	SetSpanOK(span)
 	span.End()
 
@@ -120,7 +120,7 @@ func TestSetSpanOK_RecordsOKStatus(t *testing.T) {
 func TestRecordScanResults_SetsAttributes(t *testing.T) {
 	recorder := setupTracetestProvider(t)
 
-	_, span := StartSpan(context.Background(), "deputy.scan")
+	_, span := StartSpan(t.Context(), "deputy.scan")
 	RecordScanResults(span, 100, 15, 2, 5, 6, 2)
 	span.End()
 
@@ -164,7 +164,7 @@ func TestRecordScanResults_SetsAttributes(t *testing.T) {
 func TestAddSpanEvent_RecordsEvent(t *testing.T) {
 	recorder := setupTracetestProvider(t)
 
-	_, span := StartSpan(context.Background(), "test.events")
+	_, span := StartSpan(t.Context(), "test.events")
 	AddSpanEvent(span, "cache.access",
 		AttrCacheType.String("osv"),
 		AttrCacheHit.Bool(true),
@@ -204,7 +204,7 @@ func TestAddSpanEvent_RecordsEvent(t *testing.T) {
 func TestRecordCacheAccess_AddsEvent(t *testing.T) {
 	recorder := setupTracetestProvider(t)
 
-	_, span := StartSpan(context.Background(), "test.cache")
+	_, span := StartSpan(t.Context(), "test.cache")
 	RecordCacheAccess(span, "depsdev", true, "pkg:golang/example")
 	RecordCacheAccess(span, "osv", false, "CVE-2021-1234")
 	span.End()
@@ -231,7 +231,7 @@ func TestRecordCacheAccess_AddsEvent(t *testing.T) {
 func TestRecordPolicyResult_AddsEvent(t *testing.T) {
 	recorder := setupTracetestProvider(t)
 
-	_, span := StartSpan(context.Background(), "test.policy")
+	_, span := StartSpan(t.Context(), "test.policy")
 	RecordPolicyResult(span, "block-critical", "deny")
 	span.End()
 
@@ -267,7 +267,7 @@ func TestRecordPolicyResult_AddsEvent(t *testing.T) {
 func TestWithCommandAttrs_SetsCommandAttribute(t *testing.T) {
 	recorder := setupTracetestProvider(t)
 
-	_, span := StartSpan(context.Background(), "deputy.cli",
+	_, span := StartSpan(t.Context(), "deputy.cli",
 		WithCommandAttrs("scan"))
 	span.End()
 
@@ -293,7 +293,7 @@ func TestWithCommandAttrs_SetsCommandAttribute(t *testing.T) {
 func TestWithTargetAttrs_SetsTargetAttributes(t *testing.T) {
 	recorder := setupTracetestProvider(t)
 
-	_, span := StartSpan(context.Background(), "deputy.scan",
+	_, span := StartSpan(t.Context(), "deputy.scan",
 		WithTargetAttrs("/path/to/repo", "v1.2.3", false))
 	span.End()
 
@@ -323,7 +323,7 @@ func TestWithTargetAttrs_SetsTargetAttributes(t *testing.T) {
 func TestNestedSpans_PreservesHierarchy(t *testing.T) {
 	recorder := setupTracetestProvider(t)
 
-	ctx, parentSpan := StartSpan(context.Background(), "parent")
+	ctx, parentSpan := StartSpan(t.Context(), "parent")
 	ctx, childSpan := StartSpan(ctx, "child")
 	_, grandchildSpan := StartSpan(ctx, "grandchild")
 
@@ -368,7 +368,7 @@ func TestNestedSpans_PreservesHierarchy(t *testing.T) {
 func TestSeverityCounts_Integration(t *testing.T) {
 	recorder := setupTracetestProvider(t)
 
-	ctx, span := StartSpan(context.Background(), "deputy.scan")
+	ctx, span := StartSpan(t.Context(), "deputy.scan")
 
 	sc := SeverityCounts{
 		Critical: 1,
@@ -407,7 +407,7 @@ func TestSeverityCounts_Integration(t *testing.T) {
 // TestSpanFromContext_ReturnsNoOpWhenMissing verifies graceful handling.
 func TestSpanFromContext_ReturnsNoOpWhenMissing(t *testing.T) {
 	// Don't set up a provider - use empty context
-	span := SpanFromContext(context.Background())
+	span := SpanFromContext(t.Context())
 
 	// Should return a no-op span that doesn't panic
 	span.SetAttributes(attribute.String("key", "value"))
@@ -428,7 +428,7 @@ func TestConcurrentSpans_ThreadSafe(t *testing.T) {
 
 	for i := range numGoroutines {
 		go func(id int) {
-			_, span := StartSpan(context.Background(), "concurrent.span")
+			_, span := StartSpan(t.Context(), "concurrent.span")
 			span.SetAttributes(attribute.Int("goroutine.id", id))
 			span.End()
 			done <- true
@@ -450,7 +450,7 @@ func TestConcurrentSpans_ThreadSafe(t *testing.T) {
 func TestOSVAttributes_Correctness(t *testing.T) {
 	recorder := setupTracetestProvider(t)
 
-	_, span := StartSpan(context.Background(), "deputy.osv.query",
+	_, span := StartSpan(t.Context(), "deputy.osv.query",
 		WithOSVAttrs(50, "batch"))
 	span.End()
 
@@ -477,7 +477,7 @@ func TestOSVAttributes_Correctness(t *testing.T) {
 func TestPolicyAttributes_Correctness(t *testing.T) {
 	recorder := setupTracetestProvider(t)
 
-	_, span := StartSpan(context.Background(), "deputy.policy.eval",
+	_, span := StartSpan(t.Context(), "deputy.policy.eval",
 		WithPolicyAttrs("block-critical", "scan_vulnerability"))
 	span.End()
 
@@ -504,7 +504,7 @@ func TestPolicyAttributes_Correctness(t *testing.T) {
 func TestProxyAttributes_Correctness(t *testing.T) {
 	recorder := setupTracetestProvider(t)
 
-	_, span := StartSpan(context.Background(), "deputy.proxy.request",
+	_, span := StartSpan(t.Context(), "deputy.proxy.request",
 		WithProxyAttrs("go-proxy", "go", "github.com/foo/bar", "v1.2.3"))
 	span.End()
 

--- a/internal/pin/container/strategy_test.go
+++ b/internal/pin/container/strategy_test.go
@@ -198,7 +198,7 @@ func TestStrategy_DiscoverDockerfile(t *testing.T) {
 	})
 
 	s := NewStrategy()
-	refs, err := s.Discover(context.Background(), fsys)
+	refs, err := s.Discover(t.Context(), fsys)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -225,7 +225,7 @@ func TestStrategy_DiscoverDockerfileWithPlatform(t *testing.T) {
 	})
 
 	s := NewStrategy()
-	refs, err := s.Discover(context.Background(), fsys)
+	refs, err := s.Discover(t.Context(), fsys)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -244,7 +244,7 @@ func TestStrategy_DiscoverDockerfileAlreadyPinned(t *testing.T) {
 	})
 
 	s := NewStrategy()
-	refs, err := s.Discover(context.Background(), fsys)
+	refs, err := s.Discover(t.Context(), fsys)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -263,7 +263,7 @@ func TestStrategy_DiscoverWorkflowDockerUses(t *testing.T) {
 	})
 
 	s := NewStrategy()
-	refs, err := s.Discover(context.Background(), fsys)
+	refs, err := s.Discover(t.Context(), fsys)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -290,7 +290,7 @@ func TestStrategy_DiscoverWorkflowContainer(t *testing.T) {
 	})
 
 	s := NewStrategy()
-	refs, err := s.Discover(context.Background(), fsys)
+	refs, err := s.Discover(t.Context(), fsys)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -306,7 +306,7 @@ func TestStrategy_DiscoverWorkflowContainerShortForm(t *testing.T) {
 	})
 
 	s := NewStrategy()
-	refs, err := s.Discover(context.Background(), fsys)
+	refs, err := s.Discover(t.Context(), fsys)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -327,7 +327,7 @@ func TestStrategy_DiscoverSkipsNonDockerfiles(t *testing.T) {
 	})
 
 	s := NewStrategy()
-	refs, err := s.Discover(context.Background(), fsys)
+	refs, err := s.Discover(t.Context(), fsys)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -343,7 +343,7 @@ func TestStrategy_DiscoverMixed(t *testing.T) {
 	})
 
 	s := NewStrategy()
-	refs, err := s.Discover(context.Background(), fsys)
+	refs, err := s.Discover(t.Context(), fsys)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -460,7 +460,7 @@ func TestStrategy_Resolve(t *testing.T) {
 		return "", fmt.Errorf("unknown image: %s", imageRef)
 	})
 
-	pinnedValue, versionTag, err := s.Resolve(context.Background(), pin.Ref{
+	pinnedValue, versionTag, err := s.Resolve(t.Context(), pin.Ref{
 		Name:    "alpine",
 		Version: "3.19",
 	})
@@ -488,7 +488,7 @@ func TestStrategy_ResolveUpdate_Changed(t *testing.T) {
 		return "", fmt.Errorf("unknown image: %s", imageRef)
 	})
 
-	pinnedValue, newTag, curTag, err := s.ResolveUpdate(context.Background(), pin.Ref{
+	pinnedValue, newTag, curTag, err := s.ResolveUpdate(t.Context(), pin.Ref{
 		Name:    "alpine",
 		Version: "3.19@" + oldDigest,
 	})
@@ -511,7 +511,7 @@ func TestStrategy_ResolveUpdate_NoChange(t *testing.T) {
 	})
 
 	ref := pin.Ref{Name: "alpine", Version: "3.19@" + digest}
-	pinnedValue, _, _, err := s.ResolveUpdate(context.Background(), ref)
+	pinnedValue, _, _, err := s.ResolveUpdate(t.Context(), ref)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -529,7 +529,7 @@ func TestStrategy_ResolveUpdate_DigestOnly(t *testing.T) {
 	})
 
 	ref := pin.Ref{Name: "alpine", Version: digest}
-	pinnedValue, _, _, err := s.ResolveUpdate(context.Background(), ref)
+	pinnedValue, _, _, err := s.ResolveUpdate(t.Context(), ref)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -540,7 +540,7 @@ func TestStrategy_ResolveUpdate_DigestOnly(t *testing.T) {
 
 func TestStrategy_Verify_ReturnsNil(t *testing.T) {
 	s := NewStrategy()
-	v, err := s.Verify(context.Background(), pin.Ref{})
+	v, err := s.Verify(t.Context(), pin.Ref{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pin/githubactions/strategy_test.go
+++ b/internal/pin/githubactions/strategy_test.go
@@ -25,7 +25,7 @@ jobs:
 	})
 
 	s := &Strategy{}
-	refs, err := s.Discover(context.Background(), fsys)
+	refs, err := s.Discover(t.Context(), fsys)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +71,7 @@ runs:
 	})
 
 	s := &Strategy{}
-	refs, err := s.Discover(context.Background(), fsys)
+	refs, err := s.Discover(t.Context(), fsys)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +88,7 @@ func TestStrategy_DiscoverNoWorkflows(t *testing.T) {
 	fsys := testMapFS(map[string]string{})
 
 	s := &Strategy{}
-	refs, err := s.Discover(context.Background(), fsys)
+	refs, err := s.Discover(t.Context(), fsys)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +108,7 @@ runs:
 	})
 
 	s := &Strategy{}
-	refs, err := s.Discover(context.Background(), fsys)
+	refs, err := s.Discover(t.Context(), fsys)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,7 +131,7 @@ runs:
 	})
 
 	s := &Strategy{}
-	refs, err := s.Discover(context.Background(), fsys)
+	refs, err := s.Discover(t.Context(), fsys)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -150,7 +150,7 @@ runs:
 	})
 
 	s := &Strategy{}
-	refs, err := s.Discover(context.Background(), fsys)
+	refs, err := s.Discover(t.Context(), fsys)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -165,7 +165,7 @@ func TestStrategy_DiscoverMalformedYAML(t *testing.T) {
 	})
 
 	s := &Strategy{}
-	refs, err := s.Discover(context.Background(), fsys)
+	refs, err := s.Discover(t.Context(), fsys)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -193,7 +193,7 @@ runs:
 	})
 
 	s := &Strategy{}
-	refs, err := s.Discover(context.Background(), fsys)
+	refs, err := s.Discover(t.Context(), fsys)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +223,7 @@ jobs:
 	})
 
 	s := &Strategy{}
-	refs, err := s.Discover(context.Background(), fsys)
+	refs, err := s.Discover(t.Context(), fsys)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -253,7 +253,7 @@ jobs:
 	})
 
 	s := &Strategy{}
-	refs, err := s.Discover(context.Background(), fsys)
+	refs, err := s.Discover(t.Context(), fsys)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -288,7 +288,7 @@ jobs:
 	})
 
 	s := &Strategy{}
-	refs, err := s.Discover(context.Background(), fsys)
+	refs, err := s.Discover(t.Context(), fsys)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -318,7 +318,7 @@ jobs:
 	})
 
 	s := &Strategy{}
-	refs, err := s.Discover(context.Background(), fsys)
+	refs, err := s.Discover(t.Context(), fsys)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -400,7 +400,7 @@ func TestStrategy_ResolveUpdate(t *testing.T) {
 	}
 
 	ref := pin.Ref{Name: "actions/checkout", Version: oldSHA}
-	pinnedValue, newTag, currentTag, err := s.ResolveUpdate(context.Background(), ref)
+	pinnedValue, newTag, currentTag, err := s.ResolveUpdate(t.Context(), ref)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -427,7 +427,7 @@ func TestStrategy_ResolveUpdateNoChange(t *testing.T) {
 	}
 
 	ref := pin.Ref{Name: "actions/checkout", Version: sha}
-	pinnedValue, _, _, err := s.ResolveUpdate(context.Background(), ref)
+	pinnedValue, _, _, err := s.ResolveUpdate(t.Context(), ref)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -444,4 +444,3 @@ func testResolver(refs []refEntry) *Resolver {
 	}
 	return r
 }
-

--- a/internal/pin/githubactions/verifier_test.go
+++ b/internal/pin/githubactions/verifier_test.go
@@ -1,7 +1,6 @@
 package githubactions
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -47,7 +46,7 @@ func TestVerifier_SignedCommit(t *testing.T) {
 	client := testGHClient(t, srv.URL)
 	v := NewVerifier(client)
 
-	result, err := v.Verify(context.Background(), owner, repo, sha)
+	result, err := v.Verify(t.Context(), owner, repo, sha)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +93,7 @@ func TestVerifier_UnsignedCommit(t *testing.T) {
 	client := testGHClient(t, srv.URL)
 	v := NewVerifier(client)
 
-	result, err := v.Verify(context.Background(), owner, repo, sha)
+	result, err := v.Verify(t.Context(), owner, repo, sha)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -123,7 +122,7 @@ func TestVerifier_NotFound(t *testing.T) {
 	client := testGHClient(t, srv.URL)
 	v := NewVerifier(client)
 
-	result, err := v.Verify(context.Background(), owner, repo, sha)
+	result, err := v.Verify(t.Context(), owner, repo, sha)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -162,7 +161,7 @@ func TestVerifier_BranchNotReachable(t *testing.T) {
 	client := testGHClient(t, srv.URL)
 	v := NewVerifier(client)
 
-	result, err := v.Verify(context.Background(), owner, repo, sha)
+	result, err := v.Verify(t.Context(), owner, repo, sha)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -200,7 +199,7 @@ func TestVerifier_ImposterHeuristic(t *testing.T) {
 	client := testGHClient(t, srv.URL)
 	v := NewVerifier(client)
 
-	result, err := v.Verify(context.Background(), owner, repo, sha)
+	result, err := v.Verify(t.Context(), owner, repo, sha)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -265,7 +264,7 @@ func TestVerifier_AnnotatedTagObject(t *testing.T) {
 	client := testGHClient(t, srv.URL)
 	v := NewVerifier(client)
 
-	result, err := v.Verify(context.Background(), owner, repo, tagObjSHA)
+	result, err := v.Verify(t.Context(), owner, repo, tagObjSHA)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -309,7 +308,7 @@ func TestVerifier_RenamedRepoGraceful(t *testing.T) {
 	client := testGHClient(t, srv.URL)
 	v := NewVerifier(client)
 
-	result, err := v.Verify(context.Background(), owner, repo, sha)
+	result, err := v.Verify(t.Context(), owner, repo, sha)
 	if err != nil {
 		t.Fatalf("expected graceful degradation, got error: %v", err)
 	}
@@ -351,7 +350,7 @@ func TestVerifier_RateLimited_Unverifiable(t *testing.T) {
 	client := testGHClient(t, srv.URL)
 	v := NewVerifier(client)
 
-	result, err := v.Verify(context.Background(), owner, repo, sha)
+	result, err := v.Verify(t.Context(), owner, repo, sha)
 	if err != nil {
 		t.Fatalf("expected graceful handling, got error: %v", err)
 	}
@@ -396,7 +395,7 @@ func TestVerifier_RateLimited_SignedPasses(t *testing.T) {
 	client := testGHClient(t, srv.URL)
 	v := NewVerifier(client)
 
-	result, err := v.Verify(context.Background(), owner, repo, sha)
+	result, err := v.Verify(t.Context(), owner, repo, sha)
 	if err != nil {
 		t.Fatalf("expected graceful handling, got error: %v", err)
 	}
@@ -460,7 +459,7 @@ func TestVerifier_NestedAnnotatedTags(t *testing.T) {
 	client := testGHClient(t, srv.URL)
 	v := NewVerifier(client)
 
-	result, err := v.Verify(context.Background(), owner, repo, outerTagSHA)
+	result, err := v.Verify(t.Context(), owner, repo, outerTagSHA)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/pin/pin_test.go
+++ b/internal/pin/pin_test.go
@@ -203,7 +203,7 @@ func TestPin_BasicPinning(t *testing.T) {
 		},
 	}
 
-	report, err := Pin(context.Background(), testRoot(t), Options{SkipVerification: true}, strategy)
+	report, err := Pin(t.Context(), testRoot(t), Options{SkipVerification: true}, strategy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -310,7 +310,7 @@ func TestPin_DryRun(t *testing.T) {
 		},
 	}
 
-	report, err := Pin(context.Background(), testRoot(t), Options{DryRun: true, SkipVerification: true}, strategy)
+	report, err := Pin(t.Context(), testRoot(t), Options{DryRun: true, SkipVerification: true}, strategy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -489,7 +489,7 @@ func TestVerify_Basic(t *testing.T) {
 		},
 	}
 
-	report, err := Verify(context.Background(), testRoot(t), Options{}, strategy)
+	report, err := Verify(t.Context(), testRoot(t), Options{}, strategy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -518,7 +518,7 @@ func TestVerify_Suspicious(t *testing.T) {
 		},
 	}
 
-	report, err := Verify(context.Background(), testRoot(t), Options{}, strategy)
+	report, err := Verify(t.Context(), testRoot(t), Options{}, strategy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -539,7 +539,7 @@ func TestVerify_NoVerifierAvailable(t *testing.T) {
 		},
 	}
 
-	report, err := Verify(context.Background(), testRoot(t), Options{}, strategy)
+	report, err := Verify(t.Context(), testRoot(t), Options{}, strategy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -576,7 +576,7 @@ func TestVerify_Error(t *testing.T) {
 		verifyErr: fmt.Errorf("API rate limit exceeded"),
 	}
 
-	report, err := Verify(context.Background(), testRoot(t), Options{}, strategy)
+	report, err := Verify(t.Context(), testRoot(t), Options{}, strategy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -594,7 +594,7 @@ func TestPin_AlreadyPinned(t *testing.T) {
 		},
 	}
 
-	report, err := Pin(context.Background(), testRoot(t), Options{SkipVerification: true}, strategy)
+	report, err := Pin(t.Context(), testRoot(t), Options{SkipVerification: true}, strategy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -611,7 +611,7 @@ func TestPin_SkippedExpressionRef(t *testing.T) {
 		},
 	}
 
-	report, err := Pin(context.Background(), testRoot(t), Options{SkipVerification: true}, strategy)
+	report, err := Pin(t.Context(), testRoot(t), Options{SkipVerification: true}, strategy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -632,7 +632,7 @@ func TestPin_ResolutionError(t *testing.T) {
 		resolveErr: fmt.Errorf("rate limit exceeded"),
 	}
 
-	report, err := Pin(context.Background(), testRoot(t), Options{SkipVerification: true}, strategy)
+	report, err := Pin(t.Context(), testRoot(t), Options{SkipVerification: true}, strategy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -656,7 +656,7 @@ func TestPin_Suspicious(t *testing.T) {
 	}
 
 	// In error mode a flagged ref is left unpinned and counted suspicious.
-	report, err := Pin(context.Background(), testRoot(t), Options{Verification: VerificationError}, strategy)
+	report, err := Pin(t.Context(), testRoot(t), Options{Verification: VerificationError}, strategy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -679,7 +679,7 @@ func TestPin_MixedResults(t *testing.T) {
 		},
 	}
 
-	report, err := Pin(context.Background(), testRoot(t), Options{SkipVerification: true}, strategy)
+	report, err := Pin(t.Context(), testRoot(t), Options{SkipVerification: true}, strategy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -724,7 +724,7 @@ func TestRef_IsSHAPinned(t *testing.T) {
 }
 
 func TestPin_ContextCancellation(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // cancel immediately
 
 	strategy := &mockStrategy{
@@ -752,7 +752,7 @@ func TestPin_VerificationErrorReported(t *testing.T) {
 		verifyErr: fmt.Errorf("API rate limit exceeded"),
 	}
 
-	report, err := Pin(context.Background(), testRoot(t), Options{}, strategy)
+	report, err := Pin(t.Context(), testRoot(t), Options{}, strategy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -789,7 +789,7 @@ func TestOptions_Concurrency(t *testing.T) {
 
 func TestPin_EmptyRefs(t *testing.T) {
 	strategy := &mockStrategy{refs: nil}
-	report, err := Pin(context.Background(), testRoot(t), Options{}, strategy)
+	report, err := Pin(t.Context(), testRoot(t), Options{}, strategy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -810,7 +810,7 @@ func TestPin_MultipleStrategies(t *testing.T) {
 		},
 	}
 
-	report, err := Pin(context.Background(), testRoot(t), Options{SkipVerification: true}, s1, s2)
+	report, err := Pin(t.Context(), testRoot(t), Options{SkipVerification: true}, s1, s2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -830,7 +830,7 @@ func TestPin_WriteStrategyError(t *testing.T) {
 		rewriteErr: fmt.Errorf("permission denied"),
 	}
 
-	_, err := Pin(context.Background(), testRoot(t), Options{SkipVerification: true}, strategy)
+	_, err := Pin(t.Context(), testRoot(t), Options{SkipVerification: true}, strategy)
 	if err == nil {
 		t.Fatal("expected error from rewrite failure")
 	}
@@ -870,7 +870,7 @@ func TestPin_StrategyIsPinnedUsed(t *testing.T) {
 		},
 	}
 
-	report, err := Pin(context.Background(), testRoot(t), Options{SkipVerification: true}, strategy)
+	report, err := Pin(t.Context(), testRoot(t), Options{SkipVerification: true}, strategy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -894,7 +894,7 @@ func TestPin_StrategyShouldSkipUsed(t *testing.T) {
 		},
 	}
 
-	report, err := Pin(context.Background(), testRoot(t), Options{SkipVerification: true}, strategy)
+	report, err := Pin(t.Context(), testRoot(t), Options{SkipVerification: true}, strategy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -936,7 +936,7 @@ func TestCheck_AllPinned(t *testing.T) {
 		},
 	}
 
-	report, err := Check(context.Background(), testRoot(t), Options{}, strategy)
+	report, err := Check(t.Context(), testRoot(t), Options{}, strategy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -958,7 +958,7 @@ func TestCheck_HasUnpinned(t *testing.T) {
 		},
 	}
 
-	report, err := Check(context.Background(), testRoot(t), Options{}, strategy)
+	report, err := Check(t.Context(), testRoot(t), Options{}, strategy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -978,7 +978,7 @@ func TestCheck_WithExclude(t *testing.T) {
 		},
 	}
 
-	report, err := Check(context.Background(), testRoot(t), Options{
+	report, err := Check(t.Context(), testRoot(t), Options{
 		Exclude: []string{"actions/checkout"},
 	}, strategy)
 	if err != nil {
@@ -999,7 +999,7 @@ func TestCheck_SkipsExpressions(t *testing.T) {
 		},
 	}
 
-	report, err := Check(context.Background(), testRoot(t), Options{}, strategy)
+	report, err := Check(t.Context(), testRoot(t), Options{}, strategy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1022,7 +1022,7 @@ func TestUpdate_BasicUpdate(t *testing.T) {
 		},
 	}
 
-	report, err := PinUpdate(context.Background(), testRoot(t), Options{SkipVerification: true}, strategy)
+	report, err := PinUpdate(t.Context(), testRoot(t), Options{SkipVerification: true}, strategy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1048,7 +1048,7 @@ func TestUpdate_NoChange(t *testing.T) {
 		},
 	}
 
-	report, err := PinUpdate(context.Background(), testRoot(t), Options{SkipVerification: true}, strategy)
+	report, err := PinUpdate(t.Context(), testRoot(t), Options{SkipVerification: true}, strategy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1070,7 +1070,7 @@ func TestUpdate_SkipsUnpinned(t *testing.T) {
 		},
 	}
 
-	report, err := PinUpdate(context.Background(), testRoot(t), Options{SkipVerification: true}, strategy)
+	report, err := PinUpdate(t.Context(), testRoot(t), Options{SkipVerification: true}, strategy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1094,7 +1094,7 @@ func TestUpdate_DryRun(t *testing.T) {
 		},
 	}
 
-	report, err := PinUpdate(context.Background(), testRoot(t), Options{DryRun: true, SkipVerification: true}, strategy)
+	report, err := PinUpdate(t.Context(), testRoot(t), Options{DryRun: true, SkipVerification: true}, strategy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1114,7 +1114,7 @@ func TestUpdate_WithExclude(t *testing.T) {
 		},
 	}
 
-	report, err := PinUpdate(context.Background(), testRoot(t), Options{
+	report, err := PinUpdate(t.Context(), testRoot(t), Options{
 		SkipVerification: true,
 		Exclude:          []string{"actions/checkout"},
 	}, strategy)
@@ -1142,7 +1142,7 @@ func TestUpdate_Suspicious(t *testing.T) {
 	}
 
 	// In error mode a flagged update is left unpinned and counted suspicious.
-	report, err := PinUpdate(context.Background(), testRoot(t), Options{Verification: VerificationError}, strategy)
+	report, err := PinUpdate(t.Context(), testRoot(t), Options{Verification: VerificationError}, strategy)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1197,7 +1197,7 @@ func TestPin_WithExclude(t *testing.T) {
 		},
 	}
 
-	report, err := Pin(context.Background(), testRoot(t), Options{
+	report, err := Pin(t.Context(), testRoot(t), Options{
 		SkipVerification: true,
 		Exclude:          []string{"actions/checkout"},
 	}, strategy)
@@ -1306,7 +1306,7 @@ jobs:
 		digest: digest,
 	}
 
-	report, err := Pin(context.Background(), root, Options{SkipVerification: true}, gha, ctr)
+	report, err := Pin(t.Context(), root, Options{SkipVerification: true}, gha, ctr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/policy/bundle_structured_test.go
+++ b/internal/policy/bundle_structured_test.go
@@ -1,7 +1,6 @@
 package policy
 
 import (
-	"context"
 	"strings"
 	"testing"
 )
@@ -52,7 +51,7 @@ func TestLiteralsNestedListsAndMapsEvaluate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("toCELSource: %v", err)
 	}
-	val, err := Evaluate(context.Background(), src, nil)
+	val, err := Evaluate(t.Context(), src, nil)
 	if err != nil {
 		t.Fatalf("Evaluate: %v", err)
 	}

--- a/internal/policy/engine_advisory_test.go
+++ b/internal/policy/engine_advisory_test.go
@@ -1,7 +1,6 @@
 package policy
 
 import (
-	"context"
 	"testing"
 )
 
@@ -16,7 +15,7 @@ true ? [{"action":"deny","reason":"block it"}] : []`,
 	if err != nil {
 		t.Fatalf("NewEngine: %v", err)
 	}
-	actions, err := eng.EvaluateAll(context.Background(), nil, "proxy", "")
+	actions, err := eng.EvaluateAll(t.Context(), nil, "proxy", "")
 	if err != nil {
 		t.Fatalf("EvaluateAll: %v", err)
 	}
@@ -51,7 +50,7 @@ func TestStructuredPolicyModeAdvisory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewEngine: %v", err)
 	}
-	acts, err := eng.EvaluateAll(context.Background(), nil, "scan", "scan_report")
+	acts, err := eng.EvaluateAll(t.Context(), nil, "scan", "scan_report")
 	if err != nil {
 		t.Fatalf("EvaluateAll: %v", err)
 	}

--- a/internal/policy/lsp/rpc_harness_test.go
+++ b/internal/policy/lsp/rpc_harness_test.go
@@ -14,7 +14,7 @@ import (
 // TestLSPDiagnosticsAndCodeActionsEndToEnd simulates a client talking to the LSP
 // over an in-memory net.Pipe to ensure initialize -> didOpen -> diagnostics -> codeAction flow works.
 func TestLSPDiagnosticsAndCodeActionsEndToEnd(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 	defer cancel()
 
 	serverSide, clientSide := net.Pipe()

--- a/internal/policy/policy_entrypoints_newpolicies_test.go
+++ b/internal/policy/policy_entrypoints_newpolicies_test.go
@@ -1,7 +1,6 @@
 package policy
 
 import (
-	"context"
 	"path/filepath"
 	"slices"
 	"testing"
@@ -35,7 +34,7 @@ func TestCriticalTransitiveSpotlight(t *testing.T) {
 		},
 		Env: &policyv1.Environment{Command: "scan", Entrypoint: "scan_vulnerability"},
 	}
-	actions, err := EvaluateAll(context.Background(), sources, input)
+	actions, err := EvaluateAll(t.Context(), sources, input)
 	if err != nil {
 		t.Fatalf("EvaluateAll: %v", err)
 	}
@@ -57,7 +56,7 @@ func TestTyposquatLevenshteinGuard(t *testing.T) {
 			Pkg:     &dependencyv1.Package{Name: "lodas", Ecosystem: "npm"},
 			Env:     &policyv1.Environment{Command: "proxy"},
 		}
-		if actions, err := EvaluateAll(context.Background(), sources, input); err != nil || len(actions) == 0 || actions[0].Type != "deny" {
+		if actions, err := EvaluateAll(t.Context(), sources, input); err != nil || len(actions) == 0 || actions[0].Type != "deny" {
 			t.Fatalf("expected deny for typosquat, got %+v err=%v", actions, err)
 		}
 	})
@@ -68,7 +67,7 @@ func TestTyposquatLevenshteinGuard(t *testing.T) {
 			Pkg:     &dependencyv1.Package{Name: "reqeusts", Ecosystem: "npm"},
 			Env:     &policyv1.Environment{Command: "proxy"},
 		}
-		if actions, err := EvaluateAll(context.Background(), sources, input); err != nil || len(actions) == 0 || actions[0].Type != "deny" {
+		if actions, err := EvaluateAll(t.Context(), sources, input); err != nil || len(actions) == 0 || actions[0].Type != "deny" {
 			t.Fatalf("expected deny for typosquat, got %+v err=%v", actions, err)
 		}
 	})
@@ -79,7 +78,7 @@ func TestTyposquatLevenshteinGuard(t *testing.T) {
 			Pkg:     &dependencyv1.Package{Name: "teamlib", Ecosystem: "npm"},
 			Env:     &policyv1.Environment{Command: "proxy"},
 		}
-		actions, err := EvaluateAll(context.Background(), sources, input)
+		actions, err := EvaluateAll(t.Context(), sources, input)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -96,7 +95,7 @@ func TestTyposquatLevenshteinGuard(t *testing.T) {
 			Pkg:     &dependencyv1.Package{Name: "@acme/lodas", Ecosystem: "npm"},
 			Env:     &policyv1.Environment{Command: "proxy"},
 		}
-		actions, err := EvaluateAll(context.Background(), sources, input)
+		actions, err := EvaluateAll(t.Context(), sources, input)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -113,7 +112,7 @@ func TestTyposquatLevenshteinGuard(t *testing.T) {
 			Pkg:     &dependencyv1.Package{Name: "react2", Ecosystem: "npm"},
 			Env:     &policyv1.Environment{Command: "proxy"},
 		}
-		actions, err := EvaluateAll(context.Background(), sources, input)
+		actions, err := EvaluateAll(t.Context(), sources, input)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -130,7 +129,7 @@ func TestTyposquatLevenshteinGuard(t *testing.T) {
 			Pkg:     &dependencyv1.Package{Name: "lodas", Ecosystem: "npm"},
 			Env:     &policyv1.Environment{Command: "scan"},
 		}
-		actions, err := EvaluateAll(context.Background(), sources, input)
+		actions, err := EvaluateAll(t.Context(), sources, input)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -148,8 +147,6 @@ func TestContainerLayerVulnerabilityPolicies(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadSources: %v", err)
 	}
-
-	
 
 	t.Run("deny critical base image vulnerability", func(t *testing.T) {
 		payload := map[string]any{
@@ -171,7 +168,7 @@ func TestContainerLayerVulnerabilityPolicies(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "scan", Entrypoint: "scan_vulnerability"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -201,7 +198,7 @@ func TestContainerLayerVulnerabilityPolicies(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "scan", Entrypoint: "scan_vulnerability"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -229,7 +226,7 @@ func TestContainerLayerVulnerabilityPolicies(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "scan", Entrypoint: "scan_vulnerability"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -259,7 +256,7 @@ func TestContainerLayerVulnerabilityPolicies(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "scan", Entrypoint: "scan_vulnerability"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -289,7 +286,7 @@ func TestContainerLayerVulnerabilityPolicies(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "scan", Entrypoint: "scan_vulnerability"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -319,7 +316,7 @@ func TestContainerLayerVulnerabilityPolicies(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "scan", Entrypoint: "scan_vulnerability"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -348,7 +345,7 @@ func TestContainerLayerVulnerabilityPolicies(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "scan", Entrypoint: "scan_vulnerability"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -377,7 +374,7 @@ func TestContainerLayerVulnerabilityPolicies(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "scan", Entrypoint: "scan_vulnerability"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -405,7 +402,7 @@ func TestContainerLayerVulnerabilityPolicies(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "scan", Entrypoint: "scan_vulnerability"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -433,7 +430,7 @@ func TestContainerLayerVulnerabilityPolicies(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "scan", Entrypoint: "scan_vulnerability"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}

--- a/internal/policy/policy_entrypoints_test.go
+++ b/internal/policy/policy_entrypoints_test.go
@@ -1,7 +1,6 @@
 package policy
 
 import (
-	"context"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -41,7 +40,7 @@ func TestLicenseAllowlistEntrypoints(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "sbom"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -60,7 +59,7 @@ func TestLicenseAllowlistEntrypoints(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "proxy"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -74,7 +73,7 @@ func TestLicenseAllowlistEntrypoints(t *testing.T) {
 			"pkg": &dependencyv1.Package{Name: "test-pkg"},
 			"env": &policyv1.Environment{Command: "sbom"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -88,7 +87,7 @@ func TestLicenseAllowlistEntrypoints(t *testing.T) {
 			"pkg": &dependencyv1.Package{Name: "test-pkg"},
 			"env": &policyv1.Environment{Command: "scan"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -123,7 +122,7 @@ func TestLicenseAllowlistComposedEntrypoints(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "sbom"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -144,7 +143,7 @@ func TestLicenseAllowlistComposedEntrypoints(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "sbom"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -162,7 +161,7 @@ func TestLicenseAllowlistComposedEntrypoints(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "proxy"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -174,9 +173,9 @@ func TestLicenseAllowlistComposedEntrypoints(t *testing.T) {
 	t.Run("sbom warn on missing licenses", func(t *testing.T) {
 		payload := map[string]any{
 			"pkg": &dependencyv1.Package{Name: "test-pkg"},
-			"env":       &policyv1.Environment{Command: "sbom"},
+			"env": &policyv1.Environment{Command: "sbom"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -197,7 +196,7 @@ func TestLicenseAllowlistHappySadPaths(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "sbom"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -216,7 +215,7 @@ func TestLicenseAllowlistHappySadPaths(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "proxy"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -242,7 +241,7 @@ func TestDenyAwsSdkV1Policy(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "proxy"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -266,7 +265,7 @@ func TestDenyAwsSdkV1Policy(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "proxy"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -294,7 +293,7 @@ func TestGoModRegistryAllowlist(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "proxy"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -318,7 +317,7 @@ func TestGoModRegistryAllowlist(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "proxy"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -345,7 +344,7 @@ func TestGoPseudoVersionDenyPolicy(t *testing.T) {
 				Version:   "v1.2.3-0.20240528123456-deadbeefcafe",
 			},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -368,7 +367,7 @@ func TestGoPseudoVersionDenyPolicy(t *testing.T) {
 				Version:   "v0.0.0-20170915030341-ba0f2cc1c8ab",
 			},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -391,7 +390,7 @@ func TestGoPseudoVersionDenyPolicy(t *testing.T) {
 				Version:   "v1.2.3",
 			},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -416,7 +415,7 @@ func TestPrereleaseGuardPolicy(t *testing.T) {
 				Version: "v1.2.3-beta.1",
 			},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -431,7 +430,7 @@ func TestPrereleaseGuardPolicy(t *testing.T) {
 				Version: "1.2.3",
 			},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -450,7 +449,6 @@ func TestDirectHighFixBlock(t *testing.T) {
 		t.Fatalf("LoadSources: %v", err)
 	}
 
-	
 	// vulnerability.advisory.fixed_versions, so we must use proto types.
 	t.Run("deny direct high with fix", func(t *testing.T) {
 		payload := map[string]any{
@@ -469,7 +467,7 @@ func TestDirectHighFixBlock(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "scan", Entrypoint: "scan_vulnerability"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -501,7 +499,7 @@ func TestDirectHighFixBlock(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "scan", Entrypoint: "scan_vulnerability"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -529,7 +527,7 @@ func TestNewDependencyReview(t *testing.T) {
 			"pkg": pkg,
 			"env": &policyv1.Environment{Command: "diff", Entrypoint: "diff_dependency_change"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -553,7 +551,7 @@ func TestNewDependencyReview(t *testing.T) {
 			"pkg": pkg,
 			"env": &policyv1.Environment{Command: "diff", Entrypoint: "diff_dependency_change"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -580,7 +578,7 @@ func TestFixStepCommandAllowlist(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "fix", Entrypoint: "fix_plan_step"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -603,7 +601,7 @@ func TestFixStepCommandAllowlist(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "fix", Entrypoint: "fix_plan_step"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -630,7 +628,7 @@ func TestSbomMetadataQuality(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "sbom", Entrypoint: "sbom_component"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -654,7 +652,7 @@ func TestSbomMetadataQuality(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "sbom", Entrypoint: "sbom_component"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -681,7 +679,7 @@ func TestUnstableMajorGuard(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "proxy"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -704,7 +702,7 @@ func TestUnstableMajorGuard(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "proxy"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -735,7 +733,7 @@ func TestPypiPrefixAllowlist(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "proxy", Entrypoint: "pypi_artifact_request"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -762,7 +760,7 @@ func TestPypiPrefixAllowlist(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "proxy", Entrypoint: "pypi_artifact_request"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -785,7 +783,7 @@ func TestDependencyCountGuard(t *testing.T) {
 		"changes": make([]any, 80),
 		"env":     &policyv1.Environment{Command: "diff", Entrypoint: "diff_report"},
 	}
-	if actions, err := EvaluateMap(context.Background(), sources, denyPayload); err != nil || len(actions) == 0 || actions[0].Type != "deny" {
+	if actions, err := EvaluateMap(t.Context(), sources, denyPayload); err != nil || len(actions) == 0 || actions[0].Type != "deny" {
 		t.Fatalf("expected deny for large change set, got %+v err=%v", actions, err)
 	}
 
@@ -793,7 +791,7 @@ func TestDependencyCountGuard(t *testing.T) {
 		"changes": make([]any, 30),
 		"env":     &policyv1.Environment{Command: "diff", Entrypoint: "diff_report"},
 	}
-	actions, err := EvaluateMap(context.Background(), sources, warnPayload)
+	actions, err := EvaluateMap(t.Context(), sources, warnPayload)
 	if err != nil {
 		t.Fatalf("EvaluateAll: %v", err)
 	}
@@ -812,14 +810,14 @@ func TestLicensePresentBlocker(t *testing.T) {
 		"pkg": &dependencyv1.Package{Licenses: []string{}},
 		"env": &policyv1.Environment{Command: "proxy"},
 	}
-	if actions, err := EvaluateMap(context.Background(), sources, denyPayload); err != nil || len(actions) == 0 || actions[0].Type != "deny" {
+	if actions, err := EvaluateMap(t.Context(), sources, denyPayload); err != nil || len(actions) == 0 || actions[0].Type != "deny" {
 		t.Fatalf("expected deny for missing licenses, got %+v err=%v", actions, err)
 	}
 	allowPayload := map[string]any{
 		"pkg": &dependencyv1.Package{Licenses: []string{"MIT"}},
 		"env": &policyv1.Environment{Command: "proxy"},
 	}
-	if actions, err := EvaluateMap(context.Background(), sources, allowPayload); err != nil {
+	if actions, err := EvaluateMap(t.Context(), sources, allowPayload); err != nil {
 		t.Fatalf("EvaluateAll: %v", err)
 	} else {
 		for _, a := range actions {
@@ -836,7 +834,7 @@ func TestNoFixEscalator(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadSources: %v", err)
 	}
-	
+
 	// vulnerability.advisory.severity.level
 	payload := map[string]any{
 		"vulnerability": &vulnerabilityv1.Finding{
@@ -852,7 +850,7 @@ func TestNoFixEscalator(t *testing.T) {
 		},
 		"env": &policyv1.Environment{Command: "scan", Entrypoint: "scan_vulnerability"},
 	}
-	actions, err := EvaluateMap(context.Background(), sources, payload)
+	actions, err := EvaluateMap(t.Context(), sources, payload)
 	if err != nil {
 		t.Fatalf("EvaluateAll: %v", err)
 	}
@@ -873,7 +871,7 @@ func TestProdManifestGate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadSources: %v", err)
 	}
-	
+
 	payload := map[string]any{
 		"vulnerability": &vulnerabilityv1.Finding{
 			Package: &dependencyv1.Package{
@@ -889,7 +887,7 @@ func TestProdManifestGate(t *testing.T) {
 		},
 		"env": &policyv1.Environment{Command: "scan", Entrypoint: "scan_vulnerability"},
 	}
-	if actions, err := EvaluateMap(context.Background(), sources, payload); err != nil || len(actions) == 0 || actions[0].Type != "deny" {
+	if actions, err := EvaluateMap(t.Context(), sources, payload); err != nil || len(actions) == 0 || actions[0].Type != "deny" {
 		t.Fatalf("expected deny for prod manifest vuln, got %+v err=%v", actions, err)
 	}
 }
@@ -909,7 +907,7 @@ func TestDomainBrandedPackageGuard(t *testing.T) {
 		},
 		"env": &policyv1.Environment{Command: "proxy"},
 	}
-	if actions, err := EvaluateMap(context.Background(), sources, payload); err != nil || len(actions) == 0 || actions[0].Type != "deny" {
+	if actions, err := EvaluateMap(t.Context(), sources, payload); err != nil || len(actions) == 0 || actions[0].Type != "deny" {
 		t.Fatalf("expected deny for branded package, got %+v err=%v", actions, err)
 	}
 }
@@ -929,7 +927,7 @@ func TestCriticalRuntimePinning(t *testing.T) {
 		"pkg": pkg,
 		"env": &policyv1.Environment{Command: "diff", Entrypoint: "diff_dependency_change"},
 	}
-	if actions, err := EvaluateMap(context.Background(), sources, payload); err != nil {
+	if actions, err := EvaluateMap(t.Context(), sources, payload); err != nil {
 		t.Fatalf("EvaluateAll: %v", err)
 	} else {
 		warn := false
@@ -955,7 +953,7 @@ func TestSbomSizeShapeSanity(t *testing.T) {
 		"packages": components,
 		"env":      &policyv1.Environment{Command: "sbom", Entrypoint: "sbom_report"},
 	}
-	if actions, err := EvaluateMap(context.Background(), sources, payload); err != nil {
+	if actions, err := EvaluateMap(t.Context(), sources, payload); err != nil {
 		t.Fatalf("EvaluateAll: %v", err)
 	} else {
 		warn := false
@@ -976,7 +974,6 @@ func TestExploitAvailableBlocker(t *testing.T) {
 		t.Fatalf("LoadSources: %v", err)
 	}
 
-	
 	t.Run("deny when exploit referenced", func(t *testing.T) {
 		payload := map[string]any{
 			"vulnerability": &vulnerabilityv1.Finding{
@@ -989,7 +986,7 @@ func TestExploitAvailableBlocker(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "scan", Entrypoint: "scan_vulnerability"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -1016,7 +1013,7 @@ func TestExploitAvailableBlocker(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "scan", Entrypoint: "scan_vulnerability"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -1035,7 +1032,6 @@ func TestDeprecatedModuleBlock(t *testing.T) {
 		t.Fatalf("LoadSources: %v", err)
 	}
 
-	
 	t.Run("deny deprecated in summary", func(t *testing.T) {
 		payload := map[string]any{
 			"vulnerability": &vulnerabilityv1.Finding{
@@ -1045,7 +1041,7 @@ func TestDeprecatedModuleBlock(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "scan", Entrypoint: "scan_vulnerability"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -1069,7 +1065,7 @@ func TestDeprecatedModuleBlock(t *testing.T) {
 			},
 			"env": &policyv1.Environment{Command: "scan", Entrypoint: "scan_vulnerability"},
 		}
-		actions, err := EvaluateMap(context.Background(), sources, payload)
+		actions, err := EvaluateMap(t.Context(), sources, payload)
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
@@ -1091,7 +1087,7 @@ func TestBlockPackagePolicy(t *testing.T) {
 		"pkg": &dependencyv1.Package{Name: "left-pad"},
 		"env": &policyv1.Environment{Command: "proxy"},
 	}
-	actions, err := EvaluateMap(context.Background(), sources, payload)
+	actions, err := EvaluateMap(t.Context(), sources, payload)
 	if err != nil {
 		t.Fatalf("EvaluateAll: %v", err)
 	}
@@ -1114,7 +1110,7 @@ func TestGoDowngradeGuard(t *testing.T) {
 		"pkg": pkg,
 		"env": &policyv1.Environment{Command: "diff", Entrypoint: "diff_dependency_change"},
 	}
-	if actions, err := EvaluateMap(context.Background(), sources, denyPayload); err != nil || len(actions) == 0 || actions[0].Type != "deny" {
+	if actions, err := EvaluateMap(t.Context(), sources, denyPayload); err != nil || len(actions) == 0 || actions[0].Type != "deny" {
 		t.Fatalf("expected deny for go downgrade, got %+v err=%v", actions, err)
 	}
 	allowPayload := map[string]any{
@@ -1124,7 +1120,7 @@ func TestGoDowngradeGuard(t *testing.T) {
 		"pkg": pkg,
 		"env": &policyv1.Environment{Command: "diff", Entrypoint: "diff_dependency_change"},
 	}
-	if actions, err := EvaluateMap(context.Background(), sources, allowPayload); err != nil {
+	if actions, err := EvaluateMap(t.Context(), sources, allowPayload); err != nil {
 		t.Fatalf("EvaluateAll: %v", err)
 	} else {
 		for _, a := range actions {
@@ -1145,7 +1141,7 @@ func TestLicenseAllowlistAdvisory(t *testing.T) {
 		"pkg": &dependencyv1.Package{Licenses: []string{"AGPL-3.0"}},
 		"env": &policyv1.Environment{Command: "proxy"},
 	}
-	actions, err := EvaluateMap(context.Background(), sources, payload)
+	actions, err := EvaluateMap(t.Context(), sources, payload)
 	if err != nil {
 		t.Fatalf("EvaluateAll: %v", err)
 	}
@@ -1169,7 +1165,7 @@ func TestLog4ShellPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadSources: %v", err)
 	}
-	
+
 	payload := map[string]any{
 		"vulnerabilities": []*vulnerabilityv1.Finding{
 			{
@@ -1179,7 +1175,7 @@ func TestLog4ShellPolicy(t *testing.T) {
 			},
 		},
 	}
-	actions, err := EvaluateMap(context.Background(), sources, payload)
+	actions, err := EvaluateMap(t.Context(), sources, payload)
 	if err != nil {
 		t.Fatalf("EvaluateAll: %v", err)
 	}
@@ -1201,7 +1197,7 @@ func TestMinVersionPolicy(t *testing.T) {
 			Version:   "v0.25.0",
 		},
 	}
-	actions, err := EvaluateMap(context.Background(), sources, payload)
+	actions, err := EvaluateMap(t.Context(), sources, payload)
 	if err != nil {
 		t.Fatalf("EvaluateAll: %v", err)
 	}
@@ -1223,7 +1219,7 @@ func TestNpmScopeAllowlist(t *testing.T) {
 		},
 		"env": &policyv1.Environment{Command: "proxy", Entrypoint: "npm_artifact_request"},
 	}
-	if actions, err := EvaluateMap(context.Background(), sources, denyPayload); err != nil || len(actions) == 0 || actions[0].Type != "deny" {
+	if actions, err := EvaluateMap(t.Context(), sources, denyPayload); err != nil || len(actions) == 0 || actions[0].Type != "deny" {
 		t.Fatalf("expected deny for unapproved npm package, got %+v err=%v", actions, err)
 	}
 	allowPayload := map[string]any{
@@ -1233,7 +1229,7 @@ func TestNpmScopeAllowlist(t *testing.T) {
 		},
 		"env": &policyv1.Environment{Command: "proxy", Entrypoint: "npm_artifact_request"},
 	}
-	if actions, err := EvaluateMap(context.Background(), sources, allowPayload); err != nil {
+	if actions, err := EvaluateMap(t.Context(), sources, allowPayload); err != nil {
 		t.Fatalf("EvaluateAll: %v", err)
 	} else {
 		for _, a := range actions {
@@ -1250,7 +1246,7 @@ func TestProxyCriticalAdvisory(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadSources: %v", err)
 	}
-	
+
 	payload := map[string]any{
 		"vulnerabilities": []*vulnerabilityv1.Finding{
 			{
@@ -1263,7 +1259,7 @@ func TestProxyCriticalAdvisory(t *testing.T) {
 		},
 		"env": &policyv1.Environment{Command: "proxy", Entrypoint: "go_artifact_request"},
 	}
-	actions, err := EvaluateMap(context.Background(), sources, payload)
+	actions, err := EvaluateMap(t.Context(), sources, payload)
 	if err != nil {
 		t.Fatalf("EvaluateAll: %v", err)
 	}
@@ -1295,7 +1291,7 @@ func TestRuntimeCriticalBaseline(t *testing.T) {
 		"pkg": pkg,
 		"env": &policyv1.Environment{Command: "diff", Entrypoint: "diff_dependency_change"},
 	}
-	actions, err := EvaluateMap(context.Background(), sources, payload)
+	actions, err := EvaluateMap(t.Context(), sources, payload)
 	if err != nil {
 		t.Fatalf("EvaluateAll: %v", err)
 	}
@@ -1323,7 +1319,7 @@ func TestSeverityGuardrail(t *testing.T) {
 		},
 		"env": &policyv1.Environment{Command: "scan", Entrypoint: "scan_vulnerability"},
 	}
-	actions, err := EvaluateMap(context.Background(), sources, payload)
+	actions, err := EvaluateMap(t.Context(), sources, payload)
 	if err != nil {
 		t.Fatalf("EvaluateAll: %v", err)
 	}
@@ -1346,7 +1342,7 @@ func TestShaiHuludNpm(t *testing.T) {
 		},
 		"env": &policyv1.Environment{Command: "proxy", Entrypoint: "npm_artifact_request"},
 	}
-	actions, err := EvaluateMap(context.Background(), sources, payload)
+	actions, err := EvaluateMap(t.Context(), sources, payload)
 	if err != nil {
 		t.Fatalf("EvaluateAll: %v", err)
 	}
@@ -1369,7 +1365,7 @@ func TestXZBackdoorPolicy(t *testing.T) {
 		},
 		"env": &policyv1.Environment{Command: "proxy"},
 	}
-	actions, err := EvaluateMap(context.Background(), sources, payload)
+	actions, err := EvaluateMap(t.Context(), sources, payload)
 	if err != nil {
 		t.Fatalf("EvaluateAll: %v", err)
 	}

--- a/internal/proxy/auth_integration_test.go
+++ b/internal/proxy/auth_integration_test.go
@@ -1,7 +1,6 @@
 package proxy
 
 import (
-	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -329,7 +328,7 @@ func TestAuthIntegration_JWKSRefresh(t *testing.T) {
 	defer cache.Close()
 
 	// First fetch
-	_, err = cache.GetKey(context.Background(), "test-key-1")
+	_, err = cache.GetKey(t.Context(), "test-key-1")
 	if err != nil {
 		t.Fatalf("first fetch failed: %v", err)
 	}
@@ -339,7 +338,7 @@ func TestAuthIntegration_JWKSRefresh(t *testing.T) {
 	}
 
 	// Second fetch should use cache
-	_, err = cache.GetKey(context.Background(), "test-key-1")
+	_, err = cache.GetKey(t.Context(), "test-key-1")
 	if err != nil {
 		t.Fatalf("second fetch failed: %v", err)
 	}

--- a/internal/proxy/auth_test.go
+++ b/internal/proxy/auth_test.go
@@ -483,7 +483,7 @@ func TestJWKSServer(t *testing.T) {
 	defer cache.Close()
 
 	// Get key from cache
-	key, err := cache.GetKey(context.Background(), "test-key-1")
+	key, err := cache.GetKey(t.Context(), "test-key-1")
 	if err != nil {
 		t.Fatalf("failed to get key: %v", err)
 	}
@@ -558,7 +558,7 @@ func TestAuthenticator_WithStaticKey(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+token.String())
 
 	// Authenticate
-	claims, err := auth.Authenticate(context.Background(), req)
+	claims, err := auth.Authenticate(t.Context(), req)
 	if err != nil {
 		t.Fatalf("authentication failed: %v", err)
 	}
@@ -627,7 +627,7 @@ func TestAuthenticator_ExpiredToken(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+token.String())
 
 	// Authenticate should fail
-	_, err = auth.Authenticate(context.Background(), req)
+	_, err = auth.Authenticate(t.Context(), req)
 	if err == nil {
 		t.Fatal("expected authentication to fail for expired token")
 	}
@@ -697,7 +697,7 @@ func TestAuthenticator_InvalidIssuer(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+token.String())
 
 	// Authenticate should fail
-	_, err = auth.Authenticate(context.Background(), req)
+	_, err = auth.Authenticate(t.Context(), req)
 	if err == nil {
 		t.Fatal("expected authentication to fail for invalid issuer")
 	}
@@ -745,7 +745,7 @@ func TestAuthenticator_NoToken(t *testing.T) {
 	req := httptest.NewRequest("GET", "/test", nil)
 
 	// Authenticate should return nil claims (anonymous)
-	claims, err := auth.Authenticate(context.Background(), req)
+	claims, err := auth.Authenticate(t.Context(), req)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -821,7 +821,7 @@ func TestAuthenticator_AllowedAlgorithms(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+token.String())
 
 	// Authenticate should fail due to algorithm restriction
-	_, err = auth.Authenticate(context.Background(), req)
+	_, err = auth.Authenticate(t.Context(), req)
 	if err == nil {
 		t.Fatal("expected authentication to fail for disallowed algorithm")
 	}
@@ -918,7 +918,7 @@ func TestAuthenticator_NotBeforeToken(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+token.String())
 
 	// Authenticate should fail
-	_, err = auth.Authenticate(context.Background(), req)
+	_, err = auth.Authenticate(t.Context(), req)
 	if err == nil {
 		t.Fatal("expected authentication to fail for not-yet-valid token")
 	}
@@ -985,7 +985,7 @@ func TestAuthenticator_NotBeforeValid(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+token.String())
 
 	// Authenticate should succeed
-	claims, err := auth.Authenticate(context.Background(), req)
+	claims, err := auth.Authenticate(t.Context(), req)
 	if err != nil {
 		t.Fatalf("expected authentication to succeed, got error: %v", err)
 	}
@@ -1031,7 +1031,7 @@ func TestJWKSCache_ConcurrentAccess(t *testing.T) {
 	defer cache.Close()
 
 	// Pre-warm the cache so we're testing concurrent reads from memory
-	_, err = cache.GetKey(context.Background(), "test-key-1")
+	_, err = cache.GetKey(t.Context(), "test-key-1")
 	if err != nil {
 		t.Fatalf("failed to pre-warm cache: %v", err)
 	}
@@ -1047,7 +1047,7 @@ func TestJWKSCache_ConcurrentAccess(t *testing.T) {
 			go func() {
 				for range iterations {
 					// Access the already-cached key (no network I/O)
-					_, err := cache.GetKey(context.Background(), "test-key-1")
+					_, err := cache.GetKey(t.Context(), "test-key-1")
 					if err != nil {
 						errorCount.Add(1)
 					}
@@ -1125,7 +1125,7 @@ func TestAuthMetrics_ConcurrentAccess(t *testing.T) {
 
 func TestJWTClaimsFromContext(t *testing.T) {
 	t.Run("context without claims", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := t.Context()
 		claims := JWTClaimsFromContext(ctx)
 		if claims != nil {
 			t.Error("expected nil claims for context without claims")
@@ -1134,7 +1134,7 @@ func TestJWTClaimsFromContext(t *testing.T) {
 
 	t.Run("context with claims", func(t *testing.T) {
 		expected := &JWTClaims{Subject: "user123"}
-		ctx := ContextWithJWTClaims(context.Background(), expected)
+		ctx := ContextWithJWTClaims(t.Context(), expected)
 		claims := JWTClaimsFromContext(ctx)
 		if claims == nil {
 			t.Fatal("expected non-nil claims")
@@ -1201,7 +1201,7 @@ func TestAuthenticator_MalformedToken(t *testing.T) {
 			req := httptest.NewRequest("GET", "/test", nil)
 			req.Header.Set("Authorization", "Bearer "+tt.token)
 
-			_, err := auth.Authenticate(context.Background(), req)
+			_, err := auth.Authenticate(t.Context(), req)
 			if err == nil {
 				t.Fatal("expected authentication to fail for malformed token")
 			}
@@ -1325,7 +1325,7 @@ func TestAuthenticator_TokenSizeLimit(t *testing.T) {
 	req := httptest.NewRequest("GET", "/test", nil)
 	req.Header.Set("Authorization", "Bearer "+largeToken)
 
-	_, err = auth.Authenticate(context.Background(), req)
+	_, err = auth.Authenticate(t.Context(), req)
 	if err == nil {
 		t.Fatal("expected authentication to fail for oversized token")
 	}

--- a/internal/proxy/cache_scope_test.go
+++ b/internal/proxy/cache_scope_test.go
@@ -1,7 +1,6 @@
 package proxy
 
 import (
-	"context"
 	"testing"
 
 	"github.com/temporalio/deputy/internal/analysis/osv"
@@ -453,7 +452,7 @@ func TestCacheScopeFromContext(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tc.claims != nil {
 				ctx = jwt.ContextWithClaims(ctx, tc.claims)
 			}
@@ -546,11 +545,11 @@ func TestRequestScopedOSVCacheIsolation(t *testing.T) {
 	}
 
 	// Create contexts with different tenant claims
-	ctxTenantA := jwt.ContextWithClaims(context.Background(), &jwt.Claims{
+	ctxTenantA := jwt.ContextWithClaims(t.Context(), &jwt.Claims{
 		Subject: "user1",
 		Custom:  map[string]any{"tenant": "tenant-a"},
 	})
-	ctxTenantB := jwt.ContextWithClaims(context.Background(), &jwt.Claims{
+	ctxTenantB := jwt.ContextWithClaims(t.Context(), &jwt.Claims{
 		Subject: "user2",
 		Custom:  map[string]any{"tenant": "tenant-b"},
 	})
@@ -581,7 +580,7 @@ func TestRequestScopedOSVCacheIsolation(t *testing.T) {
 	}
 
 	// Verify anonymous context (no tenant) uses base scope only
-	ctxAnon := context.Background()
+	ctxAnon := t.Context()
 	_, ok = cache.GetWithContext(ctxAnon, "go|pkg@v1.0.0")
 	if ok {
 		t.Error("anonymous context should not see tenant-scoped entries")
@@ -599,10 +598,10 @@ func TestRequestScopedImageScanCacheIsolation(t *testing.T) {
 		t.Fatal("RequestScopedImageScanCache should implement ContextAwareImageScanCache")
 	}
 
-	ctxTenantA := jwt.ContextWithClaims(context.Background(), &jwt.Claims{
+	ctxTenantA := jwt.ContextWithClaims(t.Context(), &jwt.Claims{
 		Custom: map[string]any{"tenant": "tenant-a"},
 	})
-	ctxTenantB := jwt.ContextWithClaims(context.Background(), &jwt.Claims{
+	ctxTenantB := jwt.ContextWithClaims(t.Context(), &jwt.Claims{
 		Custom: map[string]any{"tenant": "tenant-b"},
 	})
 
@@ -636,10 +635,10 @@ func TestRequestScopedLicenseCacheIsolation(t *testing.T) {
 		t.Fatal("RequestScopedLicenseCache should implement ContextAwareLicenseCache")
 	}
 
-	ctxTenantA := jwt.ContextWithClaims(context.Background(), &jwt.Claims{
+	ctxTenantA := jwt.ContextWithClaims(t.Context(), &jwt.Claims{
 		Custom: map[string]any{"org_id": "org-a"},
 	})
-	ctxTenantB := jwt.ContextWithClaims(context.Background(), &jwt.Claims{
+	ctxTenantB := jwt.ContextWithClaims(t.Context(), &jwt.Claims{
 		Custom: map[string]any{"org_id": "org-b"},
 	})
 
@@ -668,10 +667,10 @@ func TestRequestScopedDigestResolutionCacheIsolation(t *testing.T) {
 		t.Fatal("RequestScopedDigestResolutionCache should implement ContextAwareDigestResolutionCache")
 	}
 
-	ctxTenantA := jwt.ContextWithClaims(context.Background(), &jwt.Claims{
+	ctxTenantA := jwt.ContextWithClaims(t.Context(), &jwt.Claims{
 		Subject: "sa-tenant-a",
 	})
-	ctxTenantB := jwt.ContextWithClaims(context.Background(), &jwt.Claims{
+	ctxTenantB := jwt.ContextWithClaims(t.Context(), &jwt.Claims{
 		Subject: "sa-tenant-b",
 	})
 
@@ -740,7 +739,7 @@ func TestTenantIDFromContext(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			if tc.claims != nil {
 				ctx = jwt.ContextWithClaims(ctx, tc.claims)
 			}

--- a/internal/proxy/gomod_test.go
+++ b/internal/proxy/gomod_test.go
@@ -409,7 +409,7 @@ func TestGoModuleHandlerEndToEndGoGet(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			caseDir := filepath.Join(tmp, strings.ReplaceAll(test.name, " ", "_"))
 			if err := os.MkdirAll(caseDir, 0o755); err != nil {
 				t.Fatalf("mkdir: %v", err)

--- a/internal/proxy/handler_registry_test.go
+++ b/internal/proxy/handler_registry_test.go
@@ -196,7 +196,7 @@ func TestGenericHandler_ServeHTTP(t *testing.T) {
 		}
 
 		req := httptest.NewRequest(http.MethodGet, "/lodash", nil)
-		req = req.WithContext(context.Background())
+		req = req.WithContext(t.Context())
 		rec := httptest.NewRecorder()
 
 		handler.ServeHTTP(rec, req)
@@ -215,7 +215,7 @@ func TestGenericHandler_ServeHTTP(t *testing.T) {
 		}
 
 		req := httptest.NewRequest(http.MethodGet, "/github.com/foo/bar/@v/list", nil)
-		req = req.WithContext(context.Background())
+		req = req.WithContext(t.Context())
 		rec := httptest.NewRecorder()
 
 		handler.ServeHTTP(rec, req)
@@ -233,7 +233,7 @@ func TestGenericHandler_ServeHTTP(t *testing.T) {
 		}
 
 		req := httptest.NewRequest(http.MethodGet, "/invalid/path", nil)
-		req = req.WithContext(context.Background())
+		req = req.WithContext(t.Context())
 		rec := httptest.NewRecorder()
 
 		handler.ServeHTTP(rec, req)

--- a/internal/proxy/middleware_test.go
+++ b/internal/proxy/middleware_test.go
@@ -26,17 +26,17 @@ func TestRequestIDFromContext(t *testing.T) {
 		},
 		{
 			name: "empty context",
-			ctx:  context.Background(),
+			ctx:  t.Context(),
 			want: "",
 		},
 		{
 			name: "context with request ID",
-			ctx:  context.WithValue(context.Background(), requestIDKey{}, "test-id-123"),
+			ctx:  context.WithValue(t.Context(), requestIDKey{}, "test-id-123"),
 			want: "test-id-123",
 		},
 		{
 			name: "context with wrong type",
-			ctx:  context.WithValue(context.Background(), requestIDKey{}, 12345),
+			ctx:  context.WithValue(t.Context(), requestIDKey{}, 12345),
 			want: "",
 		},
 	}

--- a/internal/proxy/oci_integration_test.go
+++ b/internal/proxy/oci_integration_test.go
@@ -31,7 +31,7 @@ func TestOCIProxy_PullImageThroughProxy(t *testing.T) {
 	// gcr.io/distroless/static-debian12 is tiny (~2MB) and doesn't require auth.
 	const testImage = "gcr.io/distroless/static-debian12:nonroot"
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	defer cancel()
 
 	// Start a real upstream proxy that forwards to gcr.io
@@ -104,7 +104,7 @@ func TestOCIProxy_PullImageThroughProxy(t *testing.T) {
 // TestOCIProxy_PolicyBlocksLatestTag tests that the proxy correctly blocks
 // images with the :latest tag when configured with a policy that forbids it.
 func TestOCIProxy_PolicyBlocksLatestTag(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
 	// Create a mock upstream that returns valid OCI responses
@@ -176,7 +176,7 @@ func TestOCIProxy_PolicyBlocksLatestTag(t *testing.T) {
 // TestOCIProxy_PolicyAllowsSemverTag tests that the proxy allows images
 // with proper semver tags when the policy requires semver.
 func TestOCIProxy_PolicyAllowsSemverTag(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
 	// Create a mock upstream that returns valid OCI responses
@@ -241,7 +241,7 @@ func TestOCIProxy_PolicyAllowsSemverTag(t *testing.T) {
 // TestOCIProxy_VulnerabilityBlocksImage tests that the proxy blocks images
 // when vulnerabilities are detected and policy requires blocking.
 func TestOCIProxy_VulnerabilityBlocksImage(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -339,7 +339,7 @@ policies:
 // TestOCIProxy_ImageConfigAvailableInPolicy tests that image configuration
 // (user, env, etc.) is available for policy evaluation.
 func TestOCIProxy_ImageConfigAvailableInPolicy(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -429,7 +429,7 @@ func TestOCIProxy_RealGCRImage(t *testing.T) {
 		t.Skip("skipping real registry test in short mode")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	defer cancel()
 
 	// Forward to gcr.io

--- a/internal/proxy/otel_test.go
+++ b/internal/proxy/otel_test.go
@@ -189,7 +189,7 @@ func TestEnrichSpanWithRequest(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tracer, recorder := testTracer(t)
-			ctx, span := startTestSpan(context.Background(), tracer, "test")
+			ctx, span := startTestSpan(t.Context(), tracer, "test")
 			EnrichSpanWithRequest(span, tt.info)
 			span.End()
 
@@ -249,7 +249,7 @@ func TestRecordAuthEvent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tracer, recorder := testTracer(t)
-			ctx, span := startTestSpan(context.Background(), tracer, "test")
+			ctx, span := startTestSpan(t.Context(), tracer, "test")
 			RecordAuthEvent(ctx, span, tt.data)
 			span.End()
 
@@ -276,7 +276,7 @@ func TestRecordAuthEvent(t *testing.T) {
 func TestRecordAuthHelpers(t *testing.T) {
 	t.Run("RecordAuthSuccess", func(t *testing.T) {
 		tracer, recorder := testTracer(t)
-		ctx, span := startTestSpan(context.Background(), tracer, "test")
+		ctx, span := startTestSpan(t.Context(), tracer, "test")
 		RecordAuthSuccess(ctx, span, "user:bob")
 		span.End()
 
@@ -289,7 +289,7 @@ func TestRecordAuthHelpers(t *testing.T) {
 
 	t.Run("RecordAuthAnonymous", func(t *testing.T) {
 		tracer, recorder := testTracer(t)
-		ctx, span := startTestSpan(context.Background(), tracer, "test")
+		ctx, span := startTestSpan(t.Context(), tracer, "test")
 		RecordAuthAnonymous(ctx, span)
 		span.End()
 
@@ -301,7 +301,7 @@ func TestRecordAuthHelpers(t *testing.T) {
 
 	t.Run("RecordAuthRejected", func(t *testing.T) {
 		tracer, recorder := testTracer(t)
-		ctx, span := startTestSpan(context.Background(), tracer, "test")
+		ctx, span := startTestSpan(t.Context(), tracer, "test")
 		RecordAuthRejected(ctx, span, "expired_token")
 		span.End()
 
@@ -346,7 +346,7 @@ func TestRecordPolicyEvent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tracer, recorder := testTracer(t)
-			ctx, span := startTestSpan(context.Background(), tracer, "test")
+			ctx, span := startTestSpan(t.Context(), tracer, "test")
 			RecordPolicyEvent(ctx, span, tt.data)
 			span.End()
 
@@ -372,7 +372,7 @@ func TestRecordPolicyEvent(t *testing.T) {
 func TestRecordPolicyHelpers(t *testing.T) {
 	t.Run("RecordPolicyAllow", func(t *testing.T) {
 		tracer, recorder := testTracer(t)
-		ctx, span := startTestSpan(context.Background(), tracer, "test")
+		ctx, span := startTestSpan(t.Context(), tracer, "test")
 		RecordPolicyAllow(ctx, span, "go_artifact_request", 2, 50*time.Millisecond)
 		span.End()
 
@@ -385,7 +385,7 @@ func TestRecordPolicyHelpers(t *testing.T) {
 
 	t.Run("RecordPolicyDeny", func(t *testing.T) {
 		tracer, recorder := testTracer(t)
-		ctx, span := startTestSpan(context.Background(), tracer, "test")
+		ctx, span := startTestSpan(t.Context(), tracer, "test")
 		RecordPolicyDeny(ctx, span, "npm_artifact_request", "block-critical", "has critical vuln", "npm", 30*time.Millisecond)
 		span.End()
 
@@ -431,7 +431,7 @@ func TestRecordCacheEvent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tracer, recorder := testTracer(t)
-			ctx, span := startTestSpan(context.Background(), tracer, "test")
+			ctx, span := startTestSpan(t.Context(), tracer, "test")
 			RecordCacheEvent(ctx, span, tt.data)
 			span.End()
 
@@ -450,7 +450,7 @@ func TestRecordCacheEvent(t *testing.T) {
 func TestRecordCacheHelpers(t *testing.T) {
 	t.Run("RecordOSVCacheHit", func(t *testing.T) {
 		tracer, recorder := testTracer(t)
-		ctx, span := startTestSpan(context.Background(), tracer, "test")
+		ctx, span := startTestSpan(t.Context(), tracer, "test")
 		RecordOSVCacheHit(ctx, span, "go|pkg@v1")
 		span.End()
 
@@ -462,7 +462,7 @@ func TestRecordCacheHelpers(t *testing.T) {
 
 	t.Run("RecordOSVCacheMiss", func(t *testing.T) {
 		tracer, recorder := testTracer(t)
-		ctx, span := startTestSpan(context.Background(), tracer, "test")
+		ctx, span := startTestSpan(t.Context(), tracer, "test")
 		RecordOSVCacheMiss(ctx, span, "go|pkg@v1")
 		span.End()
 
@@ -474,7 +474,7 @@ func TestRecordCacheHelpers(t *testing.T) {
 
 	t.Run("RecordLicenseCacheHit", func(t *testing.T) {
 		tracer, recorder := testTracer(t)
-		ctx, span := startTestSpan(context.Background(), tracer, "test")
+		ctx, span := startTestSpan(t.Context(), tracer, "test")
 		RecordLicenseCacheHit(ctx, span, "npm|pkg@1.0")
 		span.End()
 
@@ -486,7 +486,7 @@ func TestRecordCacheHelpers(t *testing.T) {
 
 	t.Run("RecordImageScanCacheHit", func(t *testing.T) {
 		tracer, recorder := testTracer(t)
-		ctx, span := startTestSpan(context.Background(), tracer, "test")
+		ctx, span := startTestSpan(t.Context(), tracer, "test")
 		RecordImageScanCacheHit(ctx, span, "registry|repo@sha256:deadbeef")
 		span.End()
 
@@ -499,7 +499,7 @@ func TestRecordCacheHelpers(t *testing.T) {
 
 func TestRecordVulnerabilityCount(t *testing.T) {
 	tracer, recorder := testTracer(t)
-	_, span := startTestSpan(context.Background(), tracer, "test")
+	_, span := startTestSpan(t.Context(), tracer, "test")
 	RecordVulnerabilityCount(span, 5)
 	span.End()
 
@@ -509,7 +509,7 @@ func TestRecordVulnerabilityCount(t *testing.T) {
 
 func TestProxyRequestRecorder(t *testing.T) {
 	// Just verify it doesn't panic; actual metric recording is tested elsewhere
-	ctx := context.Background()
+	ctx := t.Context()
 	recorder := NewProxyRequestRecorder(ctx, "go")
 
 	// Simulate some work
@@ -519,7 +519,7 @@ func TestProxyRequestRecorder(t *testing.T) {
 func TestMultipleEventsOnSameSpan(t *testing.T) {
 	// Test that multiple events can be recorded on the same span
 	tracer, recorder := testTracer(t)
-	ctx, span := startTestSpan(context.Background(), tracer, "test")
+	ctx, span := startTestSpan(t.Context(), tracer, "test")
 
 	// Record auth
 	RecordAuthSuccess(ctx, span, "user:alice")
@@ -561,7 +561,7 @@ func TestMultipleEventsOnSameSpan(t *testing.T) {
 func TestEnrichSpanWithRequest_EmptyStrings(t *testing.T) {
 	// Test that empty strings don't cause issues
 	tracer, recorder := testTracer(t)
-	_, span := startTestSpan(context.Background(), tracer, "test")
+	_, span := startTestSpan(t.Context(), tracer, "test")
 
 	EnrichSpanWithRequest(span, RequestInfo{
 		Ecosystem: "",
@@ -585,14 +585,14 @@ func TestAttributeKeyConsistency(t *testing.T) {
 
 	// Only check proxy-specific keys defined locally (not reused from central otel)
 	proxySpecificKeys := []attribute.Key{
-		attrProxyEcosystem, // Local: deputy.proxy.ecosystem
-		attrAuthResult,     // Local: deputy.proxy.auth.result
-		attrAuthSubject,    // Local: deputy.proxy.auth.subject
-		attrAuthErrorCode,  // Local: deputy.proxy.auth.error_code
-		attrAuthAnonymous,  // Local: deputy.proxy.auth.anonymous
-		attrPolicyResult,   // Local: deputy.proxy.policy.result
-		attrPolicyReason,   // Local: deputy.proxy.policy.reason
-		attrPolicyWarnings, // Local: deputy.proxy.policy.warnings
+		attrProxyEcosystem,     // Local: deputy.proxy.ecosystem
+		attrAuthResult,         // Local: deputy.proxy.auth.result
+		attrAuthSubject,        // Local: deputy.proxy.auth.subject
+		attrAuthErrorCode,      // Local: deputy.proxy.auth.error_code
+		attrAuthAnonymous,      // Local: deputy.proxy.auth.anonymous
+		attrPolicyResult,       // Local: deputy.proxy.policy.result
+		attrPolicyReason,       // Local: deputy.proxy.policy.reason
+		attrPolicyWarnings,     // Local: deputy.proxy.policy.warnings
 		attrVulnerabilityCount, // Local: deputy.proxy.vulnerability.count
 	}
 

--- a/internal/proxy/pypi_test.go
+++ b/internal/proxy/pypi_test.go
@@ -257,7 +257,7 @@ func TestPyPIHandlerEndToEndPip(t *testing.T) {
 	u, _ := url.Parse(ts.URL)
 	host := u.Host
 
-	ctx := context.Background()
+	ctx := t.Context()
 	tests := []struct {
 		name    string
 		pkg     string

--- a/internal/remediation/fixresolve/resolve_test.go
+++ b/internal/remediation/fixresolve/resolve_test.go
@@ -44,7 +44,7 @@ func TestResolve_DockerMigration(t *testing.T) {
 		deflt: ExistsNo, // docker/docker@29.3.1 absent
 	}
 
-	v := Resolve(context.Background(), c, r, Options{Verify: true})
+	v := Resolve(t.Context(), c, r, Options{Verify: true})
 	if v == nil || v.Status != vulnerability.FixStatusMigration {
 		t.Fatalf("expected migration verdict, got %+v", v)
 	}
@@ -72,7 +72,7 @@ func TestResolve_MigrationWhenNoInPlaceClaim(t *testing.T) {
 	}
 	r := fakeResolver{exists: map[string]Existence{"github.com/moby/moby/v2@2.0.0-beta.14": ExistsYes}, deflt: ExistsNo}
 
-	v := Resolve(context.Background(), c, r, Options{Verify: true})
+	v := Resolve(t.Context(), c, r, Options{Verify: true})
 	if v == nil || v.Status != vulnerability.FixStatusMigration {
 		t.Fatalf("expected migration verdict, got %+v", v)
 	}
@@ -95,7 +95,7 @@ func TestResolve_MechanicalMajorBump(t *testing.T) {
 	}
 	r := fakeResolver{exists: map[string]Existence{"github.com/example/widget/v2@2.0.1": ExistsYes}, deflt: ExistsNo}
 
-	v := Resolve(context.Background(), c, r, Options{Verify: true})
+	v := Resolve(t.Context(), c, r, Options{Verify: true})
 	if v == nil || v.Status != vulnerability.FixStatusMigration {
 		t.Fatalf("expected migration verdict, got %+v", v)
 	}
@@ -113,7 +113,7 @@ func TestResolve_InPlaceVerified(t *testing.T) {
 	}
 	r := fakeResolver{exists: map[string]Existence{"golang.org/x/net@0.55.0": ExistsYes}}
 
-	v := Resolve(context.Background(), c, r, Options{Verify: true})
+	v := Resolve(t.Context(), c, r, Options{Verify: true})
 	if v == nil || v.Status != vulnerability.FixStatusInPlace {
 		t.Fatalf("expected in-place verdict, got %+v", v)
 	}
@@ -131,7 +131,7 @@ func TestResolve_UnverifiedWhenProxyUnknown(t *testing.T) {
 	}
 	r := fakeResolver{deflt: ExistsUnknown}
 
-	v := Resolve(context.Background(), c, r, Options{Verify: true})
+	v := Resolve(t.Context(), c, r, Options{Verify: true})
 	if v == nil || v.Status != vulnerability.FixStatusUnverified {
 		t.Fatalf("expected unverified verdict, got %+v", v)
 	}
@@ -149,7 +149,7 @@ func TestResolve_UnavailableWhenAbsentAndNoMigration(t *testing.T) {
 	}
 	r := fakeResolver{deflt: ExistsNo}
 
-	v := Resolve(context.Background(), c, r, Options{Verify: true})
+	v := Resolve(t.Context(), c, r, Options{Verify: true})
 	if v == nil || v.Status != vulnerability.FixStatusUnavailable {
 		t.Fatalf("expected unavailable verdict, got %+v", v)
 	}
@@ -162,11 +162,11 @@ func TestResolve_SkippedForNonGoAndDisabled(t *testing.T) {
 	c := vulnerability.Consolidated{Package: "left-pad", Version: "1.0.0", Ecosystem: "npm", FixedVersions: []string{"1.0.1"}}
 	r := fakeResolver{deflt: ExistsYes}
 
-	if v := Resolve(context.Background(), c, r, Options{Verify: true}); v != nil {
+	if v := Resolve(t.Context(), c, r, Options{Verify: true}); v != nil {
 		t.Errorf("expected nil for non-Go ecosystem, got %+v", v)
 	}
 	goC := vulnerability.Consolidated{Package: "golang.org/x/net", Version: "v0.47.0", Ecosystem: "Go", FixedVersions: []string{"0.55.0"}}
-	if v := Resolve(context.Background(), goC, r, Options{Verify: false}); v != nil {
+	if v := Resolve(t.Context(), goC, r, Options{Verify: false}); v != nil {
 		t.Errorf("expected nil when verification disabled, got %+v", v)
 	}
 }

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -1,7 +1,6 @@
 package repository
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -51,7 +50,7 @@ func TestOpen(t *testing.T) {
 
 func TestCloneInMemory_Local(t *testing.T) {
 	dir, _ := newTempRepo(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	src, err := Clone(ctx, &git.CloneOptions{URL: dir, Depth: 1, SingleBranch: true, Tags: git.NoTags}, true)
 	if err != nil {
 		t.Fatalf("Clone in memory: %v", err)
@@ -67,7 +66,7 @@ func TestCloneInMemory_Local(t *testing.T) {
 
 func TestCloneToDir_Local(t *testing.T) {
 	dir, _ := newTempRepo(t)
-	ctx := context.Background()
+	ctx := t.Context()
 	src, err := Clone(ctx, &git.CloneOptions{URL: dir, Depth: 1, SingleBranch: true, Tags: git.NoTags}, false)
 	if err != nil {
 		t.Fatalf("Clone to dir: %v", err)

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -1,7 +1,6 @@
 package sandbox_test
 
 import (
-	"context"
 	"testing"
 
 	sandboxv1 "github.com/temporalio/deputy/gen/deputy/sandbox/v1"
@@ -53,7 +52,7 @@ func TestRegistryRegisterAndGet(t *testing.T) {
 func TestRegistryAvailable(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	reg := sandbox.NewRegistry()
 
 	// None runtime is always available
@@ -69,7 +68,7 @@ func TestRegistryAvailable(t *testing.T) {
 func TestRegistryDefault(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	reg := sandbox.NewRegistry()
 
 	// No runtimes = no default
@@ -91,7 +90,7 @@ func TestRegistryDefault(t *testing.T) {
 func TestNewManager(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	mgr, err := sandbox.NewManager(ctx)
 	if err != nil {
 		t.Fatalf("NewManager() error: %v", err)
@@ -104,7 +103,7 @@ func TestNewManager(t *testing.T) {
 func TestNoneRuntimeInfo(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rt := none.New()
 
 	info, err := rt.Info(ctx)
@@ -148,7 +147,7 @@ func TestNoneRuntimeCapabilities(t *testing.T) {
 func TestNoneRuntimeExecute(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rt := none.New()
 
 	req := &sandboxv1.ExecuteRequest{
@@ -171,7 +170,7 @@ func TestNoneRuntimeExecute(t *testing.T) {
 func TestNoneRuntimeExecuteFailure(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rt := none.New()
 
 	req := &sandboxv1.ExecuteRequest{
@@ -191,7 +190,7 @@ func TestNoneRuntimeExecuteFailure(t *testing.T) {
 func TestNoneRuntimeExecuteEmpty(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rt := none.New()
 
 	req := &sandboxv1.ExecuteRequest{
@@ -208,7 +207,7 @@ func TestNoneRuntimeExecuteEmpty(t *testing.T) {
 func TestDockerRuntimeInfo(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rt := docker.New()
 
 	info, err := rt.Info(ctx)
@@ -249,7 +248,7 @@ func TestDockerRuntimeCapabilities(t *testing.T) {
 func TestManagerListRuntimes(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create manager with custom registry
 	reg := sandbox.NewRegistry()
@@ -286,7 +285,7 @@ func TestManagerListRuntimes(t *testing.T) {
 func TestCollectResult(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rt := none.New()
 
 	req := &sandboxv1.ExecuteRequest{
@@ -327,7 +326,7 @@ func TestExecutionError(t *testing.T) {
 func TestGVisorRuntimeInfo(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 	rt := gvisor.New()
 
 	info, err := rt.Info(ctx)
@@ -391,7 +390,7 @@ func TestGVisorRuntimeOptions(t *testing.T) {
 func TestGVisorStandaloneMode(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create gVisor runtime in standalone mode
 	rt := gvisor.New(gvisor.WithStandaloneMode())
@@ -410,7 +409,7 @@ func TestGVisorStandaloneMode(t *testing.T) {
 func TestDockerRuntimeWithOCIRuntime(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create Docker runtime with custom OCI runtime
 	rt := docker.New(docker.WithOCIRuntime("runsc"))
@@ -429,7 +428,7 @@ func TestDockerRuntimeWithOCIRuntime(t *testing.T) {
 func TestDockerRuntimeDefaultOCIRuntime(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create Docker runtime without OCI runtime (uses default runc)
 	rt := docker.New()

--- a/internal/sandbox/sandboxtest/sandboxtest_test.go
+++ b/internal/sandbox/sandboxtest/sandboxtest_test.go
@@ -23,7 +23,7 @@ func TestHarness_GetInfo(t *testing.T) {
 	}
 
 	harness := sandboxtest.NewHarness(t, handler)
-	info := harness.GetInfo(context.Background())
+	info := harness.GetInfo(t.Context())
 
 	if info.GetName() != "test-runtime" {
 		t.Errorf("Name: got %q, want %q", info.GetName(), "test-runtime")
@@ -48,7 +48,7 @@ func TestHarness_Execute_Success(t *testing.T) {
 	}
 
 	harness := sandboxtest.NewHarness(t, handler)
-	result := harness.Execute(context.Background(), &sandboxv1.ExecuteRequest{
+	result := harness.Execute(t.Context(), &sandboxv1.ExecuteRequest{
 		Command: []string{"echo", "hello", "world"},
 	})
 
@@ -71,7 +71,7 @@ func TestHarness_Execute_NonZeroExit(t *testing.T) {
 	}
 
 	harness := sandboxtest.NewHarness(t, handler)
-	result := harness.Execute(context.Background(), &sandboxv1.ExecuteRequest{
+	result := harness.Execute(t.Context(), &sandboxv1.ExecuteRequest{
 		Command: []string{"false"},
 	})
 
@@ -91,7 +91,7 @@ func TestHarness_Execute_FatalError(t *testing.T) {
 	}
 
 	harness := sandboxtest.NewHarness(t, handler)
-	result := harness.Execute(context.Background(), &sandboxv1.ExecuteRequest{
+	result := harness.Execute(t.Context(), &sandboxv1.ExecuteRequest{
 		Command: []string{"xyz"},
 	})
 
@@ -107,7 +107,7 @@ func TestHarness_Execute_DefaultMockBehavior(t *testing.T) {
 	handler := &sandboxtest.MockHandler{}
 
 	harness := sandboxtest.NewHarness(t, handler)
-	result := harness.Execute(context.Background(), &sandboxv1.ExecuteRequest{
+	result := harness.Execute(t.Context(), &sandboxv1.ExecuteRequest{
 		Command: []string{"echo", "test"},
 	})
 
@@ -157,7 +157,7 @@ func TestFakeCommandRunner(t *testing.T) {
 	var stdout, stderr strings.Builder
 
 	// Test echo
-	exitCode, err := runner.Run(context.Background(), []string{"echo", "hello"}, nil, &stdout, &stderr, nil, "")
+	exitCode, err := runner.Run(t.Context(), []string{"echo", "hello"}, nil, &stdout, &stderr, nil, "")
 	if err != nil {
 		t.Fatalf("Run(echo) error: %v", err)
 	}
@@ -171,7 +171,7 @@ func TestFakeCommandRunner(t *testing.T) {
 	// Reset and test false
 	stdout.Reset()
 	stderr.Reset()
-	exitCode, err = runner.Run(context.Background(), []string{"false"}, nil, &stdout, &stderr, nil, "")
+	exitCode, err = runner.Run(t.Context(), []string{"false"}, nil, &stdout, &stderr, nil, "")
 	if err != nil {
 		t.Fatalf("Run(false) error: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestFakeCommandRunner_UnknownCommand(t *testing.T) {
 		Results: map[string]*sandboxtest.FakeResult{},
 	}
 
-	_, err := runner.Run(context.Background(), []string{"unknown"}, nil, nil, nil, nil, "")
+	_, err := runner.Run(t.Context(), []string{"unknown"}, nil, nil, nil, nil, "")
 	if err == nil {
 		t.Fatal("expected error for unknown command")
 	}
@@ -245,7 +245,7 @@ func TestExamplePlugin(t *testing.T) {
 	harness := sandboxtest.NewHarness(t, &examplePlugin{})
 
 	// Test GetInfo
-	info := harness.GetInfo(context.Background())
+	info := harness.GetInfo(t.Context())
 	if info.GetName() != "example" {
 		t.Errorf("Name: got %q, want %q", info.GetName(), "example")
 	}
@@ -254,7 +254,7 @@ func TestExamplePlugin(t *testing.T) {
 	}
 
 	// Test successful execution
-	result := harness.Execute(context.Background(), &sandboxv1.ExecuteRequest{
+	result := harness.Execute(t.Context(), &sandboxv1.ExecuteRequest{
 		Command: []string{"echo", "hello", "sandbox"},
 	})
 	result.
@@ -262,7 +262,7 @@ func TestExamplePlugin(t *testing.T) {
 		AssertStdoutEquals("hello sandbox\n")
 
 	// Test command not found
-	result = harness.Execute(context.Background(), &sandboxv1.ExecuteRequest{
+	result = harness.Execute(t.Context(), &sandboxv1.ExecuteRequest{
 		Command: []string{"nonexistent"},
 	})
 	result.AssertFatalErrorCode("COMMAND_NOT_FOUND")

--- a/internal/sandbox/workspace/docker_test.go
+++ b/internal/sandbox/workspace/docker_test.go
@@ -1,7 +1,6 @@
 package workspace
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"slices"
@@ -67,7 +66,7 @@ func TestDockerIsolatorSetupAndTeardown(t *testing.T) {
 		t.Fatalf("NewDockerIsolator() error = %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Setup
 	isolatedPath, err := isolator.Setup(ctx)
@@ -114,7 +113,7 @@ func TestDockerIsolatorPreserveChanges(t *testing.T) {
 		t.Fatalf("NewDockerIsolator() error = %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	isolatedPath, err := isolator.Setup(ctx)
 	if err != nil {
 		t.Fatalf("Setup() error = %v", err)
@@ -146,7 +145,7 @@ func TestDockerIsolatorChanges(t *testing.T) {
 		t.Fatalf("NewDockerIsolator() error = %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	isolatedPath, err := isolator.Setup(ctx)
 	if err != nil {
 		t.Fatalf("Setup() error = %v", err)
@@ -198,7 +197,7 @@ func TestDockerIsolatorBuildMounts(t *testing.T) {
 		t.Fatalf("NewDockerIsolator() error = %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	isolatedPath, err := isolator.Setup(ctx)
 	if err != nil {
 		t.Fatalf("Setup() error = %v", err)
@@ -242,7 +241,7 @@ func TestDockerIsolatorApplyToHostConfig(t *testing.T) {
 		t.Fatalf("NewDockerIsolator() error = %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := isolator.Setup(ctx); err != nil {
 		t.Fatalf("Setup() error = %v", err)
 	}

--- a/internal/sandbox/workspace/review_test.go
+++ b/internal/sandbox/workspace/review_test.go
@@ -2,7 +2,6 @@ package workspace
 
 import (
 	"bytes"
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -22,7 +21,7 @@ func TestNewReviewSession(t *testing.T) {
 		t.Fatalf("New() error = %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := isolator.Setup(ctx); err != nil {
 		t.Fatalf("Setup() error = %v", err)
 	}
@@ -49,7 +48,7 @@ func TestReviewSessionLoadChanges(t *testing.T) {
 		t.Fatalf("New() error = %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	isolatedPath, err := isolator.Setup(ctx)
 	if err != nil {
 		t.Fatalf("Setup() error = %v", err)
@@ -92,7 +91,7 @@ func TestReviewSessionSummary(t *testing.T) {
 		t.Fatalf("New() error = %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	isolatedPath, err := isolator.Setup(ctx)
 	if err != nil {
 		t.Fatalf("Setup() error = %v", err)
@@ -134,7 +133,7 @@ func TestReviewSessionSelection(t *testing.T) {
 		t.Fatalf("New() error = %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	isolatedPath, err := isolator.Setup(ctx)
 	if err != nil {
 		t.Fatalf("Setup() error = %v", err)
@@ -192,7 +191,7 @@ func TestReviewSessionApplySelected(t *testing.T) {
 		t.Fatalf("New() error = %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	isolatedPath, err := isolator.Setup(ctx)
 	if err != nil {
 		t.Fatalf("Setup() error = %v", err)
@@ -245,7 +244,7 @@ func TestReviewSessionDiscard(t *testing.T) {
 		t.Fatalf("New() error = %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	isolatedPath, err := isolator.Setup(ctx)
 	if err != nil {
 		t.Fatalf("Setup() error = %v", err)
@@ -287,7 +286,7 @@ func TestReviewSessionPreserve(t *testing.T) {
 		t.Fatalf("New() error = %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	isolatedPath, err := isolator.Setup(ctx)
 	if err != nil {
 		t.Fatalf("Setup() error = %v", err)
@@ -329,7 +328,7 @@ func TestReviewSessionPrintChanges(t *testing.T) {
 		t.Fatalf("New() error = %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	isolatedPath, err := isolator.Setup(ctx)
 	if err != nil {
 		t.Fatalf("Setup() error = %v", err)
@@ -375,7 +374,7 @@ func TestReviewSessionGetDiff(t *testing.T) {
 		t.Fatalf("New() error = %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	isolatedPath, err := isolator.Setup(ctx)
 	if err != nil {
 		t.Fatalf("Setup() error = %v", err)
@@ -423,7 +422,7 @@ func TestReviewSessionNoChanges(t *testing.T) {
 		t.Fatalf("New() error = %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if _, err := isolator.Setup(ctx); err != nil {
 		t.Fatalf("Setup() error = %v", err)
 	}

--- a/internal/sandbox/workspace/workspace_test.go
+++ b/internal/sandbox/workspace/workspace_test.go
@@ -72,7 +72,7 @@ func TestDirectIsolator(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Setup should return original path
 	path, err := isolator.Setup(ctx)
@@ -128,7 +128,7 @@ func TestSnapshotIsolator(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Setup should create snapshot
 	snapshotPath, err := isolator.Setup(ctx)
@@ -208,7 +208,7 @@ func TestSnapshotIsolatorSync(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	snapshotPath, err := isolator.Setup(ctx)
 	if err != nil {
@@ -274,7 +274,7 @@ func TestSnapshotIsolatorSyncPatterns(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	snapshotPath, err := isolator.Setup(ctx)
 	if err != nil {
@@ -324,7 +324,7 @@ func TestGitWorktreeIsolator(t *testing.T) {
 	repoDir := t.TempDir()
 
 	// Initialize git repo
-	ctx := context.Background()
+	ctx := t.Context()
 	runGit := func(args ...string) error {
 		cmd := newExecCommand(ctx, "git", args...)
 		cmd.Dir = repoDir

--- a/internal/sbom/enrich_test.go
+++ b/internal/sbom/enrich_test.go
@@ -1,7 +1,6 @@
 package sbomx
 
 import (
-	"context"
 	"testing"
 
 	pb "deps.dev/api/v3"
@@ -536,7 +535,7 @@ func TestEnrichDependencyEdges_nilHandling(t *testing.T) {
 
 	t.Run("nil document", func(t *testing.T) {
 		t.Parallel()
-		count, err := enrichDependencyEdges(context.Background(), nil, nil, 10)
+		count, err := enrichDependencyEdges(t.Context(), nil, nil, 10)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -548,7 +547,7 @@ func TestEnrichDependencyEdges_nilHandling(t *testing.T) {
 	t.Run("empty document", func(t *testing.T) {
 		t.Parallel()
 		doc := &sbom.Document{}
-		count, err := enrichDependencyEdges(context.Background(), nil, doc, 10)
+		count, err := enrichDependencyEdges(t.Context(), nil, doc, 10)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}

--- a/internal/sbom/sbom_test.go
+++ b/internal/sbom/sbom_test.go
@@ -919,7 +919,7 @@ SOFTWARE.`
 		doc.NodeList.Nodes = append(doc.NodeList.Nodes, root)
 		doc.NodeList.RootElements = append(doc.NodeList.RootElements, root.Id)
 
-		err := enrichProtobomLicensesScanLocal(context.Background(), doc, ws)
+		err := enrichProtobomLicensesScanLocal(t.Context(), doc, ws)
 		if err != nil {
 			t.Fatalf("enrichProtobomLicensesScanLocal: %v", err)
 		}
@@ -935,7 +935,7 @@ SOFTWARE.`
 
 	t.Run("handles nil workspace gracefully", func(t *testing.T) {
 		doc := sbom.NewDocument()
-		err := enrichProtobomLicensesScanLocal(context.Background(), doc, nil)
+		err := enrichProtobomLicensesScanLocal(t.Context(), doc, nil)
 		if err != nil {
 			t.Errorf("expected no error for nil workspace, got %v", err)
 		}
@@ -944,7 +944,7 @@ SOFTWARE.`
 	t.Run("handles nil document gracefully", func(t *testing.T) {
 		ws := workspace.NewMemory()
 		defer ws.Close()
-		err := enrichProtobomLicensesScanLocal(context.Background(), nil, ws)
+		err := enrichProtobomLicensesScanLocal(t.Context(), nil, ws)
 		if err != nil {
 			t.Errorf("expected no error for nil document, got %v", err)
 		}
@@ -962,7 +962,7 @@ SOFTWARE.`
 		doc.NodeList.Nodes = append(doc.NodeList.Nodes, root)
 		doc.NodeList.RootElements = append(doc.NodeList.RootElements, root.Id)
 
-		err := enrichProtobomLicensesScanLocal(context.Background(), doc, ws)
+		err := enrichProtobomLicensesScanLocal(t.Context(), doc, ws)
 		if err != nil {
 			t.Errorf("expected no error, got %v", err)
 		}
@@ -975,7 +975,7 @@ SOFTWARE.`
 func Test_enrichProtobomLicensesScanWithFetcher_nilHandling(t *testing.T) {
 	t.Run("handles nil document", func(t *testing.T) {
 		fetcher := &remoteFetcher{Timeout: time.Second}
-		err := enrichProtobomLicensesScanWithFetcher(context.Background(), nil, fetcher)
+		err := enrichProtobomLicensesScanWithFetcher(t.Context(), nil, fetcher)
 		if err != nil {
 			t.Errorf("expected no error for nil document, got %v", err)
 		}
@@ -983,7 +983,7 @@ func Test_enrichProtobomLicensesScanWithFetcher_nilHandling(t *testing.T) {
 
 	t.Run("handles nil fetcher", func(t *testing.T) {
 		doc := sbom.NewDocument()
-		err := enrichProtobomLicensesScanWithFetcher(context.Background(), doc, nil)
+		err := enrichProtobomLicensesScanWithFetcher(t.Context(), doc, nil)
 		if err != nil {
 			t.Errorf("expected no error for nil fetcher, got %v", err)
 		}
@@ -1003,7 +1003,7 @@ func Test_enrichProtobomLicensesScanWithFetcher_nilHandling(t *testing.T) {
 		doc.NodeList.Nodes = append(doc.NodeList.Nodes, node)
 
 		fetcher := &remoteFetcher{Timeout: time.Second}
-		err := enrichProtobomLicensesScanWithFetcher(context.Background(), doc, fetcher)
+		err := enrichProtobomLicensesScanWithFetcher(t.Context(), doc, fetcher)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}

--- a/internal/scanning/filter_test.go
+++ b/internal/scanning/filter_test.go
@@ -1,7 +1,6 @@
 package scanning
 
 import (
-	"context"
 	"testing"
 
 	vulnerabilityv1 "github.com/temporalio/deputy/gen/deputy/vulnerability/v1"
@@ -249,7 +248,7 @@ func TestFilterByCEL(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -285,7 +284,7 @@ func TestFilterByCEL(t *testing.T) {
 }
 
 func TestFilterByCEL_EmptyResult(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	result := Result{
 		Findings:   []vulnerability.Finding{},
 		Advisories: map[string]*vulnerabilityv1.Advisory{},
@@ -302,7 +301,7 @@ func TestFilterByCEL_EmptyResult(t *testing.T) {
 }
 
 func TestFilterByCEL_StatsRecomputation(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	result := testResult()
 
 	// Filter to only critical severity
@@ -332,7 +331,7 @@ func TestFilterByCEL_StatsRecomputation(t *testing.T) {
 }
 
 func TestFilterByCEL_AdvisoriesFiltered(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	result := testResult()
 
 	// Filter to only npm ecosystem (2 findings: critical-pkg and low-pkg)
@@ -361,7 +360,7 @@ func TestFilterByCEL_AdvisoriesFiltered(t *testing.T) {
 }
 
 func TestFilterByCEL_OriginalResultUnmodified(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	result := testResult()
 
 	originalCount := len(result.Findings)
@@ -385,7 +384,7 @@ func TestFilterByCEL_OriginalResultUnmodified(t *testing.T) {
 // TestFilterByCEL_DocumentedExamples tests the exact expressions documented in the CLI help
 // and documentation to ensure they work correctly.
 func TestFilterByCEL_DocumentedExamples(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	result := testResult()
 
 	// These are the exact examples from docs/commands/scan.md

--- a/internal/scanning/supply_chain_test.go
+++ b/internal/scanning/supply_chain_test.go
@@ -1,7 +1,6 @@
 package scanning
 
 import (
-	"context"
 	"testing"
 
 	"github.com/google/osv-scalibr/extractor"
@@ -46,7 +45,7 @@ func TestCheckSupplyChain_SkipsExpressionImage(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			findings, _ := checkSupplyChain(context.Background(), []*extractor.Package{tc.pkg}, nil, "")
+			findings, _ := checkSupplyChain(t.Context(), []*extractor.Package{tc.pkg}, nil, "")
 			if len(findings) != 0 {
 				t.Errorf("expected 0 findings for expression image, got %d", len(findings))
 			}
@@ -60,7 +59,7 @@ func TestCheckSupplyChain_SkipsExpressionAction(t *testing.T) {
 	pkgs := []*extractor.Package{
 		{Name: "foo/bar", Version: "${{ env.REF }}", PURLType: "githubactions"},
 	}
-	findings, _ := checkSupplyChain(context.Background(), pkgs, nil, "")
+	findings, _ := checkSupplyChain(t.Context(), pkgs, nil, "")
 	if len(findings) != 0 {
 		t.Errorf("expected 0 findings for expression action ref, got %d", len(findings))
 	}
@@ -75,7 +74,7 @@ func TestCheckSupplyChain_UnpinnedAction(t *testing.T) {
 		},
 	}
 
-	findings, advisories := checkSupplyChain(context.Background(), pkgs, nil, "")
+	findings, advisories := checkSupplyChain(t.Context(), pkgs, nil, "")
 
 	if len(findings) != 1 {
 		t.Fatalf("expected 1 finding, got %d", len(findings))
@@ -116,7 +115,7 @@ func TestCheckSupplyChain_SelfReferenceSkipped(t *testing.T) {
 		},
 	}
 
-	findings, _ := checkSupplyChain(context.Background(), pkgs, nil, "temporalio/deputy")
+	findings, _ := checkSupplyChain(t.Context(), pkgs, nil, "temporalio/deputy")
 
 	if len(findings) != 1 {
 		t.Fatalf("expected 1 finding (third-party only), got %d", len(findings))
@@ -135,7 +134,7 @@ func TestCheckSupplyChain_SelfReferenceCaseInsensitive(t *testing.T) {
 		},
 	}
 
-	findings, _ := checkSupplyChain(context.Background(), pkgs, nil, "temporalio/deputy")
+	findings, _ := checkSupplyChain(t.Context(), pkgs, nil, "temporalio/deputy")
 
 	if len(findings) != 0 {
 		t.Errorf("expected self-reference match to be case-insensitive, got %d findings", len(findings))
@@ -151,7 +150,7 @@ func TestCheckSupplyChain_PinnedActionSkipped(t *testing.T) {
 		},
 	}
 
-	findings, advisories := checkSupplyChain(context.Background(), pkgs, nil, "")
+	findings, advisories := checkSupplyChain(t.Context(), pkgs, nil, "")
 
 	if len(findings) != 0 {
 		t.Errorf("expected 0 findings for pinned action, got %d", len(findings))
@@ -170,7 +169,7 @@ func TestCheckSupplyChain_NonGHASkipped(t *testing.T) {
 		},
 	}
 
-	findings, advisories := checkSupplyChain(context.Background(), pkgs, nil, "")
+	findings, advisories := checkSupplyChain(t.Context(), pkgs, nil, "")
 
 	if len(findings) != 0 {
 		t.Errorf("expected 0 findings for non-GHA package, got %d", len(findings))
@@ -190,7 +189,7 @@ func TestCheckSupplyChain_MixedPackages(t *testing.T) {
 		nil, // nil package should be skipped
 	}
 
-	findings, advisories := checkSupplyChain(context.Background(), pkgs, nil, "")
+	findings, advisories := checkSupplyChain(t.Context(), pkgs, nil, "")
 
 	if len(findings) != 2 {
 		t.Fatalf("expected 2 findings (2 unpinned actions), got %d", len(findings))
@@ -215,7 +214,7 @@ func TestCheckSupplyChain_MixedPackages(t *testing.T) {
 }
 
 func TestCheckSupplyChain_EmptyPackages(t *testing.T) {
-	findings, advisories := checkSupplyChain(context.Background(), nil, nil, "")
+	findings, advisories := checkSupplyChain(t.Context(), nil, nil, "")
 	if len(findings) != 0 {
 		t.Errorf("expected 0 findings, got %d", len(findings))
 	}
@@ -234,7 +233,7 @@ func TestCheckSupplyChain_LocationsPreserved(t *testing.T) {
 		},
 	}
 
-	findings, _ := checkSupplyChain(context.Background(), pkgs, nil, "")
+	findings, _ := checkSupplyChain(t.Context(), pkgs, nil, "")
 
 	if len(findings) != 1 {
 		t.Fatalf("expected 1 finding, got %d", len(findings))
@@ -255,7 +254,7 @@ func TestCheckSupplyChain_AdvisoryMetadata(t *testing.T) {
 		{Name: "actions/checkout", Version: "v4", PURLType: "githubactions"},
 	}
 
-	_, advisories := checkSupplyChain(context.Background(), pkgs, nil, "")
+	_, advisories := checkSupplyChain(t.Context(), pkgs, nil, "")
 
 	adv := advisories[AdvisoryUnpinnedAction]
 	if adv == nil {
@@ -289,7 +288,7 @@ func TestCheckSupplyChain_EcosystemField(t *testing.T) {
 		{Name: "actions/checkout", Version: "v4", PURLType: "githubactions"},
 	}
 
-	findings, _ := checkSupplyChain(context.Background(), pkgs, nil, "")
+	findings, _ := checkSupplyChain(t.Context(), pkgs, nil, "")
 
 	if len(findings) != 1 {
 		t.Fatalf("expected 1 finding, got %d", len(findings))
@@ -306,7 +305,7 @@ func TestCheckSupplyChain_UnpinnedImage(t *testing.T) {
 		{Name: "alpine", Version: "3.19", PURLType: "docker"},
 	}
 
-	findings, advisories := checkSupplyChain(context.Background(), pkgs, nil, "")
+	findings, advisories := checkSupplyChain(t.Context(), pkgs, nil, "")
 
 	if len(findings) != 1 {
 		t.Fatalf("expected 1 finding, got %d", len(findings))
@@ -332,7 +331,7 @@ func TestCheckSupplyChain_PinnedImageSkipped(t *testing.T) {
 		{Name: "ghcr.io/owner/image", Version: "v1@sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef", PURLType: "oci"},
 	}
 
-	findings, advisories := checkSupplyChain(context.Background(), pkgs, nil, "")
+	findings, advisories := checkSupplyChain(t.Context(), pkgs, nil, "")
 
 	if len(findings) != 0 {
 		t.Errorf("expected 0 findings for pinned images, got %d", len(findings))
@@ -347,7 +346,7 @@ func TestCheckSupplyChain_UnpinnedOCIImage(t *testing.T) {
 		{Name: "ghcr.io/owner/image", Version: "v2", PURLType: "oci"},
 	}
 
-	findings, advisories := checkSupplyChain(context.Background(), pkgs, nil, "")
+	findings, advisories := checkSupplyChain(t.Context(), pkgs, nil, "")
 
 	if len(findings) != 1 {
 		t.Fatalf("expected 1 finding, got %d", len(findings))
@@ -367,7 +366,7 @@ func TestCheckSupplyChain_MixedActionsAndImages(t *testing.T) {
 		{Name: "lodash", Version: "4.17.21", PURLType: "npm"},
 	}
 
-	findings, advisories := checkSupplyChain(context.Background(), pkgs, nil, "")
+	findings, advisories := checkSupplyChain(t.Context(), pkgs, nil, "")
 
 	if len(findings) != 2 {
 		t.Fatalf("expected 2 findings (1 action + 1 image), got %d", len(findings))

--- a/internal/secrets/archive_test.go
+++ b/internal/secrets/archive_test.go
@@ -5,7 +5,6 @@ import (
 	"archive/zip"
 	"bytes"
 	"compress/gzip"
-	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -221,7 +220,7 @@ func TestArchiveScanner_ScanZip(t *testing.T) {
 	}
 
 	// Scan the zip from reader
-	result, err := scanner.ScanArchiveReader(context.Background(), bytes.NewReader(buf.Bytes()), FormatZip, "test.zip")
+	result, err := scanner.ScanArchiveReader(t.Context(), bytes.NewReader(buf.Bytes()), FormatZip, "test.zip")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -298,7 +297,7 @@ func TestArchiveScanner_ScanTarGz(t *testing.T) {
 	}
 
 	// Scan the tar.gz from reader
-	result, err := scanner.ScanArchiveReader(context.Background(), bytes.NewReader(buf.Bytes()), FormatTarGz, "test.tar.gz")
+	result, err := scanner.ScanArchiveReader(t.Context(), bytes.NewReader(buf.Bytes()), FormatTarGz, "test.tar.gz")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -354,7 +353,7 @@ func TestArchiveScanner_PathTraversalProtection(t *testing.T) {
 	}
 
 	// Scan - should skip the malicious path
-	result, err := scanner.ScanArchiveReader(context.Background(), bytes.NewReader(buf.Bytes()), FormatZip, "test.zip")
+	result, err := scanner.ScanArchiveReader(t.Context(), bytes.NewReader(buf.Bytes()), FormatZip, "test.zip")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -401,7 +400,7 @@ func TestArchiveScanner_SizeLimits(t *testing.T) {
 	}
 
 	// Scan - should stop at limit
-	result, err := scanner.ScanArchiveReader(context.Background(), bytes.NewReader(buf.Bytes()), FormatZip, "test.zip")
+	result, err := scanner.ScanArchiveReader(t.Context(), bytes.NewReader(buf.Bytes()), FormatZip, "test.zip")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -439,7 +438,7 @@ func TestArchiveScanner_NestedArchives(t *testing.T) {
 	}
 
 	// Scan - should find secret in nested archive
-	result, err := scanner.ScanArchiveReader(context.Background(), bytes.NewReader(outerBuf.Bytes()), FormatZip, "outer.zip")
+	result, err := scanner.ScanArchiveReader(t.Context(), bytes.NewReader(outerBuf.Bytes()), FormatZip, "outer.zip")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -475,7 +474,7 @@ func TestSafeExtractArchive(t *testing.T) {
 	tmpFile.Close()
 
 	// Extract safely
-	root, tempDir, err := SafeExtractArchive(context.Background(), tmpFile.Name(), 1024*1024)
+	root, tempDir, err := SafeExtractArchive(t.Context(), tmpFile.Name(), 1024*1024)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -518,7 +517,7 @@ func TestArchiveScanner_BinaryStrings(t *testing.T) {
 	binaryContent.Write([]byte{0x00, 0x00})
 
 	// Scan binary content
-	findings, err := scanner.ScanBinaryContent(context.Background(), binaryContent.Bytes(), "test.bin")
+	findings, err := scanner.ScanBinaryContent(t.Context(), binaryContent.Bytes(), "test.bin")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -694,7 +693,7 @@ func TestArchiveScanner_ZipBombInRealArchive(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := scanner.ScanArchiveReader(context.Background(), bytes.NewReader(buf.Bytes()), FormatZip, "test.zip")
+	result, err := scanner.ScanArchiveReader(t.Context(), bytes.NewReader(buf.Bytes()), FormatZip, "test.zip")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -738,7 +737,7 @@ func TestArchiveScanner_WindowsPathTraversal(t *testing.T) {
 	}
 
 	// Scan
-	result, err := scanner.ScanArchiveReader(context.Background(), bytes.NewReader(buf.Bytes()), FormatZip, "test.zip")
+	result, err := scanner.ScanArchiveReader(t.Context(), bytes.NewReader(buf.Bytes()), FormatZip, "test.zip")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -783,7 +782,7 @@ func TestArchiveScanner_NullByteInjection(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := scanner.ScanArchiveReader(context.Background(), bytes.NewReader(buf.Bytes()), FormatZip, "test.zip")
+	result, err := scanner.ScanArchiveReader(t.Context(), bytes.NewReader(buf.Bytes()), FormatZip, "test.zip")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -839,7 +838,7 @@ func TestArchiveScanner_TarSymlinkBlocking(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := scanner.ScanArchiveReader(context.Background(), bytes.NewReader(buf.Bytes()), FormatTar, "test.tar")
+	result, err := scanner.ScanArchiveReader(t.Context(), bytes.NewReader(buf.Bytes()), FormatTar, "test.tar")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -881,7 +880,7 @@ func TestArchiveScanner_TarHardlinkBlocking(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := scanner.ScanArchiveReader(context.Background(), bytes.NewReader(buf.Bytes()), FormatTar, "test.tar")
+	result, err := scanner.ScanArchiveReader(t.Context(), bytes.NewReader(buf.Bytes()), FormatTar, "test.tar")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -917,7 +916,7 @@ func TestArchiveScanner_NegativeSizeProtection(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := scanner.ScanArchiveReader(context.Background(), bytes.NewReader(buf.Bytes()), FormatTar, "test.tar")
+	result, err := scanner.ScanArchiveReader(t.Context(), bytes.NewReader(buf.Bytes()), FormatTar, "test.tar")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/secrets/baseline_test.go
+++ b/internal/secrets/baseline_test.go
@@ -1,7 +1,6 @@
 package secrets
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -208,7 +207,7 @@ func TestMatchesPathFilter_RecursiveGlob(t *testing.T) {
 }
 
 func TestBaselineScanner(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a mock scanner that returns fixed findings
 	engine, err := NewEngine()
@@ -305,7 +304,7 @@ func TestParseInlineAllowlist(t *testing.T) {
 }
 
 func TestInlineAllowlistScanner(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	engine, err := NewEngine()
 	if err != nil {
@@ -416,7 +415,7 @@ func TestBaseline_Merge(t *testing.T) {
 }
 
 func TestGenerateBaseline(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create temp directory with test files
 	tmpDir := t.TempDir()

--- a/internal/secrets/detector_test.go
+++ b/internal/secrets/detector_test.go
@@ -17,7 +17,7 @@ config:
   name: test
 `)
 
-	findings, err := engine.Scan(context.Background(), content)
+	findings, err := engine.Scan(t.Context(), content)
 	if err != nil {
 		t.Fatalf("Scan() error = %v", err)
 	}
@@ -51,7 +51,7 @@ func TestEngine_Scan_AWSAccessKey(t *testing.T) {
 
 	content := []byte(`aws_access_key_id = AKIAIOSFODNN7EXAMPLE`)
 
-	findings, err := engine.Scan(context.Background(), content)
+	findings, err := engine.Scan(t.Context(), content)
 	if err != nil {
 		t.Fatalf("Scan() error = %v", err)
 	}
@@ -77,7 +77,7 @@ func TestEngine_Scan_PrivateKey(t *testing.T) {
 MIIEpAIBAAKCAQEA...
 -----END RSA PRIVATE KEY-----`)
 
-	findings, err := engine.Scan(context.Background(), content)
+	findings, err := engine.Scan(t.Context(), content)
 	if err != nil {
 		t.Fatalf("Scan() error = %v", err)
 	}
@@ -102,7 +102,7 @@ func TestEngine_Scan_JWT(t *testing.T) {
 	// Example JWT (not a real secret)
 	content := []byte(`token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c`)
 
-	findings, err := engine.Scan(context.Background(), content)
+	findings, err := engine.Scan(t.Context(), content)
 	if err != nil {
 		t.Fatalf("Scan() error = %v", err)
 	}
@@ -126,7 +126,7 @@ func TestEngine_Scan_SlackToken(t *testing.T) {
 
 	content := []byte(`SLACK_TOKEN=xoxb-1234567890-1234567890123-abcdefghijklmnop`)
 
-	findings, err := engine.Scan(context.Background(), content)
+	findings, err := engine.Scan(t.Context(), content)
 	if err != nil {
 		t.Fatalf("Scan() error = %v", err)
 	}
@@ -150,7 +150,7 @@ func TestEngine_Scan_StripeKey(t *testing.T) {
 
 	content := []byte(`stripe_key: sk_live_abcdefghijklmnopqrstuvwxyz`)
 
-	findings, err := engine.Scan(context.Background(), content)
+	findings, err := engine.Scan(t.Context(), content)
 	if err != nil {
 		t.Fatalf("Scan() error = %v", err)
 	}
@@ -179,7 +179,7 @@ version: 1.0.0
 description: A normal application
 `)
 
-	findings, err := engine.Scan(context.Background(), content)
+	findings, err := engine.Scan(t.Context(), content)
 	if err != nil {
 		t.Fatalf("Scan() error = %v", err)
 	}
@@ -198,7 +198,7 @@ func TestEngine_Scan_SendGridKey(t *testing.T) {
 	// SendGrid key format: SG.<22 chars>.<43 chars>
 	content := []byte(`SENDGRID_API_KEY=SG.abcdefghijklmnopqrstuv.wxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ012`)
 
-	findings, err := engine.Scan(context.Background(), content)
+	findings, err := engine.Scan(t.Context(), content)
 	if err != nil {
 		t.Fatalf("Scan() error = %v", err)
 	}
@@ -222,7 +222,7 @@ func TestEngine_Scan_NpmToken(t *testing.T) {
 
 	content := []byte(`//registry.npmjs.org/:_authToken=npm_abcdefghijklmnopqrstuvwxyz0123456789`)
 
-	findings, err := engine.Scan(context.Background(), content)
+	findings, err := engine.Scan(t.Context(), content)
 	if err != nil {
 		t.Fatalf("Scan() error = %v", err)
 	}
@@ -246,7 +246,7 @@ func TestEngine_ScanFile(t *testing.T) {
 
 	content := []byte(`token: ghp_ABCDEFghijklmnopqrstuvwxyz0123456789`)
 
-	findings, err := engine.ScanFile(context.Background(), "config.yaml", content)
+	findings, err := engine.ScanFile(t.Context(), "config.yaml", content)
 	if err != nil {
 		t.Fatalf("ScanFile() error = %v", err)
 	}
@@ -396,7 +396,7 @@ func TestMultiScanner(t *testing.T) {
 
 	content := []byte(`token: ghp_ABCDEFghijklmnopqrstuvwxyz0123456789`)
 
-	findings, err := multi.Scan(context.Background(), content)
+	findings, err := multi.Scan(t.Context(), content)
 	if err != nil {
 		t.Fatalf("Scan() error = %v", err)
 	}
@@ -427,7 +427,7 @@ stripe: sk_live_abcdefghijklmnopqrstuvwxyz
 
 	t.Run("allow types", func(t *testing.T) {
 		filtered := NewFilteringScanner(engine, WithAllowedTypes(TypeGitHubToken))
-		findings, err := filtered.Scan(context.Background(), content)
+		findings, err := filtered.Scan(t.Context(), content)
 		if err != nil {
 			t.Fatalf("Scan() error = %v", err)
 		}
@@ -441,7 +441,7 @@ stripe: sk_live_abcdefghijklmnopqrstuvwxyz
 
 	t.Run("deny types", func(t *testing.T) {
 		filtered := NewFilteringScanner(engine, WithDeniedTypes(TypeGitHubToken))
-		findings, err := filtered.Scan(context.Background(), content)
+		findings, err := filtered.Scan(t.Context(), content)
 		if err != nil {
 			t.Fatalf("Scan() error = %v", err)
 		}
@@ -455,7 +455,7 @@ stripe: sk_live_abcdefghijklmnopqrstuvwxyz
 
 	t.Run("min confidence", func(t *testing.T) {
 		filtered := NewFilteringScanner(engine, WithMinConfidence(0.98))
-		findings, err := filtered.Scan(context.Background(), content)
+		findings, err := filtered.Scan(t.Context(), content)
 		if err != nil {
 			t.Fatalf("Scan() error = %v", err)
 		}
@@ -470,9 +470,9 @@ stripe: sk_live_abcdefghijklmnopqrstuvwxyz
 
 func TestShannonEntropy(t *testing.T) {
 	tests := []struct {
-		input    string
-		minExp   float64
-		maxExp   float64
+		input  string
+		minExp float64
+		maxExp float64
 	}{
 		{"", 0, 0},
 		{"aaaaaaaaaa", 0, 0.1},
@@ -536,7 +536,7 @@ func TestBatchScanner_ScanBatch(t *testing.T) {
 		"clean.yaml":   []byte(`name: test`),
 	}
 
-	results := batch.ScanBatch(context.Background(), items)
+	results := batch.ScanBatch(t.Context(), items)
 
 	if len(results) != 3 {
 		t.Errorf("expected 3 results, got %d", len(results))
@@ -606,7 +606,7 @@ func TestBatchScanner_ContextCancellation(t *testing.T) {
 	batch := NewBatchScanner(engine, 1)
 
 	// Create a cancelled context
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
 	items := map[string][]byte{

--- a/internal/secrets/verify_test.go
+++ b/internal/secrets/verify_test.go
@@ -1,7 +1,6 @@
 package secrets
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"strings"
@@ -29,7 +28,7 @@ func TestGitHubVerifier_DoesNotLeakResponseBody(t *testing.T) {
 	}
 
 	verifier := newGitHubVerifier(client)
-	result := verifier.Verify(context.Background(), "ghp_example123", TypeGitHubToken)
+	result := verifier.Verify(t.Context(), "ghp_example123", TypeGitHubToken)
 
 	if result.Status != StatusError {
 		t.Fatalf("expected StatusError, got %s", result.Status)

--- a/internal/server/auth_test.go
+++ b/internal/server/auth_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -91,7 +90,7 @@ func TestServerAuthModeDisabled(t *testing.T) {
 	client := listv1connect.NewListServiceClient(http.DefaultClient, ts.URL)
 
 	// Request without auth should succeed
-	resp, err := client.ListEcosystems(context.Background(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
+	resp, err := client.ListEcosystems(t.Context(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
 	if err != nil {
 		t.Fatalf("request should succeed with auth disabled: %v", err)
 	}
@@ -120,7 +119,7 @@ func TestServerAuthModeRequired_NoToken(t *testing.T) {
 	client := listv1connect.NewListServiceClient(http.DefaultClient, ts.URL)
 
 	// Request without auth should fail
-	_, err := client.ListEcosystems(context.Background(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
+	_, err := client.ListEcosystems(t.Context(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
 	if err == nil {
 		t.Fatal("expected error for unauthenticated request when auth required")
 	}
@@ -165,7 +164,7 @@ func TestServerAuthModeRequired_ValidToken(t *testing.T) {
 	client := listv1connect.NewListServiceClient(httpClient, ts.URL)
 
 	// Request with valid token should succeed
-	resp, err := client.ListEcosystems(context.Background(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
+	resp, err := client.ListEcosystems(t.Context(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
 	if err != nil {
 		t.Fatalf("request with valid token should succeed: %v", err)
 	}
@@ -204,7 +203,7 @@ func TestServerAuthModeRequired_ExpiredToken(t *testing.T) {
 	client := listv1connect.NewListServiceClient(httpClient, ts.URL)
 
 	// Request with expired token should fail
-	_, err := client.ListEcosystems(context.Background(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
+	_, err := client.ListEcosystems(t.Context(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
 	if err == nil {
 		t.Fatal("expected error for expired token")
 	}
@@ -248,7 +247,7 @@ func TestServerAuthIssuerValidation(t *testing.T) {
 		}
 		client := listv1connect.NewListServiceClient(httpClient, ts.URL)
 
-		_, err := client.ListEcosystems(context.Background(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
+		_, err := client.ListEcosystems(t.Context(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
 		if err != nil {
 			t.Fatalf("request with valid issuer should succeed: %v", err)
 		}
@@ -266,7 +265,7 @@ func TestServerAuthIssuerValidation(t *testing.T) {
 		}
 		client := listv1connect.NewListServiceClient(httpClient, ts.URL)
 
-		_, err := client.ListEcosystems(context.Background(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
+		_, err := client.ListEcosystems(t.Context(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
 		if err == nil {
 			t.Fatal("expected error for invalid issuer")
 		}
@@ -311,7 +310,7 @@ func TestServerAuthAudienceValidation(t *testing.T) {
 		}
 		client := listv1connect.NewListServiceClient(httpClient, ts.URL)
 
-		_, err := client.ListEcosystems(context.Background(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
+		_, err := client.ListEcosystems(t.Context(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
 		if err != nil {
 			t.Fatalf("request with valid audience should succeed: %v", err)
 		}
@@ -329,7 +328,7 @@ func TestServerAuthAudienceValidation(t *testing.T) {
 		}
 		client := listv1connect.NewListServiceClient(httpClient, ts.URL)
 
-		_, err := client.ListEcosystems(context.Background(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
+		_, err := client.ListEcosystems(t.Context(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
 		if err == nil {
 			t.Fatal("expected error for invalid audience")
 		}
@@ -439,7 +438,7 @@ func TestServerMultiTenantIdentities(t *testing.T) {
 			}
 			client := listv1connect.NewListServiceClient(httpClient, ts.URL)
 
-			_, err := client.ListEcosystems(context.Background(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
+			_, err := client.ListEcosystems(t.Context(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
 
 			if tc.wantErr {
 				if err == nil {
@@ -606,7 +605,7 @@ func TestScanServiceAuth(t *testing.T) {
 	t.Run("unauthenticated scan request rejected", func(t *testing.T) {
 		client := scanv1connect.NewScanServiceClient(http.DefaultClient, ts.URL)
 
-		_, err := client.Scan(context.Background(), connect.NewRequest(&scanv1.ScanRequest{
+		_, err := client.Scan(t.Context(), connect.NewRequest(&scanv1.ScanRequest{
 			Target: "github.com/test/repo",
 		}))
 		if err == nil {
@@ -635,7 +634,7 @@ func TestScanServiceAuth(t *testing.T) {
 
 		// Request should pass auth, but may fail on scan validation
 		// (that's fine - we're testing auth, not scan logic)
-		_, err := client.Scan(context.Background(), connect.NewRequest(&scanv1.ScanRequest{
+		_, err := client.Scan(t.Context(), connect.NewRequest(&scanv1.ScanRequest{
 			Target: "", // Empty target should cause InvalidArgument, not Unauthenticated
 		}))
 
@@ -713,7 +712,7 @@ policies:
 		}
 		client := scanv1connect.NewScanServiceClient(httpClient, ts.URL)
 
-		_, err := client.Scan(context.Background(), connect.NewRequest(&scanv1.ScanRequest{
+		_, err := client.Scan(t.Context(), connect.NewRequest(&scanv1.ScanRequest{
 			Target: "github.com/test/repo",
 		}))
 		if err == nil {
@@ -742,7 +741,7 @@ policies:
 		client := scanv1connect.NewScanServiceClient(httpClient, ts.URL)
 
 		// Request should pass policy, but may fail on scan validation
-		_, err := client.Scan(context.Background(), connect.NewRequest(&scanv1.ScanRequest{
+		_, err := client.Scan(t.Context(), connect.NewRequest(&scanv1.ScanRequest{
 			Target: "", // Empty target - auth and policy passed
 		}))
 
@@ -767,7 +766,7 @@ policies:
 		}
 		client := scanv1connect.NewScanServiceClient(httpClient, ts.URL)
 
-		_, err := client.Scan(context.Background(), connect.NewRequest(&scanv1.ScanRequest{
+		_, err := client.Scan(t.Context(), connect.NewRequest(&scanv1.ScanRequest{
 			Target: "",
 		}))
 
@@ -819,7 +818,7 @@ func TestServerSecurity_AlgorithmConfusion(t *testing.T) {
 	}
 	client := listv1connect.NewListServiceClient(httpClient, ts.URL)
 
-	_, err := client.ListEcosystems(context.Background(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
+	_, err := client.ListEcosystems(t.Context(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
 	if err == nil {
 		t.Fatal("SECURITY VULNERABILITY: Server accepted alg=none token")
 	}
@@ -832,7 +831,7 @@ func TestServerSecurity_AlgorithmConfusion(t *testing.T) {
 	}
 	client2 := listv1connect.NewListServiceClient(httpClient2, ts.URL)
 
-	_, err = client2.ListEcosystems(context.Background(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
+	_, err = client2.ListEcosystems(t.Context(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
 	if err == nil {
 		t.Fatal("SECURITY VULNERABILITY: Server accepted HS256 token when ES256 expected")
 	}
@@ -867,7 +866,7 @@ func TestServerSecurity_TokenReplay(t *testing.T) {
 	}
 	client := listv1connect.NewListServiceClient(httpClient, ts.URL)
 
-	_, err := client.ListEcosystems(context.Background(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
+	_, err := client.ListEcosystems(t.Context(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
 	if err == nil {
 		t.Fatal("SECURITY: Server accepted expired token")
 	}
@@ -912,7 +911,7 @@ func TestServerSecurity_WrongKeyID(t *testing.T) {
 	}
 	client := listv1connect.NewListServiceClient(httpClient, ts.URL)
 
-	_, err = client.ListEcosystems(context.Background(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
+	_, err = client.ListEcosystems(t.Context(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
 	if err == nil {
 		t.Fatal("SECURITY: Server accepted token with unknown key ID")
 	}
@@ -994,7 +993,7 @@ policies:
 		}
 		client := listv1connect.NewListServiceClient(httpClient, ts.URL)
 
-		_, err := client.ListEcosystems(context.Background(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
+		_, err := client.ListEcosystems(t.Context(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
 		if err != nil {
 			t.Fatalf("trusted org should be allowed: %v", err)
 		}
@@ -1018,7 +1017,7 @@ policies:
 		}
 		client := scanv1connect.NewScanServiceClient(httpClient, ts.URL)
 
-		_, err := client.Scan(context.Background(), connect.NewRequest(&scanv1.ScanRequest{
+		_, err := client.Scan(t.Context(), connect.NewRequest(&scanv1.ScanRequest{
 			Target: "github.com/test/repo",
 		}))
 		if err == nil {
@@ -1048,7 +1047,7 @@ policies:
 		}
 		client := listv1connect.NewListServiceClient(httpClient, ts.URL)
 
-		_, err := client.ListEcosystems(context.Background(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
+		_, err := client.ListEcosystems(t.Context(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
 		if err == nil {
 			t.Fatal("wrong issuer should be denied")
 		}
@@ -1079,7 +1078,7 @@ policies:
 		}
 		client := listv1connect.NewListServiceClient(httpClient, ts.URL)
 
-		_, err := client.ListEcosystems(context.Background(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
+		_, err := client.ListEcosystems(t.Context(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
 		if err == nil {
 			t.Fatal("wrong audience should be denied")
 		}
@@ -1137,7 +1136,7 @@ policies:
 		client := scanv1connect.NewScanServiceClient(httpClient, ts.URL)
 
 		// Scanning a target in the same tenant should pass policy (fail on validation)
-		_, err := client.Scan(context.Background(), connect.NewRequest(&scanv1.ScanRequest{
+		_, err := client.Scan(t.Context(), connect.NewRequest(&scanv1.ScanRequest{
 			Target: "github.com/acme/internal-app",
 		}))
 
@@ -1163,7 +1162,7 @@ policies:
 		client := scanv1connect.NewScanServiceClient(httpClient, ts.URL)
 
 		// Scanning a target from different tenant should be denied
-		_, err := client.Scan(context.Background(), connect.NewRequest(&scanv1.ScanRequest{
+		_, err := client.Scan(t.Context(), connect.NewRequest(&scanv1.ScanRequest{
 			Target: "github.com/other-company/secret-app",
 		}))
 		if err == nil {

--- a/internal/server/graph_handler_test.go
+++ b/internal/server/graph_handler_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"slices"
@@ -81,7 +80,7 @@ require github.com/pkg/errors v0.9.1
 	}
 
 	h := NewGraphHandler(WithGraphLocalMode())
-	resp, err := h.BuildGraph(context.Background(), connect.NewRequest(&graphv1.BuildGraphRequest{
+	resp, err := h.BuildGraph(t.Context(), connect.NewRequest(&graphv1.BuildGraphRequest{
 		Target: tmpDir,
 		Options: &graphv1.GraphOptions{
 			Ecosystems: []string{"go"},
@@ -202,7 +201,7 @@ require github.com/pkg/errors v0.9.1
 	}
 
 	h := NewGraphHandler(WithGraphLocalMode())
-	resp, err := h.BuildGraph(context.Background(), connect.NewRequest(&graphv1.BuildGraphRequest{
+	resp, err := h.BuildGraph(t.Context(), connect.NewRequest(&graphv1.BuildGraphRequest{
 		Target: tmpDir,
 		Options: &graphv1.GraphOptions{
 			Ecosystems: []string{"go"},
@@ -243,7 +242,7 @@ require github.com/pkg/errors v0.9.1 // indirect
 	}
 
 	h := NewGraphHandler(WithGraphLocalMode())
-	resp, err := h.WhyDependency(context.Background(), connect.NewRequest(&graphv1.WhyDependencyRequest{
+	resp, err := h.WhyDependency(t.Context(), connect.NewRequest(&graphv1.WhyDependencyRequest{
 		Target:     tmpDir,
 		Dependency: "pkg:golang/github.com/pkg/errors@0.9.1",
 		Options: &graphv1.GraphOptions{

--- a/internal/server/handler_trace_test.go
+++ b/internal/server/handler_trace_test.go
@@ -71,7 +71,7 @@ func TestScanHandler_Trace_InvalidArgument(t *testing.T) {
 
 	client := scanv1connect.NewScanServiceClient(http.DefaultClient, ts.URL)
 
-	_, err = client.Scan(context.Background(), connect.NewRequest(&scanv1.ScanRequest{
+	_, err = client.Scan(t.Context(), connect.NewRequest(&scanv1.ScanRequest{
 		Target: "",
 	}))
 	if err == nil {
@@ -106,7 +106,7 @@ func TestScanHandler_Trace_TargetAttribute(t *testing.T) {
 	client := scanv1connect.NewScanServiceClient(http.DefaultClient, ts.URL)
 
 	// Use a remote target that passes validation but will fail later
-	_, _ = client.Scan(context.Background(), connect.NewRequest(&scanv1.ScanRequest{
+	_, _ = client.Scan(t.Context(), connect.NewRequest(&scanv1.ScanRequest{
 		Target: "github.com/nonexistent/repo",
 	}))
 
@@ -137,7 +137,7 @@ func TestListHandler_Trace_Ecosystems(t *testing.T) {
 
 	client := listv1connect.NewListServiceClient(http.DefaultClient, ts.URL)
 
-	resp, err := client.ListEcosystems(context.Background(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
+	resp, err := client.ListEcosystems(t.Context(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
 	if err != nil {
 		t.Fatalf("ListEcosystems failed: %v", err)
 	}
@@ -172,7 +172,7 @@ func TestSecretsHandler_Trace_ListDetectors(t *testing.T) {
 
 	client := secretsv1connect.NewSecretsServiceClient(http.DefaultClient, ts.URL)
 
-	resp, err := client.ListDetectors(context.Background(), connect.NewRequest(&secretsv1.ListDetectorsRequest{}))
+	resp, err := client.ListDetectors(t.Context(), connect.NewRequest(&secretsv1.ListDetectorsRequest{}))
 	if err != nil {
 		t.Fatalf("ListDetectors failed: %v", err)
 	}
@@ -207,7 +207,7 @@ func TestSecretsHandler_Trace_ScanError(t *testing.T) {
 
 	client := secretsv1connect.NewSecretsServiceClient(http.DefaultClient, ts.URL)
 
-	_, err = client.Scan(context.Background(), connect.NewRequest(&secretsv1.ScanRequest{
+	_, err = client.Scan(t.Context(), connect.NewRequest(&secretsv1.ScanRequest{
 		Target: "",
 	}))
 	if err == nil {
@@ -241,7 +241,7 @@ func TestHandler_Trace_SpanParenting(t *testing.T) {
 
 	client := listv1connect.NewListServiceClient(http.DefaultClient, ts.URL)
 
-	_, err = client.ListEcosystems(context.Background(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
+	_, err = client.ListEcosystems(t.Context(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
@@ -275,9 +275,9 @@ func TestOtelconnect_Integration(t *testing.T) {
 	listClient := listv1connect.NewListServiceClient(http.DefaultClient, ts.URL)
 	secretsClient := secretsv1connect.NewSecretsServiceClient(http.DefaultClient, ts.URL)
 
-	_, _ = scanClient.Scan(context.Background(), connect.NewRequest(&scanv1.ScanRequest{Target: ""}))
-	_, _ = listClient.ListEcosystems(context.Background(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
-	_, _ = secretsClient.ListDetectors(context.Background(), connect.NewRequest(&secretsv1.ListDetectorsRequest{}))
+	_, _ = scanClient.Scan(t.Context(), connect.NewRequest(&scanv1.ScanRequest{Target: ""}))
+	_, _ = listClient.ListEcosystems(t.Context(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
+	_, _ = secretsClient.ListDetectors(t.Context(), connect.NewRequest(&secretsv1.ListDetectorsRequest{}))
 
 	spans := recorder.Ended()
 	if len(spans) == 0 {
@@ -306,7 +306,7 @@ func TestScanHandler_Direct_Trace(t *testing.T) {
 	handler := NewScanHandler(WithLocalMode())
 	req := connect.NewRequest(&scanv1.ScanRequest{Target: "."})
 
-	_, err := handler.Scan(context.Background(), req)
+	_, err := handler.Scan(t.Context(), req)
 	if err != nil {
 		t.Logf("scan error (may be expected): %v", err)
 	}
@@ -328,7 +328,7 @@ func TestListHandler_Direct_Trace(t *testing.T) {
 	handler := NewListHandler(WithListLocalMode())
 	req := connect.NewRequest(&listv1.ListEcosystemsRequest{})
 
-	resp, err := handler.ListEcosystems(context.Background(), req)
+	resp, err := handler.ListEcosystems(t.Context(), req)
 	if err != nil {
 		t.Fatalf("ListEcosystems failed: %v", err)
 	}
@@ -355,7 +355,7 @@ func TestSecretsHandler_Direct_Trace(t *testing.T) {
 	}
 
 	req := connect.NewRequest(&secretsv1.ListDetectorsRequest{})
-	resp, err := handler.ListDetectors(context.Background(), req)
+	resp, err := handler.ListDetectors(t.Context(), req)
 	if err != nil {
 		t.Fatalf("ListDetectors failed: %v", err)
 	}

--- a/internal/server/secrets_handler_test.go
+++ b/internal/server/secrets_handler_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -61,7 +60,7 @@ func TestSecretsHandler_ListDetectors(t *testing.T) {
 		t.Fatalf("failed to create secrets handler: %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	req := connect.NewRequest(&secretsv1.ListDetectorsRequest{
 		IncludeDisabled: true,
 	})
@@ -101,7 +100,7 @@ func TestSecretsHandler_ScanEmptyTarget(t *testing.T) {
 		t.Fatalf("failed to create secrets handler: %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	req := connect.NewRequest(&secretsv1.ScanRequest{
 		Target: "", // Will default to "."
 	})
@@ -119,7 +118,7 @@ func TestSecretsHandler_RegisterDetector(t *testing.T) {
 		t.Fatalf("failed to create secrets handler: %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	req := connect.NewRequest(&secretsv1.RegisterDetectorRequest{
 		Detector: &secretsv1.DetectorInfo{
 			Id:          "test-custom",
@@ -172,7 +171,7 @@ func TestSecretsHandler_RegisterDetector_InvalidPattern(t *testing.T) {
 		t.Fatalf("failed to create secrets handler: %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	req := connect.NewRequest(&secretsv1.RegisterDetectorRequest{
 		Detector: &secretsv1.DetectorInfo{
 			Id:   "bad-detector",
@@ -193,7 +192,7 @@ func TestSecretsHandler_RegisterDetector_MissingPattern(t *testing.T) {
 		t.Fatalf("failed to create secrets handler: %v", err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	req := connect.NewRequest(&secretsv1.RegisterDetectorRequest{
 		Detector: &secretsv1.DetectorInfo{
 			Id:   "no-pattern",

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -76,7 +75,7 @@ func TestScanServiceRegistered(t *testing.T) {
 	)
 
 	// Call with empty target - should return InvalidArgument error
-	_, err = client.Scan(context.Background(), connect.NewRequest(&scanv1.ScanRequest{
+	_, err = client.Scan(t.Context(), connect.NewRequest(&scanv1.ScanRequest{
 		Target: "",
 	}))
 
@@ -161,7 +160,7 @@ func TestSecretsServiceRegistered(t *testing.T) {
 	)
 
 	// Call ListDetectors - should succeed
-	resp, err := client.ListDetectors(context.Background(), connect.NewRequest(&secretsv1.ListDetectorsRequest{}))
+	resp, err := client.ListDetectors(t.Context(), connect.NewRequest(&secretsv1.ListDetectorsRequest{}))
 	if err != nil {
 		t.Fatalf("ListDetectors failed: %v", err)
 	}
@@ -190,7 +189,7 @@ func TestSecretsServiceScanEmptyTarget(t *testing.T) {
 
 	// Call Scan with empty target - should use "." as default
 	// This will fail validation for remote targets, which is expected
-	_, err = client.Scan(context.Background(), connect.NewRequest(&secretsv1.ScanRequest{
+	_, err = client.Scan(t.Context(), connect.NewRequest(&secretsv1.ScanRequest{
 		Target: "",
 	}))
 
@@ -225,7 +224,7 @@ func TestListServiceRegistered(t *testing.T) {
 	)
 
 	// Call ListEcosystems - should succeed
-	resp, err := client.ListEcosystems(context.Background(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
+	resp, err := client.ListEcosystems(t.Context(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
 	if err != nil {
 		t.Fatalf("ListEcosystems failed: %v", err)
 	}

--- a/internal/services/transport_test.go
+++ b/internal/services/transport_test.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -22,7 +21,7 @@ func TestInProcessTransport(t *testing.T) {
 	clients := svc.InProcessClients()
 
 	// Test ListEcosystems (doesn't require target validation)
-	ctx := context.Background()
+	ctx := t.Context()
 	resp, err := clients.Packages.ListEcosystems(ctx, connect.NewRequest(&listv1.ListEcosystemsRequest{}))
 	if err != nil {
 		t.Fatalf("ListEcosystems failed: %v", err)
@@ -60,7 +59,7 @@ func TestInProcessTransport_NotFound(t *testing.T) {
 	// Try to call a service that's not registered
 	client := listv1connect.NewListServiceClient(httpClient, "")
 
-	_, err := client.ListEcosystems(context.Background(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
+	_, err := client.ListEcosystems(t.Context(), connect.NewRequest(&listv1.ListEcosystemsRequest{}))
 	if err == nil {
 		t.Error("expected error for unregistered handler")
 	}

--- a/internal/targets/providers/container_image_test.go
+++ b/internal/targets/providers/container_image_test.go
@@ -1,7 +1,6 @@
 package providers
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -343,7 +342,7 @@ func TestParsePlatform(t *testing.T) {
 func TestContainerImageProviderDetect(t *testing.T) {
 	t.Parallel()
 	provider := containerImageProvider{}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	tests := []struct {
 		target string

--- a/internal/targets/providers/dockerfile_test.go
+++ b/internal/targets/providers/dockerfile_test.go
@@ -1,7 +1,6 @@
 package providers
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -34,7 +33,7 @@ func TestDockerfileProviderDetect(t *testing.T) {
 	}
 
 	provider := dockerfileProvider{}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	for name, expected := range files {
 		path := filepath.Join(tmpDir, name)
@@ -65,7 +64,7 @@ ENTRYPOINT ["/main"]
 	}
 
 	provider := dockerfileProvider{}
-	ctx := context.Background()
+	ctx := t.Context()
 
 	mat, err := provider.Open(ctx, dockerfilePath, nil)
 	if err != nil {

--- a/internal/targets/providers/providers_test.go
+++ b/internal/targets/providers/providers_test.go
@@ -1,7 +1,6 @@
 package providers
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,7 +14,7 @@ import (
 
 func TestTargetsOpenLocalDirectory(t *testing.T) {
 	dir := t.TempDir()
-	mat, err := targets.Open(context.Background(), dir, nil)
+	mat, err := targets.Open(t.Context(), dir, nil)
 	if err != nil {
 		t.Fatalf("open local dir: %v", err)
 	}
@@ -29,7 +28,7 @@ func TestTargetsOpenLocalDirectory(t *testing.T) {
 
 func TestTargetsOpenLocalGitRepo(t *testing.T) {
 	dir := initGitRepo(t, false)
-	mat, err := targets.Open(context.Background(), dir, nil)
+	mat, err := targets.Open(t.Context(), dir, nil)
 	if err != nil {
 		t.Fatalf("open local git repo: %v", err)
 	}
@@ -45,7 +44,7 @@ func TestTargetsOpenLocalGitRepo(t *testing.T) {
 func TestTargetsOpenRemoteGitFileURL(t *testing.T) {
 	origin := initGitRepo(t, false)
 	remote := fmt.Sprintf("file://%s", origin)
-	mat, err := targets.Open(context.Background(), remote, map[string]string{"ref": "HEAD"})
+	mat, err := targets.Open(t.Context(), remote, map[string]string{"ref": "HEAD"})
 	if err != nil {
 		t.Fatalf("open remote git repo: %v", err)
 	}

--- a/internal/ui/progress_test.go
+++ b/internal/ui/progress_test.go
@@ -196,7 +196,7 @@ func TestMultiProgress_DuplicateTaskID(t *testing.T) {
 
 func TestProgressFunc(t *testing.T) {
 	var buf bytes.Buffer
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Test successful function
 	result, err := ProgressFunc(ctx, &buf, "Computing", func() (int, error) {
@@ -214,7 +214,7 @@ func TestProgressFunc(t *testing.T) {
 
 func TestProgressFunc_Error(t *testing.T) {
 	var buf bytes.Buffer
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Test failing function
 	_, err := ProgressFunc(ctx, &buf, "Failing", func() (int, error) {

--- a/internal/ui/repl/readline_test.go
+++ b/internal/ui/repl/readline_test.go
@@ -2,7 +2,6 @@ package repl
 
 import (
 	"bytes"
-	"context"
 	"strings"
 	"testing"
 )
@@ -20,7 +19,7 @@ func TestReadLine_NonTTY(t *testing.T) {
 	}
 
 	// Read first line
-	line, err := rl.Read(context.Background(), "> ")
+	line, err := rl.Read(t.Context(), "> ")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -29,7 +28,7 @@ func TestReadLine_NonTTY(t *testing.T) {
 	}
 
 	// Read second line
-	line, err = rl.Read(context.Background(), "> ")
+	line, err = rl.Read(t.Context(), "> ")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -38,7 +37,7 @@ func TestReadLine_NonTTY(t *testing.T) {
 	}
 
 	// Read third line
-	line, err = rl.Read(context.Background(), "> ")
+	line, err = rl.Read(t.Context(), "> ")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/vulnerability/intel/epss/epss_test.go
+++ b/internal/vulnerability/intel/epss/epss_test.go
@@ -1,7 +1,6 @@
 package epss
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -97,7 +96,7 @@ func TestClient_Lookup(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(&Config{BaseURL: server.URL, HTTPClient: testHTTPClient()})
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("found CVE", func(t *testing.T) {
 		score, err := client.Lookup(ctx, "CVE-2021-44228")
@@ -162,7 +161,7 @@ func TestClient_LookupBatch(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(&Config{BaseURL: server.URL, HTTPClient: testHTTPClient()})
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("multiple CVEs", func(t *testing.T) {
 		scores, err := client.LookupBatch(ctx, []string{
@@ -221,7 +220,7 @@ func TestClient_ScoreOrZero(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(&Config{BaseURL: server.URL, HTTPClient: testHTTPClient()})
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("found CVE", func(t *testing.T) {
 		score := client.ScoreOrZero(ctx, "CVE-2021-44228")
@@ -259,7 +258,7 @@ func TestClient_ClearCache(t *testing.T) {
 		CacheTTL:   time.Hour,
 		HTTPClient: testHTTPClient(),
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// First lookup
 	client.Lookup(ctx, "CVE-2021-44228")
@@ -298,7 +297,7 @@ func TestClient_CacheSize(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(&Config{BaseURL: server.URL, HTTPClient: testHTTPClient()})
-	ctx := context.Background()
+	ctx := t.Context()
 
 	if client.CacheSize() != 0 {
 		t.Error("expected empty cache initially")
@@ -327,7 +326,7 @@ func TestClient_ErrorHandling(t *testing.T) {
 		defer server.Close()
 
 		client := NewClient(&Config{BaseURL: server.URL, HTTPClient: testHTTPClient()})
-		ctx := context.Background()
+		ctx := t.Context()
 
 		_, err := client.Lookup(ctx, "CVE-2021-44228")
 		if err == nil {
@@ -347,7 +346,7 @@ func TestClient_ErrorHandling(t *testing.T) {
 		defer server.Close()
 
 		client := NewClient(&Config{BaseURL: server.URL, HTTPClient: testHTTPClient()})
-		ctx := context.Background()
+		ctx := t.Context()
 
 		_, err := client.Lookup(ctx, "CVE-2021-44228")
 		if err == nil {
@@ -365,7 +364,7 @@ func TestClient_ErrorHandling(t *testing.T) {
 		defer server.Close()
 
 		client := NewClient(&Config{BaseURL: server.URL, HTTPClient: testHTTPClient()})
-		ctx := context.Background()
+		ctx := t.Context()
 
 		_, err := client.Lookup(ctx, "CVE-2021-44228")
 		if err == nil {
@@ -375,7 +374,7 @@ func TestClient_ErrorHandling(t *testing.T) {
 
 	t.Run("connection error", func(t *testing.T) {
 		client := NewClient(&Config{BaseURL: "http://localhost:0/invalid"})
-		ctx := context.Background()
+		ctx := t.Context()
 
 		_, err := client.Lookup(ctx, "CVE-2021-44228")
 		if err == nil {
@@ -480,7 +479,7 @@ func TestClient_BatchSize100(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(&Config{BaseURL: server.URL, HTTPClient: testHTTPClient()})
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create 150 CVEs to test batching
 	cves := make([]string, 150)

--- a/internal/vulnerability/intel/intel_test.go
+++ b/internal/vulnerability/intel/intel_test.go
@@ -1,7 +1,6 @@
 package intel
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -100,7 +99,7 @@ func TestEnricher_Enrich(t *testing.T) {
 		EPSSClient: epssClient,
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("valid CVE in KEV", func(t *testing.T) {
 		result := enricher.Enrich(ctx, "CVE-2021-44228")
@@ -213,7 +212,7 @@ func TestEnricher_EnrichBatch(t *testing.T) {
 		EPSSClient: epssClient,
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("multiple CVEs", func(t *testing.T) {
 		results := enricher.EnrichBatch(ctx, []string{
@@ -313,7 +312,7 @@ func TestEnricher_CacheStats(t *testing.T) {
 		EPSSClient: epssClient,
 	})
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Force load by doing a lookup
 	enricher.Enrich(ctx, "CVE-2021-44228")

--- a/internal/vulnerability/intel/kev/kev_test.go
+++ b/internal/vulnerability/intel/kev/kev_test.go
@@ -1,7 +1,6 @@
 package kev
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -98,7 +97,7 @@ func TestClient_Lookup(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(&Config{CatalogURL: server.URL, HTTPClient: testHTTPClient()})
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("found CVE", func(t *testing.T) {
 		entry, found := client.Lookup(ctx, "CVE-2021-44228")
@@ -151,7 +150,7 @@ func TestClient_InKEV(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(&Config{CatalogURL: server.URL, HTTPClient: testHTTPClient()})
-	ctx := context.Background()
+	ctx := t.Context()
 
 	if !client.InKEV(ctx, "CVE-2021-44228") {
 		t.Error("expected CVE-2021-44228 to be in KEV")
@@ -181,7 +180,7 @@ func TestClient_LookupBatch(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(&Config{CatalogURL: server.URL, HTTPClient: testHTTPClient()})
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("multiple CVEs", func(t *testing.T) {
 		results := client.LookupBatch(ctx, []string{
@@ -233,7 +232,7 @@ func TestClient_Count(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(&Config{CatalogURL: server.URL, HTTPClient: testHTTPClient()})
-	ctx := context.Background()
+	ctx := t.Context()
 
 	count := client.Count(ctx)
 	if count != 3 {
@@ -257,7 +256,7 @@ func TestClient_Version(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(&Config{CatalogURL: server.URL, HTTPClient: testHTTPClient()})
-	ctx := context.Background()
+	ctx := t.Context()
 
 	version := client.Version(ctx)
 	if version != "2024.01.15" {
@@ -285,7 +284,7 @@ func TestClient_Refresh(t *testing.T) {
 		CacheTTL:   1 * time.Nanosecond, // Tiny TTL so we always refresh
 		HTTPClient: testHTTPClient(),
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Initial load
 	client.Lookup(ctx, "CVE-2021-44228")
@@ -321,7 +320,7 @@ func TestClient_CacheTTL(t *testing.T) {
 		CacheTTL:   time.Hour, // Long TTL
 		HTTPClient: testHTTPClient(),
 	})
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Initial load
 	client.Lookup(ctx, "CVE-2021-44228")
@@ -352,7 +351,7 @@ func TestClient_ErrorHandling(t *testing.T) {
 		defer server.Close()
 
 		client := NewClient(&Config{CatalogURL: server.URL, HTTPClient: testHTTPClient()})
-		ctx := context.Background()
+		ctx := t.Context()
 
 		_, found := client.Lookup(ctx, "CVE-2021-44228")
 		if found {
@@ -367,7 +366,7 @@ func TestClient_ErrorHandling(t *testing.T) {
 		defer server.Close()
 
 		client := NewClient(&Config{CatalogURL: server.URL, HTTPClient: testHTTPClient()})
-		ctx := context.Background()
+		ctx := t.Context()
 
 		_, found := client.Lookup(ctx, "CVE-2021-44228")
 		if found {
@@ -377,7 +376,7 @@ func TestClient_ErrorHandling(t *testing.T) {
 
 	t.Run("connection error", func(t *testing.T) {
 		client := NewClient(&Config{CatalogURL: "http://localhost:0/invalid", HTTPClient: testHTTPClient()})
-		ctx := context.Background()
+		ctx := t.Context()
 
 		_, found := client.Lookup(ctx, "CVE-2021-44228")
 		if found {
@@ -478,7 +477,7 @@ func TestClient_SkipsEmptyCVEID(t *testing.T) {
 	defer server.Close()
 
 	client := NewClient(&Config{CatalogURL: server.URL, HTTPClient: testHTTPClient()})
-	ctx := context.Background()
+	ctx := t.Context()
 
 	count := client.Count(ctx)
 	if count != 1 {

--- a/internal/vulnerability/ssvc/ssvc_test.go
+++ b/internal/vulnerability/ssvc/ssvc_test.go
@@ -1,7 +1,6 @@
 package ssvc
 
 import (
-	"context"
 	"testing"
 )
 
@@ -54,7 +53,7 @@ func TestDecisionTree_Decide_ActiveExploitation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := tree.Decide(context.Background(), tt.input)
+			result := tree.Decide(t.Context(), tt.input)
 			if result.Decision != tt.expected {
 				t.Errorf("Decide() = %v, want %v (reasoning: %s)",
 					result.Decision, tt.expected, result.Reasoning)
@@ -108,7 +107,7 @@ func TestDecisionTree_Decide_PoC(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := tree.Decide(context.Background(), tt.input)
+			result := tree.Decide(t.Context(), tt.input)
 			if result.Decision != tt.expected {
 				t.Errorf("Decide() = %v, want %v (reasoning: %s)",
 					result.Decision, tt.expected, result.Reasoning)
@@ -151,7 +150,7 @@ func TestDecisionTree_Decide_NoExploitation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := tree.Decide(context.Background(), tt.input)
+			result := tree.Decide(t.Context(), tt.input)
 			if result.Decision != tt.expected {
 				t.Errorf("Decide() = %v, want %v (reasoning: %s)",
 					result.Decision, tt.expected, result.Reasoning)
@@ -201,7 +200,7 @@ func TestDecisionTree_DefaultValues(t *testing.T) {
 		Exploitation:    ExploitationNone,
 	}
 
-	result := tree.Decide(context.Background(), input)
+	result := tree.Decide(t.Context(), input)
 
 	// Should have applied defaults
 	if result.Input.MissionPrevalence != MissionPrevalenceSupport {

--- a/sdk/deputy_test.go
+++ b/sdk/deputy_test.go
@@ -1,12 +1,11 @@
 package sdk
 
 import (
-	"context"
 	"testing"
 )
 
 func TestNewClient(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	client, err := NewClient(ctx)
 	if err != nil {
 		t.Fatalf("NewClient failed: %v", err)
@@ -20,7 +19,7 @@ func TestNewClient(t *testing.T) {
 }
 
 func TestNewClientWithOptions(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("force in-process mode", func(t *testing.T) {
 		client, err := NewClientWithOptions(ctx, Options{


### PR DESCRIPTION
Replace context.Background() with t.Context() at 820 call sites across 112
test files, so contexts cancel at test end and leaked goroutines surface
instead of hiding. Replacement is scope-aware: subtest closures use their
innermost t, testing.TB helpers use tb.Context(), and twelve sites stay on
context.Background() deliberately: contexts inside t.Cleanup closures (the
test context is already canceled when cleanup runs) and Example functions
(no testing.T in scope).

Closes #55.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>