### PR TITLE
Exit non-zero from deputy secrets when secrets are found

### DIFF
--- a/docs/commands/secrets.md
+++ b/docs/commands/secrets.md
@@ -163,6 +163,7 @@ Supported formats: zip, jar, war, tar, tar.gz, tgz, tar.bz2, tar.xz
 | `--output`, `-o` | Write output to file |
 | `--verify` | Verify if detected secrets are still active |
 | `--no-redact` | Show actual secret values (use with caution) |
+| `--exit-zero` | Exit 0 even when secrets are found (report without failing) |
 | `--include` | Glob pattern for files to include |
 | `--exclude` | Glob pattern for files to exclude |
 
@@ -266,11 +267,16 @@ Verification is supported for:
 ### GitHub Actions
 
 ```yaml
+# Fail the job as soon as a secret is found.
 - name: Scan for secrets
-  run: deputy secrets --format sarif > secrets.sarif
+  run: deputy secrets
+
+# Or report first and gate later: --exit-zero keeps the upload step reachable.
+- name: Scan for secrets (report)
+  run: deputy secrets --format sarif --exit-zero > secrets.sarif
 
 - name: Upload SARIF
-  uses: github/codeql-action/upload-sarif@v2
+  uses: github/codeql-action/upload-sarif@v3
   with:
     sarif_file: secrets.sarif
 ```
@@ -279,14 +285,14 @@ Verification is supported for:
 
 ```yaml
 - name: Check for new secrets
-  run: |
-    deputy secrets --diff ${{ github.event.pull_request.base.sha }} ${{ github.sha }} \
-      --format json > secrets.json
-    if [ $(jq '.secretsFound' secrets.json) -gt 0 ]; then
-      echo "Secrets detected in PR!"
-      exit 1
-    fi
+  env:
+    BASE_SHA: ${{ github.event.pull_request.base.sha }}
+    HEAD_SHA: ${{ github.sha }}
+  run: deputy secrets --diff "$BASE_SHA" "$HEAD_SHA"
 ```
+
+The command exits 1 when the diff introduces a secret, so no manual result
+parsing is needed.
 
 ### VM Image Pipeline
 
@@ -345,8 +351,33 @@ deputy secrets rootfs:///path/to/rootfs.ext4
 
 ## Exit Codes
 
-- `0` - Success (no secrets found)
-- `1` - Secrets found or scan error
+| Code | Meaning |
+| --- | --- |
+| `0` | No secrets found (or `--exit-zero` was passed) |
+| `1` | Secrets found, or the scan failed |
+
+Finding a secret is a failure condition, so `deputy secrets` can gate CI
+directly:
+
+```yaml
+- run: deputy secrets .
+```
+
+Every scan mode follows this contract: directory, file, remote Git URL,
+`--history`, base/target diff, container image, VM image, and archive.
+
+For report-only runs, `--exit-zero` keeps the exit status at 0 so a later step
+still executes, which is the usual pattern when uploading SARIF:
+
+```yaml
+- run: deputy secrets . --format sarif --exit-zero > secrets.sarif
+- uses: github/codeql-action/upload-sarif@v3
+  with:
+    sarif_file: secrets.sarif
+```
+
+A scan error always exits 1 regardless of `--exit-zero`: an unreadable target
+must not look like a clean result.
 
 ## See Also
 

--- a/docs/commands/secrets.md
+++ b/docs/commands/secrets.md
@@ -163,7 +163,7 @@ Supported formats: zip, jar, war, tar, tar.gz, tgz, tar.bz2, tar.xz
 | `--output`, `-o` | Write output to file |
 | `--verify` | Verify if detected secrets are still active |
 | `--no-redact` | Show actual secret values (use with caution) |
-| `--exit-zero` | Exit 0 even when secrets are found (report without failing) |
+| `--always-exit-zero` | Exit 0 even when secrets are found (report without failing) |
 | `--include` | Glob pattern for files to include |
 | `--exclude` | Glob pattern for files to exclude |
 
@@ -271,9 +271,9 @@ Verification is supported for:
 - name: Scan for secrets
   run: deputy secrets
 
-# Or report first and gate later: --exit-zero keeps the upload step reachable.
+# Or report first and gate later: --always-exit-zero keeps the upload step reachable.
 - name: Scan for secrets (report)
-  run: deputy secrets --format sarif --exit-zero > secrets.sarif
+  run: deputy secrets --format sarif --always-exit-zero > secrets.sarif
 
 - name: Upload SARIF
   uses: github/codeql-action/upload-sarif@v3
@@ -353,7 +353,7 @@ deputy secrets rootfs:///path/to/rootfs.ext4
 
 | Code | Meaning |
 | --- | --- |
-| `0` | No secrets found (or `--exit-zero` was passed) |
+| `0` | No secrets found (or `--always-exit-zero` was passed) |
 | `1` | Secrets found, or the scan failed |
 
 Finding a secret is a failure condition, so `deputy secrets` can gate CI
@@ -366,17 +366,17 @@ directly:
 Every scan mode follows this contract: directory, file, remote Git URL,
 `--history`, base/target diff, container image, VM image, and archive.
 
-For report-only runs, `--exit-zero` keeps the exit status at 0 so a later step
+For report-only runs, `--always-exit-zero` keeps the exit status at 0 so a later step
 still executes, which is the usual pattern when uploading SARIF:
 
 ```yaml
-- run: deputy secrets . --format sarif --exit-zero > secrets.sarif
+- run: deputy secrets . --format sarif --always-exit-zero > secrets.sarif
 - uses: github/codeql-action/upload-sarif@v3
   with:
     sarif_file: secrets.sarif
 ```
 
