### PR TITLE
Resolve submodule licenses at their subpath-prefixed tags

### DIFF
--- a/internal/license/license.go
+++ b/internal/license/license.go
@@ -448,6 +448,11 @@ func RemoteModuleLicenseScan(ctx context.Context, modulePath, version string) []
 		var ids []string
 		if strings.HasPrefix(modulePath, "github.com/") {
 			if parts := strings.Split(modulePath, "/"); len(parts) >= 3 {
+				// A module below the repo root (github.com/owner/repo/sub)
+				// follows Go's submodule conventions: tags carry the subpath
+				// prefix and the module's license is the closest one up its
+				// directory tree.
+				subpath := strings.Join(parts[3:], "/")
 				if version == "" {
 					// The GitHub License API reports the repository default branch.
 					// It is only ref-accurate for unversioned/default-branch lookups.
@@ -456,13 +461,13 @@ func RemoteModuleLicenseScan(ctx context.Context, modulePath, version string) []
 					}
 				}
 				if len(ids) == 0 && version != "" {
-					if rawIDs, err := fetchLicensesFromGitHubRaw(ctx, parts[1], parts[2], version); err == nil && len(rawIDs) > 0 {
+					if rawIDs, err := fetchLicensesFromGitHubRaw(ctx, parts[1], parts[2], subpath, version); err == nil && len(rawIDs) > 0 {
 						ids = rawIDs
 					}
 				}
 				if len(ids) == 0 {
 					repoURL := fmt.Sprintf("https://github.com/%s/%s.git", parts[1], parts[2])
-					ids = scanGitHubRepoLicensesByClone(ctx, repoURL, version)
+					ids = scanGitHubRepoLicensesByClone(ctx, repoURL, subpath, version)
 				}
 			}
 		}
@@ -486,7 +491,7 @@ func RemoteModuleLicenseScan(ctx context.Context, modulePath, version string) []
 // scanGitHubRepoLicensesByClone clones a GitHub repository just far enough to
 // run local license detection. Versioned lookups only try tag refs so an
 // explicit tag miss cannot silently become a default-branch license result.
-func scanGitHubRepoLicensesByClone(ctx context.Context, repoURL, version string) []string {
+func scanGitHubRepoLicensesByClone(ctx context.Context, repoURL, subpath, version string) []string {
 	if repoURL == "" || ctx.Err() != nil {
 		return nil
 	}
@@ -501,7 +506,7 @@ func scanGitHubRepoLicensesByClone(ctx context.Context, repoURL, version string)
 		}
 		return nil
 	}
