### PR TITLE
Make deputy.diff.v1.PackageChange the domain type for dependency changes

### DIFF
--- a/internal/cli/cmd/diff.go
+++ b/internal/cli/cmd/diff.go
@@ -333,11 +333,11 @@ PERFORMANCE TIPS:
 
 // DiffPolicyReport captures the full context of a diff operation for policy evaluation.
 type DiffPolicyReport struct {
-	Repo            string                 `json:"repo"`
-	BaseRef         string                 `json:"baseRef"`
-	TargetRef       string                 `json:"targetRef"`
-	Changes         []compare.Change       `json:"changes"`
-	Vulnerabilities []report.Vulnerability `json:"vulnerabilities"`
+	Repo            string                  `json:"repo"`
+	BaseRef         string                  `json:"baseRef"`
+	TargetRef       string                  `json:"targetRef"`
+	Changes         []*diffv1.PackageChange `json:"changes"`
+	Vulnerabilities []report.Vulnerability  `json:"vulnerabilities"`
 }
 
 // runDiffAnalysis orchestrates dependency inventory collection for the base and
@@ -815,7 +815,7 @@ func licenseScanConcurrency(total int) int {
 // renderer: license data comes from Change.Licenses, populated by
 // enrichChangeLicenses before policy evaluation and output conversion, so
 // every surface shows the same licenses.
-func displayDetailedDependencyChanges(changes []compare.Change, outW io.Writer) {
+func displayDetailedDependencyChanges(changes []*diffv1.PackageChange, outW io.Writer) {
 	if len(changes) == 0 {
 		return
 	}
@@ -826,12 +826,12 @@ func displayDetailedDependencyChanges(changes []compare.Change, outW io.Writer) 
 	var addedN, removedN, updatedN, upgradedN, downgradedN int
 
 	for _, c := range changes {
-		licenses := c.Licenses
+		licenses := c.GetPackage().GetLicenses()
 
 		// Format the combined license and direct/indirect annotation
 		var licAndDepStr string
 		var directnessStr string
-		if c.IsDirect {
+		if c.GetIsDirect() {
 			directnessStr = ui.StyleDirect.Render("[direct]")
 		} else {
 			directnessStr = ui.StyleIndirect.Render("[indirect]")
@@ -845,45 +845,45 @@ func displayDetailedDependencyChanges(changes []compare.Change, outW io.Writer) 
 			licAndDepStr = directnessStr
 		}
 
-		switch c.ChangeType {
-		case compare.Added:
-			fmt.Fprintf(outW, "  %s %s @ %s %s\n", ui.StyleAdded.Render("+"), ui.StyleAdded.Render(c.Name), ui.StyleVersion.Render(c.TargetVersion), licAndDepStr)
+		switch c.GetChangeKind() {
+		case diffv1.ChangeKind_CHANGE_KIND_ADDED:
+			fmt.Fprintf(outW, "  %s %s @ %s %s\n", ui.StyleAdded.Render("+"), ui.StyleAdded.Render(c.GetPackage().GetName()), ui.StyleVersion.Render(c.GetTargetVersion()), licAndDepStr)
 			addedN++
-		case compare.Removed:
+		case diffv1.ChangeKind_CHANGE_KIND_REMOVED:
 			// For removed dependencies, we don't have target version license info, so just show directness
 			var removedDirectnessStr string
-			if c.IsDirect {
+			if c.GetIsDirect() {
 				removedDirectnessStr = ui.StyleDirect.Render("[direct]")
 			} else {
 				removedDirectnessStr = ui.StyleIndirect.Render("[indirect]")
 			}
-			fmt.Fprintf(outW, "  %s %s @ %s %s\n", ui.StyleRemoved.Render("-"), ui.StyleRemoved.Render(c.Name), ui.StyleVersion.Render(c.BaseVersion), removedDirectnessStr)
+			fmt.Fprintf(outW, "  %s %s @ %s %s\n", ui.StyleRemoved.Render("-"), ui.StyleRemoved.Render(c.GetPackage().GetName()), ui.StyleVersion.Render(c.GetBaseVersion()), removedDirectnessStr)
 			removedN++
-		case compare.Upgraded:
+		case diffv1.ChangeKind_CHANGE_KIND_UPGRADED:
 			updatedN++
 			upgradedN++
 			oldNamePart := ""
-			if c.OldName != "" && c.OldName != c.Name {
-				oldNamePart = ui.StyleDim.Render(c.OldName) + " " + ui.StyleUpdateArrow.Render("→ ")
+			if c.GetOldName() != "" && c.GetOldName() != c.GetPackage().GetName() {
+				oldNamePart = ui.StyleDim.Render(c.GetOldName()) + " " + ui.StyleUpdateArrow.Render("→ ")
 			}
-			fmt.Fprintf(outW, "  %s %s%s @ %s %s %s %s\n", ui.StyleUpgraded.Render("↑"), oldNamePart, ui.StyleBold.Render(c.Name), ui.StyleVersion.Render(c.BaseVersion), ui.StyleUpdateArrow.Render("→"), ui.StyleVersionNew.Render(c.TargetVersion), licAndDepStr)
-		case compare.Downgraded:
+			fmt.Fprintf(outW, "  %s %s%s @ %s %s %s %s\n", ui.StyleUpgraded.Render("↑"), oldNamePart, ui.StyleBold.Render(c.GetPackage().GetName()), ui.StyleVersion.Render(c.GetBaseVersion()), ui.StyleUpdateArrow.Render("→"), ui.StyleVersionNew.Render(c.GetTargetVersion()), licAndDepStr)
+		case diffv1.ChangeKind_CHANGE_KIND_DOWNGRADED:
 			updatedN++
 			downgradedN++
 			oldNamePart := ""
-			if c.OldName != "" && c.OldName != c.Name {
-				oldNamePart = ui.StyleDim.Render(c.OldName) + " " + ui.StyleDowngradeArrow.Render("→ ")
+			if c.GetOldName() != "" && c.GetOldName() != c.GetPackage().GetName() {
+				oldNamePart = ui.StyleDim.Render(c.GetOldName()) + " " + ui.StyleDowngradeArrow.Render("→ ")
 			}
-			fmt.Fprintf(outW, "  %s %s%s @ %s %s %s %s\n", ui.StyleDowngraded.Render("↓"), oldNamePart, ui.StyleBold.Render(c.Name), ui.StyleVersion.Render(c.BaseVersion), ui.StyleDowngradeArrow.Render("→"), ui.StyleVersionNew.Render(c.TargetVersion), licAndDepStr)
-		case compare.Updated:
+			fmt.Fprintf(outW, "  %s %s%s @ %s %s %s %s\n", ui.StyleDowngraded.Render("↓"), oldNamePart, ui.StyleBold.Render(c.GetPackage().GetName()), ui.StyleVersion.Render(c.GetBaseVersion()), ui.StyleDowngradeArrow.Render("→"), ui.StyleVersionNew.Render(c.GetTargetVersion()), licAndDepStr)
+		case diffv1.ChangeKind_CHANGE_KIND_UPDATED:
 			updatedN++
 			arrowStyle := ui.StyleUpdateArrow
 			symbol := ui.StyleNeutral.Render("~")
 			oldNamePart := ""
-			if c.OldName != "" && c.OldName != c.Name {
-				oldNamePart = ui.StyleDim.Render(c.OldName) + " " + arrowStyle.Render("→ ")
+			if c.GetOldName() != "" && c.GetOldName() != c.GetPackage().GetName() {
+				oldNamePart = ui.StyleDim.Render(c.GetOldName()) + " " + arrowStyle.Render("→ ")
 			}
-			fmt.Fprintf(outW, "  %s %s%s @ %s %s %s %s\n", symbol, oldNamePart, ui.StyleBold.Render(c.Name), ui.StyleVersion.Render(c.BaseVersion), arrowStyle.Render("→"), ui.StyleVersionNew.Render(c.TargetVersion), licAndDepStr)
+			fmt.Fprintf(outW, "  %s %s%s @ %s %s %s %s\n", symbol, oldNamePart, ui.StyleBold.Render(c.GetPackage().GetName()), ui.StyleVersion.Render(c.GetBaseVersion()), arrowStyle.Render("→"), ui.StyleVersionNew.Render(c.GetTargetVersion()), licAndDepStr)
 		}
 	}
 
@@ -913,19 +913,19 @@ func displayDetailedDependencyChanges(changes []compare.Change, outW io.Writer) 
 // dependencies versus those in unchanged modules. Changes marked as Added,
 // Updated, Upgraded, or Downgraded are treated as "changed" for classification
 // purposes.
-func splitVulnsByChange(vulns []report.Vulnerability, changes []compare.Change) (changed, unchanged []report.Vulnerability) {
+func splitVulnsByChange(vulns []report.Vulnerability, changes []*diffv1.PackageChange) (changed, unchanged []report.Vulnerability) {
 	if len(vulns) == 0 {
 		return nil, nil
 	}
 	changedSet := map[string]bool{}
 	for _, c := range changes {
-		switch c.ChangeType {
-		case compare.Added, compare.Updated, compare.Upgraded, compare.Downgraded:
+		switch c.GetChangeKind() {
+		case diffv1.ChangeKind_CHANGE_KIND_ADDED, diffv1.ChangeKind_CHANGE_KIND_UPDATED, diffv1.ChangeKind_CHANGE_KIND_UPGRADED, diffv1.ChangeKind_CHANGE_KIND_DOWNGRADED:
 			// treat as changed
 		default:
 			continue
 		}
-		info := compare.ParseGoPackage(&extractor.Package{Name: c.Name})
+		info := compare.ParseGoPackage(&extractor.Package{Name: c.GetPackage().GetName()})
 		changedSet[info.CanonicalName] = true
 	}
 	for _, v := range vulns {
@@ -944,7 +944,7 @@ func splitVulnsByChange(vulns []report.Vulnerability, changes []compare.Change) 
 // (including aliases) that already affected the base version. A lookup failure
 // degrades to nil with a warning: the caller then treats every changed-package
 // advisory as newly introduced, failing toward reporting rather than hiding.
-func baseVersionAdvisories(ctx context.Context, changes []compare.Change, errW io.Writer) map[string]map[string]bool {
+func baseVersionAdvisories(ctx context.Context, changes []*diffv1.PackageChange, errW io.Writer) map[string]map[string]bool {
 	basePkgs := baseQueryPackages(changes)
 	if len(basePkgs) == 0 {
 		return nil
@@ -982,25 +982,25 @@ func baseVersionAdvisories(ctx context.Context, changes []compare.Change, errW i
 // known base version, queried under the base name when the package was
 // renamed. Added packages have no base to pre-date and removed packages have
 // no changed vulnerabilities to reclassify.
-func baseQueryPackages(changes []compare.Change) []*dependencyv1.Package {
+func baseQueryPackages(changes []*diffv1.PackageChange) []*dependencyv1.Package {
 	var basePkgs []*dependencyv1.Package
 	for _, c := range changes {
-		switch c.ChangeType {
-		case compare.Updated, compare.Upgraded, compare.Downgraded:
+		switch c.GetChangeKind() {
+		case diffv1.ChangeKind_CHANGE_KIND_UPDATED, diffv1.ChangeKind_CHANGE_KIND_UPGRADED, diffv1.ChangeKind_CHANGE_KIND_DOWNGRADED:
 		default:
 			continue
 		}
-		if c.BaseVersion == "" {
+		if c.GetBaseVersion() == "" {
 			continue
 		}
-		name := c.OldName
+		name := c.GetOldName()
 		if name == "" {
-			name = c.Name
+			name = c.GetPackage().GetName()
 		}
 		basePkgs = append(basePkgs, &dependencyv1.Package{
 			Name:      name,
-			Version:   c.BaseVersion,
-			Ecosystem: c.Ecosystem,
+			Version:   c.GetBaseVersion(),
+			Ecosystem: c.GetPackage().GetEcosystem(),
 		})
 	}
 	return basePkgs
@@ -1128,8 +1128,8 @@ func runDiffPolicies(ctx context.Context, policyPaths []string, diffReport DiffP
 		return nil, err
 	}
 
-	// Convert to proto types for CEL evaluation
-	protoChanges := internalproto.PackageChangesToProto(diffReport.Changes)
+	// Changes are already proto; findings convert for CEL evaluation.
+	protoChanges := diffReport.Changes
 	protoFindings := report.VulnerabilitiesToFindings(diffReport.Vulnerabilities)
 
 	var results []*policyv1.Action

--- a/internal/cli/cmd/diff_display_test.go
+++ b/internal/cli/cmd/diff_display_test.go
@@ -7,7 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/temporalio/deputy/internal/compare"
+	dependencyv1 "github.com/temporalio/deputy/gen/deputy/dependency/v1"
+	diffv1 "github.com/temporalio/deputy/gen/deputy/diff/v1"
 	"github.com/temporalio/deputy/internal/license"
 )
 
@@ -31,16 +32,10 @@ func TestEnrichChangeLicenses_ScanUsesBestEffortLicenses(t *testing.T) {
 	restoreBases := license.WithLicenseEndpoints(server.URL, server.URL, server.URL, server.URL, server.URL, server.URL)
 	defer restoreBases()
 
-	changes := []compare.Change{{
-		Name:          "serde",
-		TargetVersion: "1.0.0",
-		ChangeType:    compare.Added,
-		Ecosystem:     "rust",
-		IsDirect:      true,
-	}}
+	changes := []*diffv1.PackageChange{{Package: &dependencyv1.Package{Name: "serde", Version: "1.0.0", Ecosystem: "rust"}, ChangeKind: diffv1.ChangeKind_CHANGE_KIND_ADDED, TargetVersion: "1.0.0", IsDirect: true}}
 
 	enriched := enrichChangeLicenses(t.Context(), changes, "scan")
-	if len(enriched) != 1 || len(enriched[0].Licenses) == 0 || enriched[0].Licenses[0] != "MIT" {
+	if len(enriched) != 1 || len(enriched[0].GetPackage().GetLicenses()) == 0 || enriched[0].GetPackage().GetLicenses()[0] != "MIT" {
 		t.Fatalf("expected enrichment to attach MIT license, got: %+v", enriched)
 	}
 
@@ -73,11 +68,10 @@ func TestEnrichChangeLicenses_DoesNotInheritRepositoryLicense(t *testing.T) {
 	restoreBases := license.WithLicenseEndpoints(server.URL, server.URL, server.URL, server.URL, server.URL, server.URL)
 	defer restoreBases()
 
-	changes := []compare.Change{{
-		Name:          "example.com/unlicensed",
+	changes := []*diffv1.PackageChange{{
+		Package:       &dependencyv1.Package{Name: "example.com/unlicensed", Version: "1.0.0", Ecosystem: "go"},
+		ChangeKind:    diffv1.ChangeKind_CHANGE_KIND_ADDED,
 		TargetVersion: "1.0.0",
-		ChangeType:    compare.Added,
-		Ecosystem:     "go",
 	}}
 
 	for _, source := range []string{"scan", "both"} {
@@ -86,7 +80,7 @@ func TestEnrichChangeLicenses_DoesNotInheritRepositoryLicense(t *testing.T) {
 			if len(enriched) != 1 {
 				t.Fatalf("expected 1 change, got %d", len(enriched))
 			}
-			if got := enriched[0].Licenses; len(got) != 0 {
+			if got := enriched[0].GetPackage().GetLicenses(); len(got) != 0 {
 				t.Errorf("dependency inherited licenses it does not declare: %v", got)
 			}
 		})

--- a/internal/cli/cmd/diff_licenses.go
+++ b/internal/cli/cmd/diff_licenses.go
@@ -11,8 +11,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
+	diffv1 "github.com/temporalio/deputy/gen/deputy/diff/v1"
 	"github.com/temporalio/deputy/internal/cli/flags"
-	"github.com/temporalio/deputy/internal/compare"
 	"github.com/temporalio/deputy/internal/license"
 )
 
@@ -42,7 +42,7 @@ func licenseEcosystem(raw string) string {
 // output, and the rendered report all see the same license data. Lookup
 // failures degrade to an empty license list for that package, which policy
 // reads as "no license declared" rather than as a license.
-func enrichChangeLicenses(ctx context.Context, changes []compare.Change, licenseSource string) []compare.Change {
+func enrichChangeLicenses(ctx context.Context, changes []*diffv1.PackageChange, licenseSource string) []*diffv1.PackageChange {
 	if len(changes) == 0 {
 		return changes
 	}
@@ -53,10 +53,10 @@ func enrichChangeLicenses(ctx context.Context, changes []compare.Change, license
 	// Unique lookup targets: removed changes have no target version to license.
 	targets := make(map[licensePkgKey]struct{})
 	for _, c := range changes {
-		if c.ChangeType == compare.Removed || c.TargetVersion == "" {
+		if c.GetChangeKind() == diffv1.ChangeKind_CHANGE_KIND_REMOVED || c.GetTargetVersion() == "" {
 			continue
 		}
-		targets[licensePkgKey{ecosystem: licenseEcosystem(c.Ecosystem), name: c.Name, version: c.TargetVersion}] = struct{}{}
+		targets[licensePkgKey{ecosystem: licenseEcosystem(c.GetPackage().GetEcosystem()), name: c.GetPackage().GetName(), version: c.GetTargetVersion()}] = struct{}{}
 	}
 	if len(targets) == 0 {
 		return changes
@@ -102,14 +102,11 @@ func enrichChangeLicenses(ctx context.Context, changes []compare.Change, license
 		_ = g.Wait()
 	}
 
-	out := make([]compare.Change, len(changes))
-	copy(out, changes)
-	for i := range out {
-		c := &out[i]
-		if c.ChangeType == compare.Removed || c.TargetVersion == "" {
+	for _, c := range changes {
+		if c.GetChangeKind() == diffv1.ChangeKind_CHANGE_KIND_REMOVED || c.GetTargetVersion() == "" || c.GetPackage() == nil {
 			continue
 		}
-		pk := licensePkgKey{ecosystem: licenseEcosystem(c.Ecosystem), name: c.Name, version: c.TargetVersion}
+		pk := licensePkgKey{ecosystem: licenseEcosystem(c.GetPackage().GetEcosystem()), name: c.GetPackage().GetName(), version: c.GetTargetVersion()}
 		licenses := depsDevLicenses[pk]
 		if useScan {
 			// Only package-specific lookups may populate a dependency's
@@ -124,9 +121,9 @@ func enrichChangeLicenses(ctx context.Context, changes []compare.Change, license
 				licenses = license.MergeLicenseSources(licenses, rl)
 			}
 		}
-		c.Licenses = normalizeLicenseList(licenses)
+		c.Package.Licenses = normalizeLicenseList(licenses)
 	}
-	return out
+	return changes
 }
 
 // normalizeLicenseList drops placeholder entries so unknown licenses stay an

--- a/internal/cli/cmd/diff_policy_test.go
+++ b/internal/cli/cmd/diff_policy_test.go
@@ -6,8 +6,9 @@ import (
 	"strings"
 	"testing"
 
+	dependencyv1 "github.com/temporalio/deputy/gen/deputy/dependency/v1"
+	diffv1 "github.com/temporalio/deputy/gen/deputy/diff/v1"
 	policyv1 "github.com/temporalio/deputy/gen/deputy/policy/v1"
-	"github.com/temporalio/deputy/internal/compare"
 	"github.com/temporalio/deputy/internal/policy"
 )
 
@@ -50,9 +51,9 @@ func TestRunDiffPolicies_AttributesSubjects(t *testing.T) {
 		Repo:      "example.com/repo",
 		BaseRef:   "main",
 		TargetRef: "feature",
-		Changes: []compare.Change{
-			{Name: "golang.org/x/text", Ecosystem: "go", BaseVersion: "0.37.0", TargetVersion: "0.39.0", ChangeType: compare.Upgraded, IsDirect: true},
-			{Name: "golang.org/x/crypto", Ecosystem: "go", BaseVersion: "0.52.0", TargetVersion: "0.53.0", ChangeType: compare.Upgraded, IsDirect: true},
+		Changes: []*diffv1.PackageChange{
+			{Package: &dependencyv1.Package{Name: "golang.org/x/text", Version: "0.39.0", Ecosystem: "go"}, ChangeKind: diffv1.ChangeKind_CHANGE_KIND_UPGRADED, BaseVersion: "0.37.0", TargetVersion: "0.39.0", IsDirect: true},
+			{Package: &dependencyv1.Package{Name: "golang.org/x/crypto", Version: "0.53.0", Ecosystem: "go"}, ChangeKind: diffv1.ChangeKind_CHANGE_KIND_UPGRADED, BaseVersion: "0.52.0", TargetVersion: "0.53.0", IsDirect: true},
 		},
 	}
 
@@ -101,9 +102,9 @@ func TestRunDiffPolicies_DenyGatesAfterCollection(t *testing.T) {
 		Repo:      "example.com/repo",
 		BaseRef:   "main",
 		TargetRef: "feature",
-		Changes: []compare.Change{
-			{Name: "example.com/forbidden", Ecosystem: "go", TargetVersion: "1.0.0", ChangeType: compare.Added},
-			{Name: "example.com/fine", Ecosystem: "go", TargetVersion: "1.0.0", ChangeType: compare.Added},
+		Changes: []*diffv1.PackageChange{
+			{Package: &dependencyv1.Package{Name: "example.com/forbidden", Version: "1.0.0", Ecosystem: "go"}, ChangeKind: diffv1.ChangeKind_CHANGE_KIND_ADDED, TargetVersion: "1.0.0"},
+			{Package: &dependencyv1.Package{Name: "example.com/fine", Version: "1.0.0", Ecosystem: "go"}, ChangeKind: diffv1.ChangeKind_CHANGE_KIND_ADDED, TargetVersion: "1.0.0"},
 		},
 	}
 
@@ -144,9 +145,9 @@ func TestRunDiffPolicies_LicenseDataReachesPolicies(t *testing.T) {
 		Repo:      "example.com/repo",
 		BaseRef:   "main",
 		TargetRef: "feature",
-		Changes: []compare.Change{
-			{Name: "golang.org/x/crypto", Ecosystem: "go", BaseVersion: "0.52.0", TargetVersion: "0.53.0", ChangeType: compare.Upgraded, Licenses: []string{"BSD-3-Clause"}},
-			{Name: "example.com/unlicensed", Ecosystem: "go", TargetVersion: "1.0.0", ChangeType: compare.Added},
+		Changes: []*diffv1.PackageChange{
+			{Package: &dependencyv1.Package{Name: "golang.org/x/crypto", Version: "0.53.0", Ecosystem: "go", Licenses: []string{"BSD-3-Clause"}}, ChangeKind: diffv1.ChangeKind_CHANGE_KIND_UPGRADED, BaseVersion: "0.52.0", TargetVersion: "0.53.0"},
+			{Package: &dependencyv1.Package{Name: "example.com/unlicensed", Version: "1.0.0", Ecosystem: "go"}, ChangeKind: diffv1.ChangeKind_CHANGE_KIND_ADDED, TargetVersion: "1.0.0"},
 		},
 	}
 

--- a/internal/cli/cmd/diff_split_test.go
+++ b/internal/cli/cmd/diff_split_test.go
@@ -3,7 +3,8 @@ package cmd
 import (
 	"testing"
 
-	"github.com/temporalio/deputy/internal/compare"
+	dependencyv1 "github.com/temporalio/deputy/gen/deputy/dependency/v1"
+	diffv1 "github.com/temporalio/deputy/gen/deputy/diff/v1"
 	"github.com/temporalio/deputy/internal/report"
 )
 
@@ -26,8 +27,8 @@ func TestSplitVulnsByChange(t *testing.T) {
 		{Package: "github.com/foo/bar", Version: "v1.0.0"},
 		{Package: "github.com/baz/qux", Version: "v0.1.0"},
 	}
-	changes := []compare.Change{
-		{Name: "github.com/foo/bar", ChangeType: compare.Updated},
+	changes := []*diffv1.PackageChange{
+		{Package: &dependencyv1.Package{Name: "github.com/foo/bar"}, ChangeKind: diffv1.ChangeKind_CHANGE_KIND_UPDATED},
 	}
 	changed, unchanged := splitVulnsByChange(vulns, changes)
 	if len(changed) != 1 || changed[0].Package != "github.com/foo/bar" {
@@ -40,7 +41,7 @@ func TestSplitVulnsByChange(t *testing.T) {
 
 func TestSplitVulnsByChange_Downgrade(t *testing.T) {
 	vulns := []report.Vulnerability{{Package: "github.com/example/down", Version: "v1.0.0"}}
-	changes := []compare.Change{{Name: "github.com/example/down", ChangeType: compare.Downgraded}}
+	changes := []*diffv1.PackageChange{{Package: &dependencyv1.Package{Name: "github.com/example/down"}, ChangeKind: diffv1.ChangeKind_CHANGE_KIND_DOWNGRADED}}
 	changed, unchanged := splitVulnsByChange(vulns, changes)
 	if len(changed) != 1 || changed[0].Package != "github.com/example/down" {
 		t.Fatalf("downgraded package should be marked changed: changed=%#v", changed)
@@ -53,7 +54,7 @@ func TestSplitVulnsByChange_Downgrade(t *testing.T) {
 // Ensure splitVulnsByChange handles gopkg.in to GitHub path transitions.
 func TestSplitVulnsByChange_GopkgInCanonical(t *testing.T) {
 	vulns := []report.Vulnerability{{Package: "gopkg.in/go-jose/go-jose.v4", Version: "v4.0.5"}}
-	changes := []compare.Change{{Name: "github.com/go-jose/go-jose/v4", ChangeType: compare.Updated}}
+	changes := []*diffv1.PackageChange{{Package: &dependencyv1.Package{Name: "github.com/go-jose/go-jose/v4"}, ChangeKind: diffv1.ChangeKind_CHANGE_KIND_UPDATED}}
 	changed, unchanged := splitVulnsByChange(vulns, changes)
 	if len(changed) != 1 || changed[0].Package != "gopkg.in/go-jose/go-jose.v4" {
 		t.Fatalf("expected jose vuln classified as changed: %#v %#v", changed, unchanged)

--- a/internal/cli/cmd/diff_test.go
+++ b/internal/cli/cmd/diff_test.go
@@ -5,7 +5,8 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/temporalio/deputy/internal/compare"
+	dependencyv1 "github.com/temporalio/deputy/gen/deputy/dependency/v1"
+	diffv1 "github.com/temporalio/deputy/gen/deputy/diff/v1"
 	"github.com/temporalio/deputy/internal/report"
 )
 
@@ -73,37 +74,37 @@ func TestReclassifyUnchangedVulns(t *testing.T) {
 func TestBaseQueryPackages(t *testing.T) {
 	tests := []struct {
 		name    string
-		changes []compare.Change
+		changes []*diffv1.PackageChange
 		want    []string // "name@version/ecosystem"
 	}{
 		{
 			name: "updated upgraded downgraded qualify",
-			changes: []compare.Change{
-				{Name: "a", BaseVersion: "1.0.0", TargetVersion: "1.1.0", ChangeType: compare.Updated, Ecosystem: "go"},
-				{Name: "b", BaseVersion: "2.0.0", TargetVersion: "3.0.0", ChangeType: compare.Upgraded, Ecosystem: "npm"},
-				{Name: "c", BaseVersion: "5.0.0", TargetVersion: "4.0.0", ChangeType: compare.Downgraded, Ecosystem: "go"},
+			changes: []*diffv1.PackageChange{
+				{Package: &dependencyv1.Package{Name: "a", Version: "1.1.0", Ecosystem: "go"}, ChangeKind: diffv1.ChangeKind_CHANGE_KIND_UPDATED, BaseVersion: "1.0.0", TargetVersion: "1.1.0"},
+				{Package: &dependencyv1.Package{Name: "b", Version: "3.0.0", Ecosystem: "npm"}, ChangeKind: diffv1.ChangeKind_CHANGE_KIND_UPGRADED, BaseVersion: "2.0.0", TargetVersion: "3.0.0"},
+				{Package: &dependencyv1.Package{Name: "c", Version: "4.0.0", Ecosystem: "go"}, ChangeKind: diffv1.ChangeKind_CHANGE_KIND_DOWNGRADED, BaseVersion: "5.0.0", TargetVersion: "4.0.0"},
 			},
 			want: []string{"a@1.0.0/go", "b@2.0.0/npm", "c@5.0.0/go"},
 		},
 		{
 			name: "added and removed never query",
-			changes: []compare.Change{
-				{Name: "new", TargetVersion: "1.0.0", ChangeType: compare.Added, Ecosystem: "go"},
-				{Name: "gone", BaseVersion: "1.0.0", ChangeType: compare.Removed, Ecosystem: "go"},
+			changes: []*diffv1.PackageChange{
+				{Package: &dependencyv1.Package{Name: "new", Version: "1.0.0", Ecosystem: "go"}, ChangeKind: diffv1.ChangeKind_CHANGE_KIND_ADDED, TargetVersion: "1.0.0"},
+				{Package: &dependencyv1.Package{Name: "gone", Ecosystem: "go"}, ChangeKind: diffv1.ChangeKind_CHANGE_KIND_REMOVED, BaseVersion: "1.0.0"},
 			},
 			want: nil,
 		},
 		{
 			name: "missing base version is skipped",
-			changes: []compare.Change{
-				{Name: "a", TargetVersion: "1.1.0", ChangeType: compare.Updated, Ecosystem: "go"},
+			changes: []*diffv1.PackageChange{
+				{Package: &dependencyv1.Package{Name: "a", Version: "1.1.0", Ecosystem: "go"}, ChangeKind: diffv1.ChangeKind_CHANGE_KIND_UPDATED, TargetVersion: "1.1.0"},
 			},
 			want: nil,
 		},
 		{
 			name: "renamed package queries under its base name",
-			changes: []compare.Change{
-				{Name: "new/name", OldName: "old/name", BaseVersion: "1.0.0", TargetVersion: "1.1.0", ChangeType: compare.Updated, Ecosystem: "go"},
+			changes: []*diffv1.PackageChange{
+				{Package: &dependencyv1.Package{Name: "new/name", Version: "1.1.0", Ecosystem: "go"}, ChangeKind: diffv1.ChangeKind_CHANGE_KIND_UPDATED, OldName: "old/name", BaseVersion: "1.0.0", TargetVersion: "1.1.0"},
 			},
 			want: []string{"old/name@1.0.0/go"},
 		},

--- a/internal/cli/cmd/exec_review.go
+++ b/internal/cli/cmd/exec_review.go
@@ -13,6 +13,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/charmbracelet/lipgloss"
+	diffv1 "github.com/temporalio/deputy/gen/deputy/diff/v1"
 	sandboxv1 "github.com/temporalio/deputy/gen/deputy/sandbox/v1"
 	"github.com/temporalio/deputy/internal/compare"
 	"github.com/temporalio/deputy/internal/inventory"
@@ -29,7 +30,6 @@ func getTerminalWidth() int {
 	}
 	return 80 // sensible default
 }
-
 
 // truncatePath shortens a path to fit within maxLen, preserving the filename.
 func truncatePath(path string, maxLen int) string {
@@ -85,11 +85,11 @@ var dependencyManifests = map[string]string{
 	"Gemfile":      "rubygems",
 	"Gemfile.lock": "rubygems",
 	// Java / Maven / Gradle
-	"pom.xml":           "maven",
-	"build.gradle":      "maven",
-	"build.gradle.kts":  "maven",
-	"gradle.lockfile":   "maven",
-	"settings.gradle":   "maven",
+	"pom.xml":          "maven",
+	"build.gradle":     "maven",
+	"build.gradle.kts": "maven",
+	"gradle.lockfile":  "maven",
+	"settings.gradle":  "maven",
 	// .NET / NuGet
 	"*.csproj":        "nuget",
 	"packages.config": "nuget",
@@ -118,9 +118,9 @@ func isDependencyManifest(path string) (ecosystem string, ok bool) {
 
 // DependencyDiff represents the semantic difference in dependencies.
 type DependencyDiff struct {
-	Ecosystems map[string]bool    // ecosystems with changes
-	Changes    []compare.Change   // semantic dependency changes
-	Error      error              // error during diff (non-fatal)
+	Ecosystems map[string]bool         // ecosystems with changes
+	Changes    []*diffv1.PackageChange // semantic dependency changes
+	Error      error                   // error during diff (non-fatal)
 }
 
 // hasDependencyChanges checks if any file changes affect dependency manifests.
@@ -177,8 +177,8 @@ func computeDependencyDiff(ctx context.Context, originalPath, isolatedPath strin
 
 	// Track which ecosystems have changes
 	for _, change := range changes {
-		if change.Ecosystem != "" {
-			result.Ecosystems[change.Ecosystem] = true
+		if change.GetPackage().GetEcosystem() != "" {
+			result.Ecosystems[change.GetPackage().GetEcosystem()] = true
 		}
 	}
 
@@ -209,14 +209,14 @@ func renderDependencyDiff(out io.Writer, diff *DependencyDiff, termWidth int) {
 	// Count by type
 	var added, removed, upgraded, downgraded int
 	for _, c := range diff.Changes {
-		switch c.ChangeType {
-		case compare.Added:
+		switch c.GetChangeKind() {
+		case diffv1.ChangeKind_CHANGE_KIND_ADDED:
 			added++
-		case compare.Removed:
+		case diffv1.ChangeKind_CHANGE_KIND_REMOVED:
 			removed++
-		case compare.Upgraded:
+		case diffv1.ChangeKind_CHANGE_KIND_UPGRADED:
 			upgraded++
-		case compare.Downgraded:
+		case diffv1.ChangeKind_CHANGE_KIND_DOWNGRADED:
 			downgraded++
 		}
 	}
@@ -273,36 +273,36 @@ func renderDependencyDiff(out io.Writer, diff *DependencyDiff, termWidth int) {
 }
 
 // renderDependencyChange displays a single dependency change.
-func renderDependencyChange(out io.Writer, change compare.Change, termWidth int) {
+func renderDependencyChange(out io.Writer, change *diffv1.PackageChange, termWidth int) {
 	var prefix string
 	var style lipgloss.Style
 	var versionInfo string
 
-	switch change.ChangeType {
-	case compare.Added:
+	switch change.GetChangeKind() {
+	case diffv1.ChangeKind_CHANGE_KIND_ADDED:
 		prefix = "+"
 		style = ui.StyleAdded
-		versionInfo = change.TargetVersion
-	case compare.Removed:
+		versionInfo = change.GetTargetVersion()
+	case diffv1.ChangeKind_CHANGE_KIND_REMOVED:
 		prefix = "-"
 		style = ui.StyleRemoved
-		versionInfo = change.BaseVersion
-	case compare.Upgraded:
+		versionInfo = change.GetBaseVersion()
+	case diffv1.ChangeKind_CHANGE_KIND_UPGRADED:
 		prefix = "↑"
 		style = ui.StyleUpgraded
-		versionInfo = fmt.Sprintf("%s → %s", change.BaseVersion, change.TargetVersion)
-	case compare.Downgraded:
+		versionInfo = fmt.Sprintf("%s → %s", change.GetBaseVersion(), change.GetTargetVersion())
+	case diffv1.ChangeKind_CHANGE_KIND_DOWNGRADED:
 		prefix = "↓"
 		style = ui.StyleDowngraded
-		versionInfo = fmt.Sprintf("%s → %s", change.BaseVersion, change.TargetVersion)
+		versionInfo = fmt.Sprintf("%s → %s", change.GetBaseVersion(), change.GetTargetVersion())
 	default:
 		prefix = "~"
 		style = ui.StyleDim
-		versionInfo = fmt.Sprintf("%s → %s", change.BaseVersion, change.TargetVersion)
+		versionInfo = fmt.Sprintf("%s → %s", change.GetBaseVersion(), change.GetTargetVersion())
 	}
 
 	// Truncate package name if needed
-	name := change.Name
+	name := change.GetPackage().GetName()
 	maxNameWidth := termWidth - 30 // Leave room for version info
 	if len(name) > maxNameWidth {
 		name = "..." + name[len(name)-maxNameWidth+3:]
@@ -310,7 +310,7 @@ func renderDependencyChange(out io.Writer, change compare.Change, termWidth int)
 
 	// Direct/indirect indicator
 	directIndicator := ""
-	if change.IsDirect {
+	if change.GetIsDirect() {
 		directIndicator = ui.StyleDirect.Render(" [direct]")
 	}
 
@@ -642,15 +642,15 @@ func suggestValidChoice(input string) string {
 		"sync":   "Did you mean 'a' for accept?",
 		"s":      "Did you mean 'a' for accept?",
 		// Reject variations
-		"reject": "Did you mean 'r' for reject?",
+		"reject":  "Did you mean 'r' for reject?",
 		"discard": "Did you mean 'r' for reject?",
-		"cancel": "Did you mean 'r' for reject or 'q' for quit?",
-		"c":      "Did you mean 'r' for reject?",
-		"x":      "Did you mean 'r' for reject?",
+		"cancel":  "Did you mean 'r' for reject or 'q' for quit?",
+		"c":       "Did you mean 'r' for reject?",
+		"x":       "Did you mean 'r' for reject?",
 		// Diff variations
-		"diff":  "Did you mean 'd' for diff?",
-		"show":  "Did you mean 'd' for diff?",
-		"f":     "Did you mean 'd' for diff (file)?",
+		"diff": "Did you mean 'd' for diff?",
+		"show": "Did you mean 'd' for diff?",
+		"f":    "Did you mean 'd' for diff (file)?",
 		// View variations
 		"view":  "Did you mean 'v' for view?",
 		"open":  "Did you mean 'v' for view?",
@@ -658,10 +658,10 @@ func suggestValidChoice(input string) string {
 		"p":     "Did you mean 'v' for view?",
 		"less":  "Did you mean 'v' for view?",
 		// Quit variations
-		"quit":   "Did you mean 'q' for quit?",
-		"exit":   "Did you mean 'q' for quit?",
-		"abort":  "Did you mean 'q' for quit?",
-		"e":      "Did you mean 'q' for quit (exit)?",
+		"quit":  "Did you mean 'q' for quit?",
+		"exit":  "Did you mean 'q' for quit?",
+		"abort": "Did you mean 'q' for quit?",
+		"e":     "Did you mean 'q' for quit (exit)?",
 		// Help
 		"help": "Options: a (accept), r (reject), d (diff), v (view), q (quit)",
 		"h":    "Options: a (accept), r (reject), d (diff), v (view), q (quit)",

--- a/internal/compare/compare.go
+++ b/internal/compare/compare.go
@@ -9,6 +9,8 @@ import (
 	"github.com/google/osv-scalibr/semantic"
 	"golang.org/x/mod/semver"
 
+	dependencyv1 "github.com/temporalio/deputy/gen/deputy/dependency/v1"
+	diffv1 "github.com/temporalio/deputy/gen/deputy/diff/v1"
 	"github.com/temporalio/deputy/internal/ecosystem"
 	"github.com/temporalio/deputy/internal/repository/workspace"
 )
@@ -54,22 +56,45 @@ func (c ChangeType) String() string {
 	}
 }
 
-// Change captures a single dependency delta between two scans. For Added
-// entries BaseVersion/OldName are empty. For Removed entries TargetVersion is
-// empty. Updated entries record both old and new identifying information.
-//
-// Ecosystem is currently always "go" but is modeled for future multi-ecosystem
-// support. IsDirect is true when the module root appears explicitly (without
-// "// indirect" annotation) in go.mod of the target workspace.
-type Change struct {
-	Name          string     `json:"name"`               // canonical or full import path in target inventory
-	OldName       string     `json:"oldName"`            // previous path (may differ after canonicalization)
-	TargetVersion string     `json:"targetVersion"`      // version in target inventory (for Added/Updated)
-	BaseVersion   string     `json:"baseVersion"`        // version in base inventory (for Removed/Updated)
-	ChangeType    ChangeType `json:"changeType"`         // classification of the change
-	Ecosystem     string     `json:"ecosystem"`          // e.g. "go", "npm"
-	IsDirect      bool       `json:"isDirect"`           // true if a direct dependency when known (currently Go)
-	Licenses      []string   `json:"licenses,omitempty"` // SPDX identifiers for the target version, when license enrichment ran
+// Dependency changes use deputy.diff.v1.PackageChange as their domain type:
+// the same message every surface (JSON output, MCP, policy inputs) already
+// speaks, so nothing converts or drifts in between. ChangeType remains the
+// internal classification enum for container-image comparisons; Kind bridges
+// it onto the proto vocabulary.
+
+// Kind converts the internal classification to the proto ChangeKind.
+func (c ChangeType) Kind() diffv1.ChangeKind {
+	switch c {
+	case Added:
+		return diffv1.ChangeKind_CHANGE_KIND_ADDED
+	case Removed:
+		return diffv1.ChangeKind_CHANGE_KIND_REMOVED
+	case Upgraded:
+		return diffv1.ChangeKind_CHANGE_KIND_UPGRADED
+	case Downgraded:
+		return diffv1.ChangeKind_CHANGE_KIND_DOWNGRADED
+	case Updated:
+		return diffv1.ChangeKind_CHANGE_KIND_UPDATED
+	default:
+		return diffv1.ChangeKind_CHANGE_KIND_UNSPECIFIED
+	}
+}
+
+// newPackageChange builds a dependency change record. Package.Version carries
+// the target version (empty for removals), matching what consumers act on.
+func newPackageChange(kind ChangeType, name, oldName, baseVersion, targetVersion, ecosystem string, direct bool) *diffv1.PackageChange {
+	return &diffv1.PackageChange{
+		Package: &dependencyv1.Package{
+			Name:      name,
+			Version:   targetVersion,
+			Ecosystem: ecosystem,
+		},
+		ChangeKind:    kind.Kind(),
+		BaseVersion:   baseVersion,
+		TargetVersion: targetVersion,
+		OldName:       oldName,
+		IsDirect:      direct,
+	}
 }
 
 // GoPackageInfo represents a parsed interpretation of an import path possibly
@@ -269,12 +294,12 @@ func ParseGoPackage(pkg *extractor.Package) GoPackageInfo {
 	return info
 }
 
-// CompareGoPackageVersions compares BaseVersion and TargetVersion of a Change
-// returning 1 if TargetVersion is a semantic upgrade, -1 if a downgrade, and 0
-// if versions are identical or unparsable.
-func CompareGoPackageVersions(c Change) int {
-	oldV := normalizeGoVersion(c.BaseVersion)
-	newV := normalizeGoVersion(c.TargetVersion)
+// CompareGoPackageVersions compares a base and target Go version, returning 1
+// if target is a semantic upgrade, -1 if a downgrade, and 0 if versions are
+// identical or unparsable.
+func CompareGoPackageVersions(baseVersion, targetVersion string) int {
+	oldV := normalizeGoVersion(baseVersion)
+	newV := normalizeGoVersion(targetVersion)
 	return semver.Compare(newV, oldV)
 }
 
@@ -672,7 +697,7 @@ type CompareOptions struct {
 //
 // If deps is nil, direct dependencies are inferred from go.mod in the supplied
 // workspace.
-func ComparePackages(oldPkgs, newPkgs []*extractor.Package, goDirect map[string]bool, pkgDirect map[string]bool, ws workspace.ReadableFS) []Change {
+func ComparePackages(oldPkgs, newPkgs []*extractor.Package, goDirect map[string]bool, pkgDirect map[string]bool, ws workspace.ReadableFS) []*diffv1.PackageChange {
 	return ComparePackagesWithOptions(oldPkgs, newPkgs, CompareOptions{
 		GoDirect:  goDirect,
 		PkgDirect: pkgDirect,
@@ -681,7 +706,7 @@ func ComparePackages(oldPkgs, newPkgs []*extractor.Package, goDirect map[string]
 }
 
 // ComparePackagesWithOptions computes the dependency delta with configurable options.
-func ComparePackagesWithOptions(oldPkgs, newPkgs []*extractor.Package, opts CompareOptions) []Change {
+func ComparePackagesWithOptions(oldPkgs, newPkgs []*extractor.Package, opts CompareOptions) []*diffv1.PackageChange {
 	if len(oldPkgs) == 0 && len(newPkgs) == 0 {
 		return nil
 	}
@@ -710,66 +735,52 @@ func ComparePackagesWithOptions(oldPkgs, newPkgs []*extractor.Package, opts Comp
 		goDirect = GetDirectDependencies(opts.Workspace)
 	}
 	pkgDirect := opts.PkgDirect
-	var changes []Change
+	var changes []*diffv1.PackageChange
 	for key, oldMeta := range oldMap {
 		newMeta, ok := newMap[key]
 		if !ok {
-			changes = append(changes, Change{
-				Name:        oldMeta.pkg.Name,
-				BaseVersion: oldMeta.pkg.Version,
-				ChangeType:  Removed,
-				Ecosystem:   oldMeta.ecosystemName(),
-				IsDirect:    isDirectForSummary(oldMeta, goDirect, pkgDirect),
-			})
+			changes = append(changes, newPackageChange(Removed,
+				oldMeta.pkg.Name, "", oldMeta.pkg.Version, "",
+				oldMeta.ecosystemName(), isDirectForSummary(oldMeta, goDirect, pkgDirect)))
 			continue
 		}
 		if oldMeta.pkg.Version != newMeta.pkg.Version || oldMeta.pkg.Name != newMeta.pkg.Name {
 			ct := selectChangeType(newMeta.ecosystemName(), oldMeta.pkg.Version, newMeta.pkg.Version)
-			changes = append(changes, Change{
-				Name:          newMeta.pkg.Name,
-				OldName:       oldMeta.pkg.Name,
-				BaseVersion:   oldMeta.pkg.Version,
-				TargetVersion: newMeta.pkg.Version,
-				ChangeType:    ct,
-				Ecosystem:     newMeta.ecosystemName(),
-				IsDirect:      isDirectForSummary(newMeta, goDirect, pkgDirect),
-			})
+			changes = append(changes, newPackageChange(ct,
+				newMeta.pkg.Name, oldMeta.pkg.Name, oldMeta.pkg.Version, newMeta.pkg.Version,
+				newMeta.ecosystemName(), isDirectForSummary(newMeta, goDirect, pkgDirect)))
 		}
 	}
 	for key, newMeta := range newMap {
 		if _, ok := oldMap[key]; ok {
 			continue
 		}
-		changes = append(changes, Change{
-			Name:          newMeta.pkg.Name,
-			TargetVersion: newMeta.pkg.Version,
-			ChangeType:    Added,
-			Ecosystem:     newMeta.ecosystemName(),
-			IsDirect:      isDirectForSummary(newMeta, goDirect, pkgDirect),
-		})
+		changes = append(changes, newPackageChange(Added,
+			newMeta.pkg.Name, "", "", newMeta.pkg.Version,
+			newMeta.ecosystemName(), isDirectForSummary(newMeta, goDirect, pkgDirect)))
 	}
 
 	// Sort changes for consistent output: by change type priority, then name
-	slices.SortFunc(changes, func(a, b Change) int {
-		// Sort by change type: Upgraded, Downgraded, Added, Removed, Updated
-		typePriority := func(ct ChangeType) int {
-			switch ct {
-			case Upgraded:
+	slices.SortFunc(changes, func(a, b *diffv1.PackageChange) int {
+		// Sort by change kind: Upgraded, Downgraded, Added, Removed, Updated
+		kindPriority := func(ck diffv1.ChangeKind) int {
+			switch ck {
+			case diffv1.ChangeKind_CHANGE_KIND_UPGRADED:
 				return 0
-			case Downgraded:
+			case diffv1.ChangeKind_CHANGE_KIND_DOWNGRADED:
 				return 1
-			case Added:
+			case diffv1.ChangeKind_CHANGE_KIND_ADDED:
 				return 2
-			case Removed:
+			case diffv1.ChangeKind_CHANGE_KIND_REMOVED:
 				return 3
 			default:
 				return 4
 			}
 		}
-		if n := cmp.Compare(typePriority(a.ChangeType), typePriority(b.ChangeType)); n != 0 {
+		if n := cmp.Compare(kindPriority(a.GetChangeKind()), kindPriority(b.GetChangeKind())); n != 0 {
 			return n
 		}
-		return cmp.Compare(a.Name, b.Name)
+		return cmp.Compare(a.GetPackage().GetName(), b.GetPackage().GetName())
 	})
 
 	return changes

--- a/internal/compare/compare.go
+++ b/internal/compare/compare.go
@@ -80,23 +80,6 @@ func (c ChangeType) Kind() diffv1.ChangeKind {
 	}
 }
 
-// newPackageChange builds a dependency change record. Package.Version carries
-// the target version (empty for removals), matching what consumers act on.
-func newPackageChange(kind ChangeType, name, oldName, baseVersion, targetVersion, ecosystem string, direct bool) *diffv1.PackageChange {
-	return &diffv1.PackageChange{
-		Package: &dependencyv1.Package{
-			Name:      name,
-			Version:   targetVersion,
-			Ecosystem: ecosystem,
-		},
-		ChangeKind:    kind.Kind(),
-		BaseVersion:   baseVersion,
-		TargetVersion: targetVersion,
-		OldName:       oldName,
-		IsDirect:      direct,
-	}
-}
-
 // GoPackageInfo represents a parsed interpretation of an import path possibly
 // containing a semantic major version suffix (e.g. /v2) or a historical vanity
 // host (gopkg.in). CanonicalName removes redundant major version path segments
@@ -735,29 +718,53 @@ func ComparePackagesWithOptions(oldPkgs, newPkgs []*extractor.Package, opts Comp
 		goDirect = GetDirectDependencies(opts.Workspace)
 	}
 	pkgDirect := opts.PkgDirect
+	// Package.Version carries the target version (empty for removals), which is
+	// the version consumers act on.
 	var changes []*diffv1.PackageChange
 	for key, oldMeta := range oldMap {
 		newMeta, ok := newMap[key]
 		if !ok {
-			changes = append(changes, newPackageChange(Removed,
-				oldMeta.pkg.Name, "", oldMeta.pkg.Version, "",
-				oldMeta.ecosystemName(), isDirectForSummary(oldMeta, goDirect, pkgDirect)))
+			changes = append(changes, &diffv1.PackageChange{
+				Package: &dependencyv1.Package{
+					Name:      oldMeta.pkg.Name,
+					Ecosystem: oldMeta.ecosystemName(),
+				},
+				ChangeKind:  Removed.Kind(),
+				BaseVersion: oldMeta.pkg.Version,
+				IsDirect:    isDirectForSummary(oldMeta, goDirect, pkgDirect),
+			})
 			continue
 		}
 		if oldMeta.pkg.Version != newMeta.pkg.Version || oldMeta.pkg.Name != newMeta.pkg.Name {
 			ct := selectChangeType(newMeta.ecosystemName(), oldMeta.pkg.Version, newMeta.pkg.Version)
-			changes = append(changes, newPackageChange(ct,
-				newMeta.pkg.Name, oldMeta.pkg.Name, oldMeta.pkg.Version, newMeta.pkg.Version,
-				newMeta.ecosystemName(), isDirectForSummary(newMeta, goDirect, pkgDirect)))
+			changes = append(changes, &diffv1.PackageChange{
+				Package: &dependencyv1.Package{
+					Name:      newMeta.pkg.Name,
+					Version:   newMeta.pkg.Version,
+					Ecosystem: newMeta.ecosystemName(),
+				},
+				ChangeKind:    ct.Kind(),
+				BaseVersion:   oldMeta.pkg.Version,
+				TargetVersion: newMeta.pkg.Version,
+				OldName:       oldMeta.pkg.Name,
+				IsDirect:      isDirectForSummary(newMeta, goDirect, pkgDirect),
+			})
 		}
 	}
 	for key, newMeta := range newMap {
 		if _, ok := oldMap[key]; ok {
 			continue
 		}
-		changes = append(changes, newPackageChange(Added,
-			newMeta.pkg.Name, "", "", newMeta.pkg.Version,
-			newMeta.ecosystemName(), isDirectForSummary(newMeta, goDirect, pkgDirect)))
+		changes = append(changes, &diffv1.PackageChange{
+			Package: &dependencyv1.Package{
+				Name:      newMeta.pkg.Name,
+				Version:   newMeta.pkg.Version,
+				Ecosystem: newMeta.ecosystemName(),
+			},
+			ChangeKind:    Added.Kind(),
+			TargetVersion: newMeta.pkg.Version,
+			IsDirect:      isDirectForSummary(newMeta, goDirect, pkgDirect),
+		})
 	}
 
 	// Sort changes for consistent output: by change type priority, then name

--- a/internal/compare/compare_test.go
+++ b/internal/compare/compare_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/google/osv-scalibr/extractor"
 	scalpurl "github.com/google/osv-scalibr/purl"
+	diffv1 "github.com/temporalio/deputy/gen/deputy/diff/v1"
 	"github.com/temporalio/deputy/internal/repository/workspace"
 )
 
@@ -280,19 +281,19 @@ require (
 
 	var added, removed, upgraded bool
 	for _, c := range changes {
-		switch c.ChangeType {
-		case Added:
-			if c.Name != "github.com/new/added" || c.TargetVersion != "v1.0.0" || !c.IsDirect || c.Ecosystem != "Go" {
+		switch c.GetChangeKind() {
+		case diffv1.ChangeKind_CHANGE_KIND_ADDED:
+			if c.GetPackage().GetName() != "github.com/new/added" || c.GetTargetVersion() != "v1.0.0" || !c.GetIsDirect() || c.GetPackage().GetEcosystem() != "Go" {
 				t.Fatalf("bad added: %+v", c)
 			}
 			added = true
-		case Removed:
-			if c.Name != "github.com/old/removed" || c.BaseVersion != "v0.9.0" || c.Ecosystem != "Go" {
+		case diffv1.ChangeKind_CHANGE_KIND_REMOVED:
+			if c.GetPackage().GetName() != "github.com/old/removed" || c.GetBaseVersion() != "v0.9.0" || c.GetPackage().GetEcosystem() != "Go" {
 				t.Fatalf("bad removed: %+v", c)
 			}
 			removed = true
-		case Upgraded:
-			if c.Name != "github.com/keep/updated" || c.BaseVersion != "v1.0.0" || c.TargetVersion != "v1.1.0" || !c.IsDirect || c.Ecosystem != "Go" {
+		case diffv1.ChangeKind_CHANGE_KIND_UPGRADED:
+			if c.GetPackage().GetName() != "github.com/keep/updated" || c.GetBaseVersion() != "v1.0.0" || c.GetTargetVersion() != "v1.1.0" || !c.GetIsDirect() || c.GetPackage().GetEcosystem() != "Go" {
 				t.Fatalf("bad upgraded: %+v", c)
 			}
 			upgraded = true
@@ -320,24 +321,24 @@ func TestComparePackages_DowngradeAndRename(t *testing.T) {
 	if len(changes) != 2 {
 		t.Fatalf("expected 2 changes got %d: %+v", len(changes), changes)
 	}
-	seen := map[ChangeType]bool{}
+	seen := map[diffv1.ChangeKind]bool{}
 	for _, c := range changes {
-		switch c.ChangeType {
-		case Downgraded:
-			seen[Downgraded] = true
-			if c.Name != "github.com/example/down" || c.BaseVersion != "v1.2.0" || c.TargetVersion != "v1.1.0" || c.Ecosystem != "Go" {
+		switch c.GetChangeKind() {
+		case diffv1.ChangeKind_CHANGE_KIND_DOWNGRADED:
+			seen[diffv1.ChangeKind_CHANGE_KIND_DOWNGRADED] = true
+			if c.GetPackage().GetName() != "github.com/example/down" || c.GetBaseVersion() != "v1.2.0" || c.GetTargetVersion() != "v1.1.0" || c.GetPackage().GetEcosystem() != "Go" {
 				t.Fatalf("unexpected downgrade change: %+v", c)
 			}
-		case Updated:
-			seen[Updated] = true
-			if c.Name != "github.com/example/rename/v2" || c.OldName != "github.com/example/rename" || c.Ecosystem != "Go" {
+		case diffv1.ChangeKind_CHANGE_KIND_UPDATED:
+			seen[diffv1.ChangeKind_CHANGE_KIND_UPDATED] = true
+			if c.GetPackage().GetName() != "github.com/example/rename/v2" || c.GetOldName() != "github.com/example/rename" || c.GetPackage().GetEcosystem() != "Go" {
 				t.Fatalf("unexpected rename change: %+v", c)
 			}
 		default:
-			t.Fatalf("unexpected change type %v", c.ChangeType)
+			t.Fatalf("unexpected change type %v", c.GetChangeKind())
 		}
 	}
-	if !seen[Downgraded] || !seen[Updated] {
+	if !seen[diffv1.ChangeKind_CHANGE_KIND_DOWNGRADED] || !seen[diffv1.ChangeKind_CHANGE_KIND_UPDATED] {
 		t.Fatalf("missing expected change types: %+v", seen)
 	}
 }
@@ -356,22 +357,22 @@ func TestComparePackages_NonGo(t *testing.T) {
 	}
 	var added, updated bool
 	for _, c := range changes {
-		if c.Ecosystem != scalpurl.TypeNPM {
+		if c.GetPackage().GetEcosystem() != scalpurl.TypeNPM {
 			t.Fatalf("unexpected ecosystem for npm package: %+v", c)
 		}
-		switch c.ChangeType {
-		case Added:
-			if c.Name != "colors" || c.TargetVersion != "2.0.0" || c.IsDirect {
+		switch c.GetChangeKind() {
+		case diffv1.ChangeKind_CHANGE_KIND_ADDED:
+			if c.GetPackage().GetName() != "colors" || c.GetTargetVersion() != "2.0.0" || c.GetIsDirect() {
 				t.Fatalf("unexpected added change: %+v", c)
 			}
 			added = true
-		case Upgraded:
-			if c.Name != "left-pad" || c.BaseVersion != "1.0.0" || c.TargetVersion != "1.1.0" || c.IsDirect {
+		case diffv1.ChangeKind_CHANGE_KIND_UPGRADED:
+			if c.GetPackage().GetName() != "left-pad" || c.GetBaseVersion() != "1.0.0" || c.GetTargetVersion() != "1.1.0" || c.GetIsDirect() {
 				t.Fatalf("unexpected upgraded change: %+v", c)
 			}
 			updated = true
 		default:
-			t.Fatalf("unexpected change type %v", c.ChangeType)
+			t.Fatalf("unexpected change type %v", c.GetChangeKind())
 		}
 	}
 	if !added || !updated {
@@ -420,8 +421,8 @@ func TestComparePackages_PyPINameNormalization(t *testing.T) {
 	if len(changes) != 1 {
 		t.Fatalf("expected 1 change (upgrade) got %d: %+v", len(changes), changes)
 	}
-	if changes[0].ChangeType != Upgraded {
-		t.Fatalf("expected Upgraded change type, got %v: %+v", changes[0].ChangeType, changes[0])
+	if changes[0].GetChangeKind() != diffv1.ChangeKind_CHANGE_KIND_UPGRADED {
+		t.Fatalf("expected Upgraded change type, got %v: %+v", changes[0].GetChangeKind(), changes[0])
 	}
 	if changes[0].BaseVersion != "1.0.0" || changes[0].TargetVersion != "1.1.0" {
 		t.Fatalf("unexpected versions: %+v", changes[0])
@@ -466,8 +467,8 @@ func TestComparePackages_GoMajorVersionUpgrade(t *testing.T) {
 	if len(changes) != 1 {
 		t.Fatalf("expected 1 change got %d: %+v", len(changes), changes)
 	}
-	if changes[0].ChangeType != Upgraded {
-		t.Fatalf("expected Upgraded, got %v: %+v", changes[0].ChangeType, changes[0])
+	if changes[0].GetChangeKind() != diffv1.ChangeKind_CHANGE_KIND_UPGRADED {
+		t.Fatalf("expected Upgraded, got %v: %+v", changes[0].GetChangeKind(), changes[0])
 	}
 }
 
@@ -485,8 +486,8 @@ func TestComparePackages_GoGopkgInNormalization(t *testing.T) {
 	if len(changes) != 1 {
 		t.Fatalf("expected 1 change got %d: %+v", len(changes), changes)
 	}
-	if changes[0].ChangeType != Upgraded {
-		t.Fatalf("expected Upgraded change type, got %v: %+v", changes[0].ChangeType, changes[0])
+	if changes[0].GetChangeKind() != diffv1.ChangeKind_CHANGE_KIND_UPGRADED {
+		t.Fatalf("expected Upgraded change type, got %v: %+v", changes[0].GetChangeKind(), changes[0])
 	}
 	if changes[0].OldName != "gopkg.in/yaml.v3" {
 		t.Fatalf("expected OldName to be gopkg.in/yaml.v3, got %q", changes[0].OldName)
@@ -531,8 +532,8 @@ func TestComparePackages_CargoNameNormalization(t *testing.T) {
 	if len(changes) != 1 {
 		t.Fatalf("expected 1 change (upgrade) got %d: %+v", len(changes), changes)
 	}
-	if changes[0].ChangeType != Upgraded {
-		t.Fatalf("expected Upgraded change type, got %v: %+v", changes[0].ChangeType, changes[0])
+	if changes[0].GetChangeKind() != diffv1.ChangeKind_CHANGE_KIND_UPGRADED {
+		t.Fatalf("expected Upgraded change type, got %v: %+v", changes[0].GetChangeKind(), changes[0])
 	}
 	if changes[0].BaseVersion != "1.0.0" || changes[0].TargetVersion != "1.1.0" {
 		t.Fatalf("unexpected versions: %+v", changes[0])
@@ -553,8 +554,8 @@ func TestComparePackages_NpmCaseNormalization(t *testing.T) {
 	if len(changes) != 1 {
 		t.Fatalf("expected 1 change (upgrade) got %d: %+v", len(changes), changes)
 	}
-	if changes[0].ChangeType != Upgraded {
-		t.Fatalf("expected Upgraded change type, got %v: %+v", changes[0].ChangeType, changes[0])
+	if changes[0].GetChangeKind() != diffv1.ChangeKind_CHANGE_KIND_UPGRADED {
+		t.Fatalf("expected Upgraded change type, got %v: %+v", changes[0].GetChangeKind(), changes[0])
 	}
 }
 
@@ -792,21 +793,21 @@ func TestComparePackages_PackageMatching(t *testing.T) {
 
 	var upgraded, added, removed int
 	for _, c := range changes {
-		switch c.ChangeType {
-		case Upgraded:
+		switch c.GetChangeKind() {
+		case diffv1.ChangeKind_CHANGE_KIND_UPGRADED:
 			upgraded++
-			if c.Name != "curl" && c.Name != "openssl" {
-				t.Errorf("unexpected upgraded package: %s", c.Name)
+			if c.GetPackage().GetName() != "curl" && c.GetPackage().GetName() != "openssl" {
+				t.Errorf("unexpected upgraded package: %s", c.GetPackage().GetName())
 			}
-		case Added:
+		case diffv1.ChangeKind_CHANGE_KIND_ADDED:
 			added++
-			if c.Name != "new-pkg" {
-				t.Errorf("unexpected added package: %s", c.Name)
+			if c.GetPackage().GetName() != "new-pkg" {
+				t.Errorf("unexpected added package: %s", c.GetPackage().GetName())
 			}
-		case Removed:
+		case diffv1.ChangeKind_CHANGE_KIND_REMOVED:
 			removed++
-			if c.Name != "removed-pkg" {
-				t.Errorf("unexpected removed package: %s", c.Name)
+			if c.GetPackage().GetName() != "removed-pkg" {
+				t.Errorf("unexpected removed package: %s", c.GetPackage().GetName())
 			}
 		}
 	}
@@ -898,8 +899,8 @@ func TestComparePackagesWithOptions_ExcludeMainModule(t *testing.T) {
 	if len(changesWithExclude) != 1 {
 		t.Fatalf("expected 1 change with exclusion, got %d: %+v", len(changesWithExclude), changesWithExclude)
 	}
-	if changesWithExclude[0].Name != "github.com/dep/a" {
-		t.Errorf("expected dep/a change, got %s", changesWithExclude[0].Name)
+	if changesWithExclude[0].GetPackage().GetName() != "github.com/dep/a" {
+		t.Errorf("expected dep/a change, got %s", changesWithExclude[0].GetPackage().GetName())
 	}
 }
 
@@ -921,7 +922,7 @@ func TestComparePackagesWithOptions_GoToolchainNotFiltered(t *testing.T) {
 	if len(changes) != 1 {
 		t.Fatalf("expected 1 change (go toolchain added), got %d: %+v", len(changes), changes)
 	}
-	if changes[0].Name != "go" || changes[0].ChangeType != Added {
+	if changes[0].GetPackage().GetName() != "go" || changes[0].GetChangeKind() != diffv1.ChangeKind_CHANGE_KIND_ADDED {
 		t.Errorf("expected go toolchain as added, got: %+v", changes[0])
 	}
 }

--- a/internal/compare/container_image.go
+++ b/internal/compare/container_image.go
@@ -78,9 +78,17 @@ type ImageDiffSummary struct {
 }
 
 // ImagePackageChange represents a package difference between two images.
-// Extends the base Change type with container-specific layer information.
+// The identity fields are inlined (not the deputy.diff.v1.PackageChange
+// proto) because container comparisons key on flat name/ecosystem pairs and
+// this type only crosses surfaces via explicit proto conversion.
 type ImagePackageChange struct {
-	Change
+	Name          string     `json:"name"`
+	OldName       string     `json:"oldName"`
+	TargetVersion string     `json:"targetVersion"`
+	BaseVersion   string     `json:"baseVersion"`
+	ChangeType    ChangeType `json:"changeType"`
+	Ecosystem     string     `json:"ecosystem"`
+	IsDirect      bool       `json:"isDirect"`
 
 	// BaseLayerDetails indicates which layer the package was in the base image.
 	// Nil if the package was not in the base image (added).

--- a/internal/compare/container_image_test.go
+++ b/internal/compare/container_image_test.go
@@ -290,11 +290,11 @@ func TestAnalyzeLayerDiff(t *testing.T) {
 func TestCalculateImageDiffSummary(t *testing.T) {
 	report := &ImageDiffReport{
 		PackageChanges: []ImagePackageChange{
-			{Change: Change{ChangeType: Added}},
-			{Change: Change{ChangeType: Added}},
-			{Change: Change{ChangeType: Removed}},
-			{Change: Change{ChangeType: Upgraded}},
-			{Change: Change{ChangeType: Downgraded}},
+			{ChangeType: Added},
+			{ChangeType: Added},
+			{ChangeType: Removed},
+			{ChangeType: Upgraded},
+			{ChangeType: Downgraded},
 		},
 		VulnerabilityChanges: []VulnerabilityChange{
 			{ChangeType: VulnAdded},

--- a/internal/compare/versions_quick_test.go
+++ b/internal/compare/versions_quick_test.go
@@ -15,13 +15,9 @@ func TestVersionComparisonTransitivity(t *testing.T) {
 		v2 := fmt.Sprintf("v1.%d.0", b)
 		v3 := fmt.Sprintf("v1.%d.0", c)
 
-		change12 := Change{BaseVersion: v2, TargetVersion: v1}
-		change23 := Change{BaseVersion: v3, TargetVersion: v2}
-		change13 := Change{BaseVersion: v3, TargetVersion: v1}
-
-		cmp12 := CompareGoPackageVersions(change12)
-		cmp23 := CompareGoPackageVersions(change23)
-		cmp13 := CompareGoPackageVersions(change13)
+		cmp12 := CompareGoPackageVersions(v2, v1)
+		cmp23 := CompareGoPackageVersions(v3, v2)
+		cmp13 := CompareGoPackageVersions(v3, v1)
 
 		// Transitivity: if v1 > v2 and v2 > v3, then v1 > v3
 		if cmp12 > 0 && cmp23 > 0 {
@@ -42,11 +38,8 @@ func TestVersionComparisonSymmetry(t *testing.T) {
 		v1 := fmt.Sprintf("v1.%d.0", a)
 		v2 := fmt.Sprintf("v1.%d.0", b)
 
-		change12 := Change{BaseVersion: v2, TargetVersion: v1}
-		change21 := Change{BaseVersion: v1, TargetVersion: v2}
-
-		cmp12 := CompareGoPackageVersions(change12)
-		cmp21 := CompareGoPackageVersions(change21)
+		cmp12 := CompareGoPackageVersions(v2, v1)
+		cmp21 := CompareGoPackageVersions(v1, v2)
 
 		// Antisymmetry: cmp(v1, v2) = -cmp(v2, v1)
 		return cmp12 == -cmp21
@@ -61,8 +54,7 @@ func TestVersionComparisonSymmetry(t *testing.T) {
 func TestVersionComparisonReflexivity(t *testing.T) {
 	f := func(a uint8) bool {
 		v := fmt.Sprintf("v1.%d.0", a)
-		change := Change{BaseVersion: v, TargetVersion: v}
-		cmp := CompareGoPackageVersions(change)
+		cmp := CompareGoPackageVersions(v, v)
 		return cmp == 0
 	}
 

--- a/internal/compare/versions_test.go
+++ b/internal/compare/versions_test.go
@@ -17,8 +17,7 @@ func Test_CompareGoPackageVersions(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			chg := Change{BaseVersion: c.base, TargetVersion: c.target}
-			got := CompareGoPackageVersions(chg)
+			got := CompareGoPackageVersions(c.base, c.target)
 			if got != c.want {
 				t.Fatalf("CompareGoPackageVersions(%q→%q)=%d want %d", c.base, c.target, got, c.want)
 			}

--- a/internal/proto/container_diff.go
+++ b/internal/proto/container_diff.go
@@ -146,20 +146,21 @@ func compareContainerPackagesFromScanning(baseResult, targetResult *scanning.Res
 	// Convert to proto
 	changes := make([]*diffv1.ContainerPackageChange, 0, len(baseChanges))
 	for _, c := range baseChanges {
+		name := c.GetPackage().GetName()
 		change := &diffv1.ContainerPackageChange{
-			Name:               c.Name,
-			Ecosystem:          c.Ecosystem,
-			ChangeKind:         convertChangeKind(c.ChangeType),
-			BaseVersion:        c.BaseVersion,
-			TargetVersion:      c.TargetVersion,
-			OldName:            c.OldName,
-			IsDirect:           c.IsDirect,
-			BaseLayerDetails:   baseLayerMap[c.Name],
-			TargetLayerDetails: targetLayerMap[c.Name],
+			Name:               name,
+			Ecosystem:          c.GetPackage().GetEcosystem(),
+			ChangeKind:         c.GetChangeKind(),
+			BaseVersion:        c.GetBaseVersion(),
+			TargetVersion:      c.GetTargetVersion(),
+			OldName:            c.GetOldName(),
+			IsDirect:           c.GetIsDirect(),
+			BaseLayerDetails:   baseLayerMap[name],
+			TargetLayerDetails: targetLayerMap[name],
 		}
 		// For removed packages, use old name if different
-		if c.ChangeType == compare.Removed && c.OldName != "" {
-			change.BaseLayerDetails = baseLayerMap[c.OldName]
+		if c.GetChangeKind() == diffv1.ChangeKind_CHANGE_KIND_REMOVED && c.GetOldName() != "" {
+			change.BaseLayerDetails = baseLayerMap[c.GetOldName()]
 		}
 		changes = append(changes, change)
 	}
@@ -683,15 +684,13 @@ func ContainerDiffResponseToReport(resp *diffv1.DiffContainerImagesResponse) *co
 	// Convert package changes
 	for _, pc := range resp.PackageChanges {
 		report.PackageChanges = append(report.PackageChanges, compare.ImagePackageChange{
-			Change: compare.Change{
-				Name:          pc.Name,
-				Ecosystem:     pc.Ecosystem,
-				ChangeType:    protoChangeKindToCompare(pc.ChangeKind),
-				BaseVersion:   pc.BaseVersion,
-				TargetVersion: pc.TargetVersion,
-				OldName:       pc.OldName,
-				IsDirect:      pc.IsDirect,
-			},
+			Name:          pc.Name,
+			Ecosystem:     pc.Ecosystem,
+			ChangeType:    protoChangeKindToCompare(pc.ChangeKind),
+			BaseVersion:   pc.BaseVersion,
+			TargetVersion: pc.TargetVersion,
+			OldName:       pc.OldName,
+			IsDirect:      pc.IsDirect,
 			BaseLayerDetails:   pc.BaseLayerDetails,
 			TargetLayerDetails: pc.TargetLayerDetails,
 		})
@@ -911,7 +910,7 @@ func ImageDiffReportToProto(report *compare.ImageDiffReport) *diffv1.DiffContain
 		resp.PackageChanges = append(resp.PackageChanges, &diffv1.ContainerPackageChange{
 			Name:               pc.Name,
 			Ecosystem:          pc.Ecosystem,
-			ChangeKind:         ChangeKindToProto(pc.ChangeType),
+			ChangeKind:         pc.ChangeType.Kind(),
 			BaseVersion:        pc.BaseVersion,
 			TargetVersion:      pc.TargetVersion,
 			OldName:            pc.OldName,
@@ -971,7 +970,7 @@ func ImageDiffReportToProto(report *compare.ImageDiffReport) *diffv1.DiffContain
 		for _, ec := range cc.EnvChanges {
 			resp.ConfigChanges.EnvChanges = append(resp.ConfigChanges.EnvChanges, &diffv1.EnvChange{
 				Name:        ec.Name,
-				ChangeKind:  ChangeKindToProto(ec.ChangeType),
+				ChangeKind:  ec.ChangeType.Kind(),
 				BaseValue:   ec.BaseValue,
 				TargetValue: ec.TargetValue,
 				IsSensitive: ec.IsSensitive,
@@ -980,7 +979,7 @@ func ImageDiffReportToProto(report *compare.ImageDiffReport) *diffv1.DiffContain
 		for _, lc := range cc.LabelChanges {
 			resp.ConfigChanges.LabelChanges = append(resp.ConfigChanges.LabelChanges, &diffv1.LabelChange{
 				Key:         lc.Key,
-				ChangeKind:  ChangeKindToProto(lc.ChangeType),
+				ChangeKind:  lc.ChangeType.Kind(),
 				BaseValue:   lc.BaseValue,
 				TargetValue: lc.TargetValue,
 			})

--- a/internal/proto/diff.go
+++ b/internal/proto/diff.go
@@ -3,31 +3,12 @@ package proto
 import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	dependencyv1 "github.com/temporalio/deputy/gen/deputy/dependency/v1"
 	diffv1 "github.com/temporalio/deputy/gen/deputy/diff/v1"
 	policyv1 "github.com/temporalio/deputy/gen/deputy/policy/v1"
 	targetv1 "github.com/temporalio/deputy/gen/deputy/target/v1"
 	vulnerabilityv1 "github.com/temporalio/deputy/gen/deputy/vulnerability/v1"
 	"github.com/temporalio/deputy/internal/compare"
 )
-
-// ChangeKindToProto converts internal compare.ChangeType to proto diffv1.ChangeKind.
-func ChangeKindToProto(ct compare.ChangeType) diffv1.ChangeKind {
-	switch ct {
-	case compare.Added:
-		return diffv1.ChangeKind_CHANGE_KIND_ADDED
-	case compare.Removed:
-		return diffv1.ChangeKind_CHANGE_KIND_REMOVED
-	case compare.Upgraded:
-		return diffv1.ChangeKind_CHANGE_KIND_UPGRADED
-	case compare.Downgraded:
-		return diffv1.ChangeKind_CHANGE_KIND_DOWNGRADED
-	case compare.Updated:
-		return diffv1.ChangeKind_CHANGE_KIND_UPDATED
-	default:
-		return diffv1.ChangeKind_CHANGE_KIND_UNSPECIFIED
-	}
-}
 
 // ChangeKindFromProto converts proto diffv1.ChangeKind to internal compare.ChangeType.
 func ChangeKindFromProto(ck diffv1.ChangeKind) compare.ChangeType {
@@ -47,83 +28,22 @@ func ChangeKindFromProto(ck diffv1.ChangeKind) compare.ChangeType {
 	}
 }
 
-// PackageChangeToProto converts an internal compare.Change to proto diffv1.PackageChange.
-func PackageChangeToProto(c compare.Change) *diffv1.PackageChange {
-	return &diffv1.PackageChange{
-		Package: &dependencyv1.Package{
-			Name:      c.Name,
-			Version:   c.TargetVersion,
-			Ecosystem: c.Ecosystem,
-			Licenses:  c.Licenses,
-		},
-		ChangeKind:    ChangeKindToProto(c.ChangeType),
-		BaseVersion:   c.BaseVersion,
-		TargetVersion: c.TargetVersion,
-		OldName:       c.OldName,
-		IsDirect:      c.IsDirect,
-	}
-}
-
-// PackageChangeFromProto converts a proto diffv1.PackageChange to internal compare.Change.
-func PackageChangeFromProto(pc *diffv1.PackageChange) compare.Change {
-	if pc == nil {
-		return compare.Change{}
-	}
-	c := compare.Change{
-		ChangeType:    ChangeKindFromProto(pc.ChangeKind),
-		BaseVersion:   pc.BaseVersion,
-		TargetVersion: pc.TargetVersion,
-		OldName:       pc.OldName,
-		IsDirect:      pc.IsDirect,
-	}
-	if pc.Package != nil {
-		c.Name = pc.Package.Name
-		c.Ecosystem = pc.Package.Ecosystem
-		c.Licenses = pc.Package.Licenses
-	}
-	return c
-}
-
-// PackageChangesToProto converts a slice of internal changes to proto.
-func PackageChangesToProto(changes []compare.Change) []*diffv1.PackageChange {
-	if len(changes) == 0 {
-		return nil
-	}
-	out := make([]*diffv1.PackageChange, len(changes))
-	for i, c := range changes {
-		out[i] = PackageChangeToProto(c)
-	}
-	return out
-}
-
-// PackageChangesFromProto converts proto PackageChanges to internal changes.
-func PackageChangesFromProto(changes []*diffv1.PackageChange) []compare.Change {
-	if len(changes) == 0 {
-		return nil
-	}
-	out := make([]compare.Change, len(changes))
-	for i, c := range changes {
-		out[i] = PackageChangeFromProto(c)
-	}
-	return out
-}
-
-// DiffStatsToProto converts internal change counts to proto DiffStats.
-func DiffStatsToProto(changes []compare.Change) *diffv1.DiffStats {
+// DiffStatsToProto summarizes dependency changes into proto DiffStats.
+func DiffStatsToProto(changes []*diffv1.PackageChange) *diffv1.DiffStats {
 	stats := &diffv1.DiffStats{
 		TotalChanges: int32(len(changes)),
 	}
 	for _, c := range changes {
-		switch c.ChangeType {
-		case compare.Added:
+		switch c.GetChangeKind() {
+		case diffv1.ChangeKind_CHANGE_KIND_ADDED:
 			stats.AddedCount++
-		case compare.Removed:
+		case diffv1.ChangeKind_CHANGE_KIND_REMOVED:
 			stats.RemovedCount++
-		case compare.Upgraded:
+		case diffv1.ChangeKind_CHANGE_KIND_UPGRADED:
 			stats.UpgradedCount++
-		case compare.Downgraded:
+		case diffv1.ChangeKind_CHANGE_KIND_DOWNGRADED:
 			stats.DowngradedCount++
-		case compare.Updated:
+		case diffv1.ChangeKind_CHANGE_KIND_UPDATED:
 			stats.UpdatedCount++
 		}
 	}
@@ -143,7 +63,7 @@ func DiffStatsToProto(changes []compare.Change) *diffv1.DiffStats {
 // server handler does. See #135.
 func GitDiffReportToProto(
 	repo, baseRef, targetRef string,
-	changes []compare.Change,
+	changes []*diffv1.PackageChange,
 	added, unchanged []*vulnerabilityv1.Finding,
 	advisories map[string]*vulnerabilityv1.Advisory,
 	policyActions []*policyv1.Action,
@@ -158,7 +78,7 @@ func GitDiffReportToProto(
 		},
 		GeneratedAt:              timestamppb.Now(),
 		Advisories:               advisories,
-		Changes:                  PackageChangesToProto(changes),
+		Changes:                  changes,
 		ChangeStats:              DiffStatsToProto(changes),
 		AddedVulnerabilities:     added,
 		UnchangedVulnerabilities: unchanged,

--- a/internal/server/diff_handler.go
+++ b/internal/server/diff_handler.go
@@ -130,7 +130,7 @@ func (h *DiffHandler) DiffPackages(
 			DisplayPath: targetExec.Result.Target.DisplayPath,
 		},
 		GeneratedAt: timestamppb.Now(),
-		Changes:     internalproto.PackageChangesToProto(changes),
+		Changes:     changes,
 		Stats:       internalproto.DiffStatsToProto(changes),
 	}
 


### PR DESCRIPTION
## What

Retires `compare.Change`, the hand-written twin of `deputy.diff.v1.PackageChange` that carried JSON tags nothing marshaled (the exact cross-surface-struct smell AGENTS.md warns about). `ComparePackages`/`ComparePackagesWithOptions` now produce the proto message directly, and every consumer speaks the contract type end to end:

- `runDiffPolicies` and the `--format json`/`markdown` paths pass changes through with zero conversion (the per-evaluation `PackageChangesToProto` call is simply gone).
- The server `DiffPackages` handler assigns `Changes: changes` directly.
- The container conversion reads proto fields instead of converting an intermediate struct.
- `PackageChangeToProto`, `PackageChangeFromProto`, `PackageChangesToProto`, `PackageChangesFromProto`, and `ChangeKindToProto` are deleted; `compare.ChangeType.Kind()` bridges the internal classification enum onto the proto vocabulary where the container path still needs it.

Deliberately kept: `compare.ChangeType` remains the internal enum for container-image comparisons, and `ImagePackageChange` inlines the formerly embedded fields rather than adopting the proto pointer type: container comparisons key on flat name/ecosystem pairs, only cross surfaces via explicit proto conversion, and pointer semantics plus `proto.Equal` would cost more than the embed ever did. Its JSON shape is unchanged (same tags, now direct fields).

No behavior changes intended: output ordering, JSON shape, and policy inputs are identical; the full test suite (including the license-enrichment, policy-subject, and markdown renderer tests from the PRs below) passes unchanged apart from mechanical literal updates.

Closes #84.

Part of the #53 stack (based on #85, after #82).

🤖 Generated with [Claude Code](https://claude.com/claude-code)