-A scan error always exits 1 regardless of `--exit-zero`: an unreadable target
+A scan error always exits 1 regardless of `--always-exit-zero`: an unreadable target
 must not look like a clean result.
 
 ## See Also

--- a/internal/cli/cmd/secrets.go
+++ b/internal/cli/cmd/secrets.go
@@ -55,7 +55,7 @@ func AddSecretsCommand(root *cobra.Command, c *services.Clients) {
 		excludeGlob    string
 		noRedact       bool
 		verifyFlag     bool
-		exitZero       bool
+		alwaysExitZero bool
 		historyFlag    bool
 		maxCommits     int
 		sinceFlag      string
@@ -222,16 +222,16 @@ CI/CD WORKFLOWS:
   deputy secrets --diff $BASE_SHA $HEAD_SHA --format json
 
   # Scan full history in initial audit (report only, do not fail the step)
-  deputy secrets --history --include-removed --format json --exit-zero > secrets-audit.json
+  deputy secrets --history --include-removed --format json --always-exit-zero > secrets-audit.json
 
 GITHUB ACTIONS INTEGRATION:
   # Fail the job as soon as a secret is found
   - name: Scan for secrets
     run: deputy secrets
 
-  # Or report first and gate later: --exit-zero keeps the upload reachable
+  # Or report first and gate later: --always-exit-zero keeps the upload reachable
   - name: Scan for secrets (report)
-    run: deputy secrets --format sarif --exit-zero > secrets.sarif
+    run: deputy secrets --format sarif --always-exit-zero > secrets.sarif
   - name: Upload SARIF
     uses: github/codeql-action/upload-sarif@v3
     with:
@@ -303,7 +303,7 @@ FILTERING:
 					targetRef = args[2]
 				}
 				found, err := runDiffSecretsScan(ctx, out, errW, target, baseRef, targetRef, formatFlag, noRedact, pathFilter)
-				return secretsExit(found, err, exitZero)
+				return secretsExit(found, err, alwaysExitZero)
 			}
 
 			// Default to current directory for non-diff modes
@@ -326,19 +326,19 @@ FILTERING:
 					includeRemoved: includeRemoved,
 				}
 				found, err := runHistoricalSecretsScan(ctx, out, errW, historyOpts)
-				return secretsExit(found, err, exitZero)
+				return secretsExit(found, err, alwaysExitZero)
 			}
 
 			// Check if target is a VM/rootfs image
 			if isVMImageTarget(target) {
 				found, err := runVMImageSecretsScan(ctx, out, errW, target, formatFlag, noRedact, includeGlob, excludeGlob)
-				return secretsExit(found, err, exitZero)
+				return secretsExit(found, err, alwaysExitZero)
 			}
 
 			// Check if target is a container image reference
 			if isImageTargetScheme(target) || looksLikeContainerReference(target) {
 				found, err := runContainerSecretsScan(ctx, out, errW, target, formatFlag, noRedact, deepScan)
-				return secretsExit(found, err, exitZero)
+				return secretsExit(found, err, alwaysExitZero)
 			}
 
 			// Check if target is a remote Git URL (e.g., github.com/owner/repo)
@@ -405,7 +405,7 @@ FILTERING:
 					default:
 						renderErr = renderSecretsTextWithVerification(out, result, noRedact, nil)
 					}
-					return secretsExit(len(findings), renderErr, exitZero)
+					return secretsExit(len(findings), renderErr, alwaysExitZero)
 				}
 				return fmt.Errorf("accessing target: %w", err)
 			}
@@ -415,7 +415,7 @@ FILTERING:
 				format, _ := secrets.DetectArchiveFormat(target)
 				if format != secrets.FormatUnknown {
 					found, err := runArchiveSecretsScan(ctx, out, errW, target, format, formatFlag, noRedact, deepScan)
-					return secretsExit(found, err, exitZero)
+					return secretsExit(found, err, alwaysExitZero)
 				}
 			}
 
@@ -503,7 +503,7 @@ FILTERING:
 			default:
 				renderErr = renderSecretsTextWithVerification(out, result, noRedact, verificationResults)
 			}
-			return secretsExit(len(findings), renderErr, exitZero)
+			return secretsExit(len(findings), renderErr, alwaysExitZero)
 		},
 	}
 
@@ -512,7 +512,7 @@ FILTERING:
 	secretsCmd.Flags().StringVar(&excludeGlob, "exclude", "", "Comma-separated globs to exclude (e.g., 'vendor/**,node_modules/**')")
 	secretsCmd.Flags().BoolVar(&noRedact, "no-redact", false, "Show actual secret values (use with caution)")
 	secretsCmd.Flags().BoolVar(&verifyFlag, "verify", false, "Verify if detected secrets are still active")
-	secretsCmd.Flags().BoolVar(&exitZero, "exit-zero", false, "Exit 0 even when secrets are found (report without failing)")
+	secretsCmd.Flags().BoolVar(&alwaysExitZero, "always-exit-zero", false, "Exit 0 even when secrets are found (report without failing)")
 
 	// History scanning flags
 	secretsCmd.Flags().BoolVar(&historyFlag, "history", false, "Scan git history for secrets")