-	for _, ref := range gitTagReferenceNames(version) {
+	for _, ref := range gitTagReferenceNames(version, subpath) {
 		opts.ReferenceName = ref
 		if src, err := repository.CloneInMemory(ctx, opts); err == nil {
 			defer src.Close()
@@ -515,9 +520,9 @@ func scanGitHubRepoLicensesByClone(ctx context.Context, repoURL, version string)
 // fallback. Commit SHAs are excluded because go-git's shallow clone path needs
 // a branch or tag reference; SHA-addressed license lookups are handled by the
 // raw-content path before clone fallback.
-func gitTagReferenceNames(version string) []plumbing.ReferenceName {
+func gitTagReferenceNames(version, subpath string) []plumbing.ReferenceName {
 	var refs []plumbing.ReferenceName
-	for _, ref := range githubLicenseRefCandidates(version) {
+	for _, ref := range githubLicenseRefCandidates(version, subpath) {
 		if isGitCommitSHARef(ref) {
 			continue
 		}
@@ -1240,24 +1245,36 @@ func fetchLicenseFromGitHubAPI(ctx context.Context, owner, repo string) []string
 //
 // License files are fetched in parallel with bounded concurrency to improve
 // performance while respecting GitHub rate limits.
-func fetchLicensesFromGitHubRaw(ctx context.Context, owner, repo, version string) ([]string, error) {
-	refs := githubLicenseRefCandidates(version)
+func fetchLicensesFromGitHubRaw(ctx context.Context, owner, repo, subpath, version string) ([]string, error) {
+	refs := githubLicenseRefCandidates(version, subpath)
 	if len(refs) == 0 {
 		return nil, fmt.Errorf("unable to derive git ref")
 	}
+	// A submodule's license is the closest one up its directory tree (the
+	// pkg.go.dev rule), so a module below the repo root checks its own
+	// directory at each ref before the repository root.
+	var dirs []string
+	if subpath = strings.Trim(strings.TrimSpace(subpath), "/"); subpath != "" {
+		dirs = append(dirs, subpath)
+	}
+	dirs = append(dirs, "")
 	for _, ref := range refs {
-		ids, err := fetchLicensesFromGitHubRawRef(ctx, owner, repo, ref)
-		if err == nil && len(ids) > 0 {
-			return ids, nil
+		for _, dir := range dirs {
+			ids, err := fetchLicensesFromGitHubRawRef(ctx, owner, repo, ref, dir)
+			if err == nil && len(ids) > 0 {
+				return ids, nil
+			}
 		}
 	}
 	return nil, fmt.Errorf("no license files via raw")
 }
 
 // fetchLicensesFromGitHubRawRef scans common license filenames at one concrete
-// GitHub raw-content ref. It treats missing files and transient fetch failures
-// as non-fatal so callers can try the next candidate ref or fallback strategy.
-func fetchLicensesFromGitHubRawRef(ctx context.Context, owner, repo, ref string) ([]string, error) {
+// GitHub raw-content ref, under dir when non-empty (a submodule's own
+// directory) or the repository root. It treats missing files and transient
+// fetch failures as non-fatal so callers can try the next candidate ref or
+// fallback strategy.
+func fetchLicensesFromGitHubRawRef(ctx context.Context, owner, repo, ref, dir string) ([]string, error) {
 	if owner == "" || repo == "" || ref == "" || ctx.Err() != nil {
 		return nil, fmt.Errorf("invalid github raw license request")
 	}
@@ -1277,7 +1294,11 @@ func fetchLicensesFromGitHubRawRef(ctx context.Context, owner, repo, ref string)
 
 	for _, name := range defaultLicenseFilenames {
 		g.Go(func() error {
-			url := fmt.Sprintf("%s/%s/%s/%s/%s", strings.TrimRight(githubRawBase, "/"), owner, repo, ref, name)
+			filePath := name
+			if dir != "" {
+				filePath = dir + "/" + name
+			}
+			url := fmt.Sprintf("%s/%s/%s/%s/%s", strings.TrimRight(githubRawBase, "/"), owner, repo, ref, filePath)
 			req, err := nethttp.NewRequestWithContext(ctx, nethttp.MethodGet, url, nil)
 			if err != nil {
 				return nil // non-fatal, continue with other files
@@ -1345,7 +1366,7 @@ func fetchLicensesFromGitHubRawRef(ctx context.Context, owner, repo, ref string)
 // Candidates are ordered from most precise to fallback. Commit SHAs and Go
 // pseudo-version commits are used verbatim; non-v-prefixed tag-like versions
 // try the common GitHub release tag form first, then the literal ref.
-func githubLicenseRefCandidates(version string) []string {
+func githubLicenseRefCandidates(version, subpath string) []string {
 	if version == "" {
 		return nil
 	}
@@ -1359,10 +1380,25 @@ func githubLicenseRefCandidates(version string) []string {
 	if isGitCommitSHARef(v) {
 		return []string{strings.ToLower(v)}
 	}
+	var plain []string
 	if !strings.HasPrefix(v, "v") {
-		return []string{"v" + v, v}
+		plain = []string{"v" + v, v}
+	} else {
+		plain = []string{v}
 	}
-	return []string{v}
+	// Go submodules tag releases as "<subpath>/<version>" (module
+	// github.com/owner/repo/sub tags sub/v1.2.3), so a module below the repo
+	// root tries its subpath-prefixed tags first. Commit SHAs and
+	// pseudo-versions above are path-independent and skip this.
+	subpath = strings.Trim(strings.TrimSpace(subpath), "/")
+	if subpath == "" {
+		return plain
+	}
+	refs := make([]string, 0, len(plain)*2)
+	for _, p := range plain {
+		refs = append(refs, subpath+"/"+p)
+	}
+	return append(refs, plain...)
 }
 
 // isGitCommitSHARef reports whether version is a short or full hexadecimal Git

--- a/internal/license/license.go
+++ b/internal/license/license.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	nethttp "net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -447,7 +448,13 @@ func RemoteModuleLicenseScan(ctx context.Context, modulePath, version string) []
 		}
 		var ids []string
 		if strings.HasPrefix(modulePath, "github.com/") {
-			if parts := strings.Split(modulePath, "/"); len(parts) >= 3 {
+			// Strip the semantic-import major suffix before deriving the
+			// repository subdirectory: for github.com/owner/repo/sub/v2 the
+			// release tag is sub/v2.3.0, not sub/v2/v2.3.0. Leaving the
+			// suffix in would probe a tag that cannot exist and then fall
+			// back to the unrelated root tag of a different module.
+			pathNoMajor, _, _ := module.SplitPathVersion(modulePath)
+			if parts := strings.Split(pathNoMajor, "/"); len(parts) >= 3 {
 				// A module below the repo root (github.com/owner/repo/sub)
 				// follows Go's submodule conventions: tags carry the subpath
 				// prefix and the module's license is the closest one up its
@@ -488,6 +495,52 @@ func RemoteModuleLicenseScan(ctx context.Context, modulePath, version string) []
 	return nil
 }
 
+// moduleLicenseScan resolves the license for a module rooted at subpath the
+// way Go does: the closest license file walking up from the module directory
+// to the repository root. Sibling directories are never consulted, so a
+// submodule in a monorepo cannot inherit an unrelated module's license.
+//
+// An empty subpath means the repository root module.
+func moduleLicenseScan(ws workspace.FS, subpath string) []string {
+	if ws == nil {
+		return nil
+	}
+	dir := path.Clean(strings.TrimSpace(subpath))
+	if dir == "" || dir == "/" {
+		dir = "."
+	}
+	for {
+		var ids []string
+		for _, name := range defaultLicenseFilenames {
+			rel := name
+			if dir != "." {
+				rel = path.Join(dir, name)
+			}
+			data, err := ws.ReadFile(rel)
+			if err != nil {
+				continue
+			}
+			for _, id := range DetectLicenseIDs(data) {
+				if id != "" && !slices.Contains(ids, id) {
+					ids = append(ids, id)
+				}
+			}
+		}
+		if len(ids) > 0 {
+			slices.Sort(ids)
+			return ids
+		}
+		if dir == "." {
+			return nil
+		}
+		parent := path.Dir(dir)
+		if parent == dir {
+			return nil
+		}
+		dir = parent
+	}
+}
+
 // scanGitHubRepoLicensesByClone clones a GitHub repository just far enough to
 // run local license detection. Versioned lookups only try tag refs so an
 // explicit tag miss cannot silently become a default-branch license result.
@@ -502,7 +555,7 @@ func scanGitHubRepoLicensesByClone(ctx context.Context, repoURL, subpath, versio
 	if version == "" {
 		if src, err := repository.CloneInMemory(ctx, opts); err == nil {
 			defer src.Close()
-			return LocalRepoLicenseScan(src.Workspace())
+			return moduleLicenseScan(src.Workspace(), subpath)
 		}
 		return nil
 	}
@@ -510,7 +563,7 @@ func scanGitHubRepoLicensesByClone(ctx context.Context, repoURL, subpath, versio
 		opts.ReferenceName = ref
 		if src, err := repository.CloneInMemory(ctx, opts); err == nil {
 			defer src.Close()
-			return LocalRepoLicenseScan(src.Workspace())
+			return moduleLicenseScan(src.Workspace(), subpath)
 		}
 	}
 	return nil

--- a/internal/license/licenses_fallback_test.go
+++ b/internal/license/licenses_fallback_test.go
@@ -16,6 +16,8 @@ import (
 	"testing"
 
 	pb "deps.dev/api/v3"
+	"github.com/temporalio/deputy/internal/repository/workspace"
+	"golang.org/x/mod/module"
 )
 
 type countingDepsClientEcosystem struct {
@@ -908,5 +910,117 @@ func swapGitHubHTTPClient(server *httptest.Server) func() {
 		setGitHubHTTPClientForTest(origClient)
 		githubAPIBase = origBase
 		githubRawBase = origRawBase
+	}
+}
+
+// TestSubmoduleTagPrefixExcludesMajorSuffix pins Go's tag convention for
+// versioned submodules: the semantic-import suffix is part of the module
+// path but not of the tag prefix, so github.com/owner/repo/sub/v2 releases
+// as sub/v2.3.0. Deriving the subpath from the raw module path would probe
+// sub/v2/v2.3.0, which cannot exist, and then fall back to the root tag of a
+// different module.
+func TestSubmoduleTagPrefixExcludesMajorSuffix(t *testing.T) {
+	tests := []struct {
+		modulePath  string
+		wantSubpath string
+	}{
+		{"github.com/owner/repo/sub/v2", "sub"},
+		{"github.com/owner/repo/sub", "sub"},
+		{"github.com/owner/repo/v2", ""},
+		{"github.com/owner/repo", ""},
+		{"github.com/owner/repo/a/b/v3", "a/b"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.modulePath, func(t *testing.T) {
+			pathNoMajor, _, _ := module.SplitPathVersion(tt.modulePath)
+			parts := strings.Split(pathNoMajor, "/")
+			var got string
+			if len(parts) >= 3 {
+				got = strings.Join(parts[3:], "/")
+			}
+			if got != tt.wantSubpath {
+				t.Errorf("subpath = %q, want %q", got, tt.wantSubpath)
+			}
+		})
+	}
+}
+
+// License bodies long enough for the detector to classify confidently.
+const mitLicenseText = `MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.`
+
+const apacheLicenseText = `Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the
+copyright owner that is granting the License.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.`
+
+// TestModuleLicenseScan_DoesNotInheritSiblingLicenses pins the clone-fallback
+// scope. Go resolves a module's license as the closest one up its directory
+// tree, so a submodule with its own license uses that, one without inherits
+// the repository root, and neither may ever pick up a sibling module's.
+func TestModuleLicenseScan_DoesNotInheritSiblingLicenses(t *testing.T) {
+	ws := workspace.NewMemory()
+	t.Cleanup(func() { _ = ws.Close() })
+
+	write := func(p, body string) {
+		t.Helper()
+		if err := ws.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+	write("LICENSE", mitLicenseText)
+	write("sibling/LICENSE", apacheLicenseText)
+	write("withown/LICENSE", apacheLicenseText)
+	write("noown/keep.txt", "x")
+
+	tests := []struct {
+		name    string
+		subpath string
+		want    string
+	}{
+		{name: "module with its own license uses it", subpath: "withown", want: "Apache-2.0"},
+		{name: "module without one inherits the root", subpath: "noown", want: "MIT"},
+		{name: "root module uses the root license", subpath: "", want: "MIT"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := moduleLicenseScan(ws, tt.subpath)
+			if !slices.Contains(got, tt.want) {
+				t.Fatalf("licenses = %v, want to contain %s", got, tt.want)
+			}
+			// A sibling module's license must never leak in.
+			if tt.want != "Apache-2.0" && slices.Contains(got, "Apache-2.0") {
+				t.Fatalf("licenses = %v, leaked a sibling module's license", got)
+			}
+		})
 	}
 }

--- a/internal/license/licenses_fallback_test.go
+++ b/internal/license/licenses_fallback_test.go
@@ -454,6 +454,51 @@ func TestRemoteModuleLicenseScan_GitHubVersionedUsesRequestedRef(t *testing.T) {
 	}
 }
 
+// TestRemoteModuleLicenseScan_GitHubSubmoduleUsesSubpathTag pins submodule
+// resolution: a module below the repo root resolves its subpath-prefixed tag
+// (sub/v1.2.3) and reads the license closest to the module directory, without
+// consulting the default-branch License API.
+func TestRemoteModuleLicenseScan_GitHubSubmoduleUsesSubpathTag(t *testing.T) {
+	resetLicenseTestState(t)
+
+	var mu sync.Mutex
+	var sawAPI bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/repos/owner/repo/license"):
+			mu.Lock()
+			sawAPI = true
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"license": map[string]any{"key": "apache-2.0", "spdx_id": "Apache-2.0", "name": "Apache License 2.0"},
+			})
+		case r.URL.Path == "/owner/repo/sub/v1.2.3/sub/LICENSE":
+			// The submodule tag with the submodule's own license file.
+			_, _ = w.Write([]byte(testMITLicenseText))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	restoreClient := swapGitHubHTTPClient(server)
+	defer restoreClient()
+	restoreHTTP := WithLicenseHTTPClient(server.Client())
+	defer restoreHTTP()
+	restoreBases := WithLicenseEndpoints(server.URL, cratesBase, packagistBase, pubBase, cocoapodsBase, hexpmBase)
+	defer restoreBases()
+
+	got := RemoteModuleLicenseScan(t.Context(), "github.com/owner/repo/sub", "v1.2.3")
+	if want := []string{"MIT"}; !slices.Equal(got, want) {
+		t.Fatalf("expected submodule-tag license %v, got %v", want, got)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if sawAPI {
+		t.Fatal("versioned submodule lookup used default-branch License API")
+	}
+}
+
 func TestRemoteModuleLicenseScan_GitHubVersionedDoesNotFallBackToDefaultBranchLicense(t *testing.T) {
 	resetLicenseTestState(t)
 
@@ -517,7 +562,7 @@ func TestFetchLicensesFromGitHubRawUsesSHAWithoutVPrefix(t *testing.T) {
 	restoreClient := swapGitHubHTTPClient(server)
 	defer restoreClient()
 
-	got, err := fetchLicensesFromGitHubRaw(t.Context(), "owner", "repo", sha)
+	got, err := fetchLicensesFromGitHubRaw(t.Context(), "owner", "repo", "", sha)
 	if err != nil {
 		t.Fatalf("fetchLicensesFromGitHubRaw returned error: %v", err)
 	}
@@ -537,6 +582,7 @@ func TestGitHubLicenseRefCandidates(t *testing.T) {
 	tests := []struct {
 		name    string
 		version string
+		subpath string
 		want    []string
 	}{
 		{
@@ -564,11 +610,35 @@ func TestGitHubLicenseRefCandidates(t *testing.T) {
 			version: "v1.2.3+incompatible",
 			want:    []string{"v1.2.3"},
 		},
+		{
+			name:    "submodule_tags_first",
+			version: "v1.2.3",
+			subpath: "sub/dir",
+			want:    []string{"sub/dir/v1.2.3", "v1.2.3"},
+		},
+		{
+			name:    "submodule_without_v",
+			version: "1.2.3",
+			subpath: "sub",
+			want:    []string{"sub/v1.2.3", "sub/1.2.3", "v1.2.3", "1.2.3"},
+		},
+		{
+			name:    "submodule_sha_is_path_independent",
+			version: "fad22eb3fa582b7357fc0ea48af6645851b884fd",
+			subpath: "sub",
+			want:    []string{"fad22eb3fa582b7357fc0ea48af6645851b884fd"},
+		},
+		{
+			name:    "submodule_pseudo_version_is_path_independent",
+			version: "v0.0.0-20200622213623-75b288015ac9",
+			subpath: "sub",
+			want:    []string{"75b288015ac9"},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := githubLicenseRefCandidates(tc.version); !slices.Equal(got, tc.want) {
-				t.Fatalf("githubLicenseRefCandidates(%q) = %v, want %v", tc.version, got, tc.want)
+			if got := githubLicenseRefCandidates(tc.version, tc.subpath); !slices.Equal(got, tc.want) {
+				t.Fatalf("githubLicenseRefCandidates(%q, %q) = %v, want %v", tc.version, tc.subpath, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
Versioned license lookups derived tag candidates only from the version
(v1.2.3, 1.2.3), so a Go submodule tagged sub/v1.2.3 missed both the
raw-content and clone fallbacks and resolved no license, tripping
deny-unlicensed policies for correctly tagged modules. Modules below the
repo root now try their subpath-prefixed tags first and read the license
closest to the module directory (the pkg.go.dev rule) before the repository
root. Commit SHAs and pseudo-versions stay path-independent.

The other half of #57 (a provenance-marked default-branch fallback) needs a
per-result license provenance design across the SBOM surface and stays
open.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>