@@ -759,16 +759,16 @@ func isBinaryContent(content []byte) bool {
 
 // secretsExit maps a completed secrets scan onto the command's exit status.
 // Finding a secret is a failure condition: the documented contract is exit 1
-// so CI gates catch leaked credentials, and --exit-zero opts out for
+// so CI gates catch leaked credentials, and --always-exit-zero opts out for
 // report-only runs (for example generating SARIF for later upload).
 //
 // Scan errors take precedence and are returned unchanged. A findings exit
 // carries no message because the findings themselves were already rendered.
-func secretsExit(found int, err error, exitZero bool) error {
+func secretsExit(found int, err error, alwaysExitZero bool) error {
 	if err != nil {
 		return err
 	}
-	if found > 0 && !exitZero {
+	if found > 0 && !alwaysExitZero {
 		return deputyerrors.Silent(deputyerrors.WithExitCode(nil, 1))
 	}
 	return nil

--- a/internal/cli/cmd/secrets.go
+++ b/internal/cli/cmd/secrets.go
@@ -18,6 +18,7 @@ import (
 
 	secretsv1 "github.com/temporalio/deputy/gen/deputy/secrets/v1"
 	"github.com/temporalio/deputy/internal/container/image"
+	deputyerrors "github.com/temporalio/deputy/internal/errors"
 	gitx "github.com/temporalio/deputy/internal/gitutil"
 	"github.com/temporalio/deputy/internal/globmatch"
 	internalproto "github.com/temporalio/deputy/internal/proto"
@@ -54,6 +55,7 @@ func AddSecretsCommand(root *cobra.Command, c *services.Clients) {
 		excludeGlob    string
 		noRedact       bool
 		verifyFlag     bool
+		exitZero       bool
 		historyFlag    bool
 		maxCommits     int
 		sinceFlag      string
@@ -296,7 +298,8 @@ FILTERING:
 					baseRef = args[1]
 					targetRef = args[2]
 				}
-				return runDiffSecretsScan(ctx, out, errW, target, baseRef, targetRef, formatFlag, noRedact, pathFilter)
+				found, err := runDiffSecretsScan(ctx, out, errW, target, baseRef, targetRef, formatFlag, noRedact, pathFilter)
+				return secretsExit(found, err, exitZero)
 			}
 
 			// Default to current directory for non-diff modes
@@ -318,17 +321,20 @@ FILTERING:
 					pathFilter:     pathFilter,
 					includeRemoved: includeRemoved,
 				}
-				return runHistoricalSecretsScan(ctx, out, errW, historyOpts)
+				found, err := runHistoricalSecretsScan(ctx, out, errW, historyOpts)
+				return secretsExit(found, err, exitZero)
 			}
 
 			// Check if target is a VM/rootfs image
 			if isVMImageTarget(target) {
-				return runVMImageSecretsScan(ctx, out, errW, target, formatFlag, noRedact, includeGlob, excludeGlob)
+				found, err := runVMImageSecretsScan(ctx, out, errW, target, formatFlag, noRedact, includeGlob, excludeGlob)
+				return secretsExit(found, err, exitZero)
 			}
 
 			// Check if target is a container image reference
 			if isImageTargetScheme(target) || looksLikeContainerReference(target) {
-				return runContainerSecretsScan(ctx, out, errW, target, formatFlag, noRedact, deepScan)
+				found, err := runContainerSecretsScan(ctx, out, errW, target, formatFlag, noRedact, deepScan)
+				return secretsExit(found, err, exitZero)
 			}
 
 			// Check if target is a remote Git URL (e.g., github.com/owner/repo)
@@ -386,14 +392,16 @@ FILTERING:
 						Stats:               stats,
 					}
 
+					var renderErr error
 					switch formatFlag {
 					case "json":
-						return outputSecretsProtoJSON(out, resp.Msg)
+						renderErr = outputSecretsProtoJSON(out, resp.Msg)
 					case "sarif":
-						return renderSecretsSARIF(out, result, target)
+						renderErr = renderSecretsSARIF(out, result, target)
 					default:
-						return renderSecretsTextWithVerification(out, result, noRedact, nil)
+						renderErr = renderSecretsTextWithVerification(out, result, noRedact, nil)
 					}
+					return secretsExit(len(findings), renderErr, exitZero)
 				}
 				return fmt.Errorf("accessing target: %w", err)
 			}
@@ -402,7 +410,8 @@ FILTERING:
 			if !info.IsDir() {
 				format, _ := secrets.DetectArchiveFormat(target)
 				if format != secrets.FormatUnknown {
-					return runArchiveSecretsScan(ctx, out, errW, target, format, formatFlag, noRedact, deepScan)
+					found, err := runArchiveSecretsScan(ctx, out, errW, target, format, formatFlag, noRedact, deepScan)
+					return secretsExit(found, err, exitZero)
 				}
 			}
 
@@ -476,18 +485,21 @@ FILTERING:
 				Stats:               stats,
 			}
 
+			var renderErr error
 			switch formatFlag {
 			case "json":
 				// JSON output when no post-processing was needed
 				if baselinePath == "" && !verifyFlag {
-					return outputSecretsProtoJSON(out, resp.Msg)
+					renderErr = outputSecretsProtoJSON(out, resp.Msg)
+				} else {
+					renderErr = renderSecretsJSONWithVerification(out, result, verificationResults)
 				}
-				return renderSecretsJSONWithVerification(out, result, verificationResults)
 			case "sarif":
-				return renderSecretsSARIF(out, result, target)
+				renderErr = renderSecretsSARIF(out, result, target)
 			default:
-				return renderSecretsTextWithVerification(out, result, noRedact, verificationResults)
+				renderErr = renderSecretsTextWithVerification(out, result, noRedact, verificationResults)
 			}
+			return secretsExit(len(findings), renderErr, exitZero)
 		},
 	}
 
@@ -496,6 +508,7 @@ FILTERING:
 	secretsCmd.Flags().StringVar(&excludeGlob, "exclude", "", "Comma-separated globs to exclude (e.g., 'vendor/**,node_modules/**')")
 	secretsCmd.Flags().BoolVar(&noRedact, "no-redact", false, "Show actual secret values (use with caution)")
 	secretsCmd.Flags().BoolVar(&verifyFlag, "verify", false, "Verify if detected secrets are still active")
+	secretsCmd.Flags().BoolVar(&exitZero, "exit-zero", false, "Exit 0 even when secrets are found (report without failing)")
 
 	// History scanning flags
 	secretsCmd.Flags().BoolVar(&historyFlag, "history", false, "Scan git history for secrets")
@@ -740,6 +753,23 @@ func isBinaryContent(content []byte) bool {
 	return false
 }
 
+// secretsExit maps a completed secrets scan onto the command's exit status.
+// Finding a secret is a failure condition: the documented contract is exit 1
+// so CI gates catch leaked credentials, and --exit-zero opts out for
+// report-only runs (for example generating SARIF for later upload).
+//
+// Scan errors take precedence and are returned unchanged. A findings exit
+// carries no message because the findings themselves were already rendered.
+func secretsExit(found int, err error, exitZero bool) error {
+	if err != nil {
+		return err
+	}
+	if found > 0 && !exitZero {
+		return deputyerrors.Silent(deputyerrors.WithExitCode(nil, 1))
+	}
+	return nil
+}
+
 // outputSecretsProtoJSON writes a secrets response as JSON using protojson.
 func outputSecretsProtoJSON(w io.Writer, resp *secretsv1.ScanResponse) error {
 	opts := internalproto.CLIJSONMarshalOptions()
@@ -822,13 +852,13 @@ type historyScanOptions struct {
 }
 
 // runHistoricalSecretsScan performs git history scanning for secrets.
-func runHistoricalSecretsScan(ctx context.Context, out io.Writer, errW io.Writer, opts historyScanOptions) error {
+func runHistoricalSecretsScan(ctx context.Context, out io.Writer, errW io.Writer, opts historyScanOptions) (int, error) {
 	// Parse since time if provided
 	var sinceTime *time.Time
 	if opts.since != "" {
 		t, err := parseRelativeTime(opts.since)
 		if err != nil {
-			return fmt.Errorf("invalid --since value: %w", err)
+			return 0, fmt.Errorf("invalid --since value: %w", err)
 		}
 		sinceTime = &t
 	}
@@ -838,7 +868,7 @@ func runHistoricalSecretsScan(ctx context.Context, out io.Writer, errW io.Writer
 	if opts.until != "" {
 		t, err := parseRelativeTime(opts.until)
 		if err != nil {
-			return fmt.Errorf("invalid --until value: %w", err)
+			return 0, fmt.Errorf("invalid --until value: %w", err)
 		}
 		untilTime = &t
 	}
@@ -865,7 +895,7 @@ func runHistoricalSecretsScan(ctx context.Context, out io.Writer, errW io.Writer
 
 	scanner, err := secrets.NewHistoryScanner(config)
 	if err != nil {
-		return fmt.Errorf("initializing history scanner: %w", err)
+		return 0, fmt.Errorf("initializing history scanner: %w", err)
 	}
 
 	// Build progress message
@@ -880,29 +910,30 @@ func runHistoricalSecretsScan(ctx context.Context, out io.Writer, errW io.Writer
 
 	result, err := scanner.ScanRepository(ctx, opts.target)
 	if err != nil {
-		return fmt.Errorf("scanning repository history: %w", err)
+		return 0, fmt.Errorf("scanning repository history: %w", err)
 	}
 
+	found := len(result.Findings)
 	if opts.format == "json" {
-		return renderHistoricalSecretsJSON(out, result)
+		return found, renderHistoricalSecretsJSON(out, result)
 	}
-	return renderHistoricalSecretsText(out, result, opts.noRedact)
+	return found, renderHistoricalSecretsText(out, result, opts.noRedact)
 }
 
 // runDiffSecretsScan scans for secrets introduced between two git refs.
 // This is ideal for CI/CD pipelines to detect new secrets in PRs.
-func runDiffSecretsScan(ctx context.Context, out io.Writer, errW io.Writer, repoPath, baseRef, targetRef, format string, noRedact bool, pathFilter string) error {
+func runDiffSecretsScan(ctx context.Context, out io.Writer, errW io.Writer, repoPath, baseRef, targetRef, format string, noRedact bool, pathFilter string) (int, error) {
 	// Open repository
 	repo, err := git.PlainOpen(repoPath)
 	if err != nil {
-		return fmt.Errorf("opening git repository: %w", err)
+		return 0, fmt.Errorf("opening git repository: %w", err)
 	}
 
 	// Resolve base ref (use default branch if empty)
 	if baseRef == "" {
 		defaultBranch, err := gitx.GetDefaultBranch(repo)
 		if err != nil {
-			return fmt.Errorf("determining default branch: %w", err)
+			return 0, fmt.Errorf("determining default branch: %w", err)
 		}
 		baseRef = defaultBranch
 	}
@@ -912,18 +943,18 @@ func runDiffSecretsScan(ctx context.Context, out io.Writer, errW io.Writer, repo
 	if err != nil {
 		suggestions := gitx.GetReferenceSuggestions(repo, baseRef)
 		if len(suggestions) > 0 {
-			return fmt.Errorf("invalid base reference %q: %v\nDid you mean one of these?\n  %s", baseRef, err, strings.Join(suggestions, "\n  "))
+			return 0, fmt.Errorf("invalid base reference %q: %v\nDid you mean one of these?\n  %s", baseRef, err, strings.Join(suggestions, "\n  "))
 		}
-		return fmt.Errorf("invalid base reference %q: %w", baseRef, err)
+		return 0, fmt.Errorf("invalid base reference %q: %w", baseRef, err)
 	}
 
 	targetHash, err := gitx.ResolveRevisionEnhanced(repo, targetRef)
 	if err != nil {
 		suggestions := gitx.GetReferenceSuggestions(repo, targetRef)
 		if len(suggestions) > 0 {
-			return fmt.Errorf("invalid target reference %q: %v\nDid you mean one of these?\n  %s", targetRef, err, strings.Join(suggestions, "\n  "))
+			return 0, fmt.Errorf("invalid target reference %q: %v\nDid you mean one of these?\n  %s", targetRef, err, strings.Join(suggestions, "\n  "))
 		}
-		return fmt.Errorf("invalid target reference %q: %w", targetRef, err)
+		return 0, fmt.Errorf("invalid target reference %q: %w", targetRef, err)
 	}
 
 	fmt.Fprintf(errW, "%s\n", ui.StyleMeta.Render(fmt.Sprintf("Scanning for new secrets: %s → %s", baseRef, targetRef)))
@@ -941,13 +972,13 @@ func runDiffSecretsScan(ctx context.Context, out io.Writer, errW io.Writer, repo
 
 	scanner, err := secrets.NewHistoryScanner(config)
 	if err != nil {
-		return fmt.Errorf("initializing scanner: %w", err)
+		return 0, fmt.Errorf("initializing scanner: %w", err)
 	}
 
 	// Scan for secrets in the diff
 	findings, err := scanner.ScanDiff(ctx, repoPath, baseHash.String(), targetHash.String())
 	if err != nil {
-		return fmt.Errorf("scanning diff: %w", err)
+		return 0, fmt.Errorf("scanning diff: %w", err)
 	}
 
 	// Build result
@@ -962,10 +993,11 @@ func runDiffSecretsScan(ctx context.Context, out io.Writer, errW io.Writer, repo
 		Findings:   findings,
 	}
 
+	found := len(findings)
 	if format == "json" {
-		return renderDiffSecretsJSON(out, result)
+		return found, renderDiffSecretsJSON(out, result)
 	}
-	return renderDiffSecretsText(out, result, noRedact)
+	return found, renderDiffSecretsText(out, result, noRedact)
 }
 
 // SecretsDiffResult contains results from a diff-based secret scan.
@@ -1507,7 +1539,7 @@ func verificationStatusLabel(status secrets.VerificationStatus) string {
 // runContainerSecretsScan scans a container image for secrets in its config,
 // environment variables, build history, labels, and layer contents.
 // When deepScan is true, it also scans files within each layer using SCALIBR.
-func runContainerSecretsScan(ctx context.Context, out io.Writer, errW io.Writer, target, format string, noRedact, deepScan bool) error {
+func runContainerSecretsScan(ctx context.Context, out io.Writer, errW io.Writer, target, format string, noRedact, deepScan bool) (int, error) {
 	fmt.Fprintln(errW, ui.StyleMeta.Render("Loading container image..."))
 
 	// Normalize target to include scheme if needed
@@ -1516,7 +1548,7 @@ func runContainerSecretsScan(ctx context.Context, out io.Writer, errW io.Writer,
 	// Open the container image using Deputy's target system
 	mat, err := targets.Open(ctx, normalizedTarget, nil)
 	if err != nil {
-		return fmt.Errorf("loading container image: %w", err)
+		return 0, fmt.Errorf("loading container image: %w", err)
 	}
 	if mat.Cleanup != nil {
 		defer mat.Cleanup()
@@ -1525,19 +1557,19 @@ func runContainerSecretsScan(ctx context.Context, out io.Writer, errW io.Writer,
 	// Extract ContainerImageData which contains both SCALIBR image and v1.Image
 	imgData, ok := mat.Data.(*providers.ContainerImageData)
 	if !ok || imgData == nil {
-		return fmt.Errorf("target %q is not a container image", target)
+		return 0, fmt.Errorf("target %q is not a container image", target)
 	}
 
 	// Extract v1.Image for config access
 	v1Img := imgData.V1Image
 	if v1Img == nil {
-		return fmt.Errorf("image config extraction not available for this transport; try using docker:// scheme for remote images")
+		return 0, fmt.Errorf("image config extraction not available for this transport; try using docker:// scheme for remote images")
 	}
 
 	// Extract image info (config, metadata, history)
 	imageInfo, err := image.Extract(v1Img)
 	if err != nil {
-		return fmt.Errorf("extracting image configuration: %w", err)
+		return 0, fmt.Errorf("extracting image configuration: %w", err)
 	}
 
 	fmt.Fprintln(errW, ui.StyleMeta.Render("Scanning image configuration for secrets..."))
@@ -1546,7 +1578,7 @@ func runContainerSecretsScan(ctx context.Context, out io.Writer, errW io.Writer,
 	config := secrets.DefaultContainerScanConfig()
 	scanner, err := secrets.NewContainerScanner(config)
 	if err != nil {
-		return fmt.Errorf("initializing container scanner: %w", err)
+		return 0, fmt.Errorf("initializing container scanner: %w", err)
 	}
 
 	// Build ImageConfig from extracted info for the scanner
@@ -1555,7 +1587,7 @@ func runContainerSecretsScan(ctx context.Context, out io.Writer, errW io.Writer,
 	// Scan image config (env vars, labels, history, entrypoint)
 	findings, err := scanner.ScanImageConfig(ctx, imgConfig)
 	if err != nil {
-		return fmt.Errorf("scanning image config: %w", err)
+		return 0, fmt.Errorf("scanning image config: %w", err)
 	}
 
 	// Deep layer scanning if requested
@@ -1565,7 +1597,7 @@ func runContainerSecretsScan(ctx context.Context, out io.Writer, errW io.Writer,
 		// Get SCALIBR layers from the image data
 		layers, err := imgData.Layers()
 		if err != nil {
-			return fmt.Errorf("getting image layers for deep scan: %w", err)
+			return 0, fmt.Errorf("getting image layers for deep scan: %w", err)
 		}
 
 		if len(layers) > 0 {
@@ -1618,21 +1650,22 @@ func runContainerSecretsScan(ctx context.Context, out io.Writer, errW io.Writer,
 		Stats:         stats,
 	}
 
+	found := len(findings)
 	if format == "json" {
-		return renderContainerSecretsJSON(out, result)
+		return found, renderContainerSecretsJSON(out, result)
 	}
-	return renderContainerSecretsText(out, result, noRedact)
+	return found, renderContainerSecretsText(out, result, noRedact)
 }
 
 // runVMImageSecretsScan scans a VM disk image or rootfs for secrets.
 // It opens the disk image, extracts the filesystem, and walks it to find secrets.
-func runVMImageSecretsScan(ctx context.Context, out io.Writer, errW io.Writer, target, format string, noRedact bool, includeGlob, excludeGlob string) error {
+func runVMImageSecretsScan(ctx context.Context, out io.Writer, errW io.Writer, target, format string, noRedact bool, includeGlob, excludeGlob string) (int, error) {
 	fmt.Fprintln(errW, ui.StyleMeta.Render("Loading VM image..."))
 
 	// Open the VM image using Deputy's target system
 	mat, err := targets.Open(ctx, target, nil)
 	if err != nil {
-		return fmt.Errorf("loading VM image: %w", err)
+		return 0, fmt.Errorf("loading VM image: %w", err)
 	}
 	if mat.Cleanup != nil {
 		defer mat.Cleanup()
@@ -1640,7 +1673,7 @@ func runVMImageSecretsScan(ctx context.Context, out io.Writer, errW io.Writer, t
 
 	// Verify we got a filesystem
 	if mat.FS == nil {
-		return fmt.Errorf("VM image %q did not provide a filesystem", target)
+		return 0, fmt.Errorf("VM image %q did not provide a filesystem", target)
 	}
 
 	fmt.Fprintln(errW, ui.StyleMeta.Render("Scanning VM filesystem for secrets..."))
@@ -1648,13 +1681,13 @@ func runVMImageSecretsScan(ctx context.Context, out io.Writer, errW io.Writer, t
 	// Create secret detection engine
 	engine, err := secrets.NewEngine()
 	if err != nil {
-		return fmt.Errorf("creating secrets engine: %w", err)
+		return 0, fmt.Errorf("creating secrets engine: %w", err)
 	}
 
 	// Scan the filesystem for secrets
 	findings, filesScanned, err := scanFilesystem(ctx, engine, mat.FS, includeGlob, excludeGlob)
 	if err != nil {
-		return fmt.Errorf("scanning VM filesystem: %w", err)
+		return 0, fmt.Errorf("scanning VM filesystem: %w", err)
 	}
 
 	// Build stats
@@ -1677,6 +1710,8 @@ func runVMImageSecretsScan(ctx context.Context, out io.Writer, errW io.Writer, t
 		Stats:               stats,
 	}
 
+	found := len(findings)
+
 	// Add provenance info if available
 	if mat.Meta.Provenance != nil {
 		if format == "json" {
@@ -1691,17 +1726,17 @@ func runVMImageSecretsScan(ctx context.Context, out io.Writer, errW io.Writer, t
 			}
 			enc := json.NewEncoder(out)
 			enc.SetIndent("", "  ")
-			return enc.Encode(vmResult)
+			return found, enc.Encode(vmResult)
 		}
 	}
 
 	if format == "json" {
 		enc := json.NewEncoder(out)
 		enc.SetIndent("", "  ")
-		return enc.Encode(result)
+		return found, enc.Encode(result)
 	}
 
-	return renderVMSecretsText(out, result, mat.Meta.Provenance, noRedact)
+	return found, renderVMSecretsText(out, result, mat.Meta.Provenance, noRedact)
 }
 
 // scanFilesystem scans an fs.FS for secrets.
@@ -2083,7 +2118,7 @@ func normalizeContainerTarget(target string) string {
 
 // runArchiveSecretsScan scans an archive file (zip, tar, tar.gz, etc.) for secrets.
 // When deepScan is true, it also scans binary files for embedded strings.
-func runArchiveSecretsScan(ctx context.Context, out io.Writer, errW io.Writer, target string, format secrets.ArchiveFormat, outputFormat string, noRedact, deepScan bool) error {
+func runArchiveSecretsScan(ctx context.Context, out io.Writer, errW io.Writer, target string, format secrets.ArchiveFormat, outputFormat string, noRedact, deepScan bool) (int, error) {
 	fmt.Fprintf(errW, "%s\n", ui.StyleMeta.Render(fmt.Sprintf("Scanning %s archive: %s", format, filepath.Base(target))))
 
 	// Create archive scanner with configuration
@@ -2094,13 +2129,13 @@ func runArchiveSecretsScan(ctx context.Context, out io.Writer, errW io.Writer, t
 
 	scanner, err := secrets.NewArchiveScanner(config)
 	if err != nil {
-		return fmt.Errorf("initializing archive scanner: %w", err)
+		return 0, fmt.Errorf("initializing archive scanner: %w", err)
 	}
 
 	// Scan the archive
 	result, err := scanner.ScanArchive(ctx, target)
 	if err != nil {
-		return fmt.Errorf("scanning archive: %w", err)
+		return 0, fmt.Errorf("scanning archive: %w", err)
 	}
 
 	// Report any non-fatal errors
@@ -2112,10 +2147,11 @@ func runArchiveSecretsScan(ctx context.Context, out io.Writer, errW io.Writer, t
 		fmt.Fprintf(errW, "Warning: scan truncated: %s\n", result.TruncationReason)
 	}
 
+	found := len(result.Findings)
 	if outputFormat == "json" {
-		return renderArchiveSecretsJSON(out, result)
+		return found, renderArchiveSecretsJSON(out, result)
 	}
-	return renderArchiveSecretsText(out, result, noRedact)
+	return found, renderArchiveSecretsText(out, result, noRedact)
 }
 
 // renderArchiveSecretsJSON outputs archive scan results as JSON.

--- a/internal/cli/cmd/secrets.go
+++ b/internal/cli/cmd/secrets.go
@@ -221,15 +221,19 @@ CI/CD WORKFLOWS:
   # Check for new secrets in PR (exit non-zero if found)
   deputy secrets --diff $BASE_SHA $HEAD_SHA --format json
 
-  # Scan full history in initial audit
-  deputy secrets --history --include-removed --format json > secrets-audit.json
+  # Scan full history in initial audit (report only, do not fail the step)
+  deputy secrets --history --include-removed --format json --exit-zero > secrets-audit.json
 
 GITHUB ACTIONS INTEGRATION:
-  # Upload SARIF to GitHub Code Scanning
+  # Fail the job as soon as a secret is found
   - name: Scan for secrets
-    run: deputy secrets --format sarif > secrets.sarif
+    run: deputy secrets
+
+  # Or report first and gate later: --exit-zero keeps the upload reachable
+  - name: Scan for secrets (report)
+    run: deputy secrets --format sarif --exit-zero > secrets.sarif
   - name: Upload SARIF
-    uses: github/codeql-action/upload-sarif@v2
+    uses: github/codeql-action/upload-sarif@v3
     with:
       sarif_file: secrets.sarif
 

--- a/internal/cli/cmd/secrets_exit_test.go
+++ b/internal/cli/cmd/secrets_exit_test.go
@@ -1,0 +1,140 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	deputyerrors "github.com/temporalio/deputy/internal/errors"
+)
+
+// TestSecretsExit pins the documented CI contract for `deputy secrets`:
+// finding a secret must exit non-zero so a pipeline gate fails, a clean scan
+// must exit 0, and scan errors must surface unchanged rather than being
+// flattened into the findings signal.
+func TestSecretsExit(t *testing.T) {
+	scanErr := errors.New("scanning target: boom")
+
+	tests := []struct {
+		name     string
+		found    int
+		err      error
+		exitZero bool
+		wantCode int
+		wantErr  error // non-nil means the exact error must pass through
+		// wantSilent asserts the CLI suppresses printing, because the
+		// findings were already rendered to the user.
+		wantSilent bool
+	}{
+		{
+			name:     "clean scan exits zero",
+			found:    0,
+			wantCode: 0,
+		},
+		{
+			name:       "findings exit one silently",
+			found:      1,
+			wantCode:   1,
+			wantSilent: true,
+		},
+		{
+			name:       "many findings still exit one",
+			found:      42,
+			wantCode:   1,
+			wantSilent: true,
+		},
+		{
+			name:     "exit-zero suppresses the findings exit",
+			found:    7,
+			exitZero: true,
+			wantCode: 0,
+		},
+		{
+			name:     "scan error propagates unchanged",
+			found:    0,
+			err:      scanErr,
+			wantCode: 1,
+			wantErr:  scanErr,
+		},
+		{
+			name: "scan error wins over findings",
+			// A partial scan that both found secrets and failed must report
+			// the failure: exiting on the findings alone would imply the scan
+			// completed.
+			found:    3,
+			err:      scanErr,
+			wantCode: 1,
+			wantErr:  scanErr,
+		},
+		{
+			name:     "scan error is not suppressed by exit-zero",
+			found:    0,
+			err:      scanErr,
+			exitZero: true,
+			wantCode: 1,
+			wantErr:  scanErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := secretsExit(tt.found, tt.err, tt.exitZero)
+
+			if code := deputyerrors.ExitCode(got); code != tt.wantCode {
+				t.Errorf("ExitCode = %d, want %d (err %v)", code, tt.wantCode, got)
+			}
+
+			if tt.wantErr != nil {
+				if !errors.Is(got, tt.wantErr) {
+					t.Errorf("error = %v, want it to wrap %v", got, tt.wantErr)
+				}
+				return
+			}
+
+			if tt.wantCode == 0 && got != nil {
+				t.Errorf("expected nil error for a zero exit, got %v", got)
+			}
+
+			if tt.wantSilent {
+				var silent *deputyerrors.SilentError
+				if !errors.As(got, &silent) {
+					t.Errorf("findings exit must be silent so the CLI does not print over the report, got %#v", got)
+				}
+			}
+		})
+	}
+}
+
+// TestSecretsExit_FindingsExitCarriesNoCause guards the user-visible result of
+// a findings exit: the process fails, but nothing extra is printed after the
+// rendered report. The CLI suppresses printing for SilentError, and the exit
+// wraps no underlying failure, so there is no diagnostic to lose.
+func TestSecretsExit_FindingsExitCarriesNoCause(t *testing.T) {
+	err := secretsExit(1, nil, false)
+	if err == nil {
+		t.Fatal("expected a non-nil error to carry the exit code")
+	}
+
+	var silent *deputyerrors.SilentError
+	if !errors.As(err, &silent) {
+		t.Fatalf("findings exit must be silent, got %#v", err)
+	}
+
+	var exit *deputyerrors.ExitError
+	if !errors.As(err, &exit) {
+		t.Fatalf("findings exit must carry an exit code, got %#v", err)
+	}
+	if exit.Cause != nil {
+		t.Errorf("findings exit should signal only, wrapping no error; got cause %v", exit.Cause)
+	}
+}
+
+// TestSecretsExit_WrappedErrorKeepsCustomExitCode verifies the helper does not
+// clobber an exit code a scan path already chose.
+func TestSecretsExit_WrappedErrorKeepsCustomExitCode(t *testing.T) {
+	custom := deputyerrors.WithExitCode(fmt.Errorf("interrupted"), 130)
+	got := secretsExit(5, custom, false)
+	if code := deputyerrors.ExitCode(got); code != 130 {
+		t.Errorf("ExitCode = %d, want 130 (the scan's own code must win)", code)
+	}
+}

--- a/internal/cli/cmd/secrets_exit_test.go
+++ b/internal/cli/cmd/secrets_exit_test.go
@@ -16,12 +16,12 @@ func TestSecretsExit(t *testing.T) {
 	scanErr := errors.New("scanning target: boom")
 
 	tests := []struct {
-		name     string
-		found    int
-		err      error
-		exitZero bool
-		wantCode int
-		wantErr  error // non-nil means the exact error must pass through
+		name           string
+		found          int
+		err            error
+		alwaysExitZero bool
+		wantCode       int
+		wantErr        error // non-nil means the exact error must pass through
 		// wantSilent asserts the CLI suppresses printing, because the
 		// findings were already rendered to the user.
 		wantSilent bool
@@ -44,10 +44,10 @@ func TestSecretsExit(t *testing.T) {
 			wantSilent: true,
 		},
 		{
-			name:     "exit-zero suppresses the findings exit",
-			found:    7,
-			exitZero: true,
-			wantCode: 0,
+			name:           "always-exit-zero suppresses the findings exit",
+			found:          7,
+			alwaysExitZero: true,
+			wantCode:       0,
 		},
 		{
 			name:     "scan error propagates unchanged",
@@ -67,18 +67,18 @@ func TestSecretsExit(t *testing.T) {
 			wantErr:  scanErr,
 		},
 		{
-			name:     "scan error is not suppressed by exit-zero",
-			found:    0,
-			err:      scanErr,
-			exitZero: true,
-			wantCode: 1,
-			wantErr:  scanErr,
+			name:           "scan error is not suppressed by always-exit-zero",
+			found:          0,
+			err:            scanErr,
+			alwaysExitZero: true,
+			wantCode:       1,
+			wantErr:        scanErr,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := secretsExit(tt.found, tt.err, tt.exitZero)
+			got := secretsExit(tt.found, tt.err, tt.alwaysExitZero)
 
 			if code := deputyerrors.ExitCode(got); code != tt.wantCode {
 				t.Errorf("ExitCode = %d, want %d (err %v)", code, tt.wantCode, got)


### PR DESCRIPTION
## The bug

`deputy secrets` rendered its findings and returned `nil`, so it **exited 0 even when it detected leaked credentials**. The documented contract is exit 1 on findings (`docs/commands/secrets.md`), and the command has no `--policy` flag, so there was no way at all to gate CI on a leaked secret: every pipeline running `deputy secrets` passed silently.

Evidence that this was load-bearing: the generated pre-commit hook works around it by running the scan with `|| true` and then grepping the rendered output for `"Secrets Detected\|secretsFound.*[1-9]"` to decide whether to block a commit (`internal/secrets/hooks.go`).

## The fix

Every scan mode now reports its finding count and a single helper maps that onto the exit status:

```go
func secretsExit(found int, err error, exitZero bool) error
```

Covered modes: directory, file, remote Git URL, `--history`, base/target ref diff, container image, VM image, and archive. Previously each rendered and returned nil independently, so a fix at one call site would have left the others broken.

Semantics, each pinned by a test:

- Findings present: exit 1, **silently**. The error wraps no cause, and the CLI's `SilentError` path suppresses printing, so nothing is emitted after the report. Verified end to end: stderr is empty.
- Clean scan: exit 0.
- Scan error: propagates unchanged and keeps precedence over findings, so an unreadable target never looks like a clean result, and a path that already chose a specific exit code (for example 130) keeps it.
- `--exit-zero`: report-only runs exit 0, which keeps a later SARIF upload step reachable. Scan errors still exit 1.

## Behavior change

This is intentionally breaking for anyone whose pipeline currently passes *because* of the bug: those jobs were reporting leaked credentials and exiting 0. They will now fail, which is the documented and expected behavior. `--exit-zero` is the escape hatch for report-only usage.

Docs updated: the exit-code table, the new flag, and two CI examples that were stale under the fixed behavior (the SARIF example would have skipped its upload step; the diff example hand-rolled a `jq` gate that is now redundant). The diff example also moves its `${{ }}` interpolation into `env:`, per the repo's own injection-safe guidance.

## Naming

`--exit-zero` follows the convention used by several linters. Happy to rename before merge if you prefer something else.

## Follow-ups (to be filed as issues)

- The generated pre-commit hook can drop its output-scraping and check the exit code now.
- Findings and tool errors both exit 1 across the CLI, so a CI job cannot distinguish "found secrets" from "the scanner crashed". Worth deciding whether findings deserve a distinct code repo-wide (`pin` already uses 2 for suspicious pins).
- `deputy secrets` has no `--policy` flag even though `secrets_report` and `secrets_finding` policy entrypoints are defined, so severity-based gating is not expressible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)