### PR TITLE
Drop .orValue() from non-optional policy receivers

### DIFF
--- a/internal/policy/source_test.go
+++ b/internal/policy/source_test.go
@@ -110,27 +110,33 @@ func TestLoadStructuredBundle(t *testing.T) {
 	}
 }
 
+// shippedPolicyPaths returns every policy bundle this repo ships, resolving the
+// repo root from whichever directory the test binary runs in. Both the examples
+// and the gates Deputy runs on its own PRs are included: policy/ci was outside
+// the corpus when all three gates broke on a cel-go bump, so anything asserting
+// a property of "our policies" has to cover it.
+func shippedPolicyPaths(t *testing.T) []string {
+	t.Helper()
+	for _, prefix := range []string{"policy", "../policy", "../../policy"} {
+		var paths []string
+		for _, dir := range []string{"examples", "ci"} {
+			matches, err := filepath.Glob(filepath.Join(prefix, dir, "*.yaml"))
+			if err != nil {
+				t.Fatalf("glob %s/%s: %v", prefix, dir, err)
+			}
+			paths = append(paths, matches...)
+		}
+		if len(paths) > 0 {
+			return paths
+		}
+	}
+	t.Fatal("no shipped policies found")
+	return nil
+}
+
 func TestExampleBundlesCompile(t *testing.T) {
 	t.Parallel()
-	patterns := []string{
-		"policy/examples/*.yaml",
-		"../policy/examples/*.yaml",
-		"../../policy/examples/*.yaml",
-	}
-	var paths []string
-	for _, pattern := range patterns {
-		matches, err := filepath.Glob(pattern)
-		if err != nil {
-			t.Fatalf("glob %s: %v", pattern, err)
-		}
-		if len(matches) > 0 {
-			paths = matches
-			break
-		}
-	}
-	if len(paths) == 0 {
-		t.Fatalf("no example policies found")
-	}
+	paths := shippedPolicyPaths(t)
 	extraVars := []string{"licenses"}
 	for _, path := range paths {
 		t.Run(filepath.Base(path), func(t *testing.T) {
@@ -147,5 +153,87 @@ func TestExampleBundlesCompile(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// receiverOf returns the receiver expression immediately preceding the
+// ".orValue(" that ends at idx, by walking back over the identifier/selector
+// chain. Stops at anything that cannot be part of a receiver path so that
+// "a && b.orValue(x)" yields "b", not "a && b".
+func receiverOf(expr string, idx int) string {
+	start := idx
+	depth := 0
+	for start > 0 {
+		c := expr[start-1]
+		switch {
+		case c == ')' || c == ']':
+			depth++
+		case c == '(' || c == '[':
+			if depth == 0 {
+				return expr[start:idx]
+			}
+			depth--
+		case depth > 0:
+			// inside a nested call or index; keep consuming
+		case c == '.' || c == '?' || c == '_' ||
+			(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9'):
+			// part of the receiver path
+		default:
+			return expr[start:idx]
+		}
+		start--
+	}
+	return expr[start:idx]
+}
+
+// TestNoOrValueOnNonOptional pins the rule that .orValue() may only be applied
+// to something that is actually optional, meaning the receiver chain contains
+// a ?. select or a [?] index.
+//
+// Applying it to a plain variable is a silent no-op, not a default: through
+// cel-go v0.26 the runtime handed the receiver back without ever evaluating
+// the argument, and it does not rescue an unbound variable either, because
+// attribute resolution fails before the call. cel-go v0.28 turned the same
+// expression into "no such overload", which broke all three CI gates at once.
+//
+// Neither a compile check nor an eval check catches this on the pinned
+// version, since the bad form both compiles and evaluates there. A static
+// check is the only thing that holds across cel-go versions.
+func TestNoOrValueOnNonOptional(t *testing.T) {
+	t.Parallel()
+	for _, path := range shippedPolicyPaths(t) {
+		t.Run(filepath.Base(path), func(t *testing.T) {
+			body, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			for i, line := range strings.Split(string(body), "\n") {
+				if strings.HasPrefix(strings.TrimSpace(line), "#") {
+					continue // comment, not an expression
+				}
+				for _, m := range orValueSites(line) {
+					if !strings.Contains(m, "?") {
+						t.Errorf("%s:%d: .orValue() applied to non-optional receiver %q; "+
+							"guard the hop that can actually be absent (x.?y.orValue(z)) or drop the call",
+							filepath.Base(path), i+1, m)
+					}
+				}
+			}
+		})
+	}
+}
+
+// orValueSites returns the receiver of every ".orValue(" occurrence in line.
+func orValueSites(line string) []string {
+	const marker = ".orValue("
+	var out []string
+	for off := 0; ; {
+		j := strings.Index(line[off:], marker)
+		if j < 0 {
+			return out
+		}
+		at := off + j
+		out = append(out, receiverOf(line, at))
+		off = at + len(marker)
 	}
 }

--- a/internal/policy/source_test.go
+++ b/internal/policy/source_test.go
@@ -313,6 +313,21 @@ func TestNoOrValueOnNonOptional(t *testing.T) {
 				},
 			},
 			{
+				name:          "ternary receiver is flagged",
+				when:          `size((change.added ? packages : changes).orValue([])) > 0`,
+				wantReceivers: []string{`change.added ? packages : changes`},
+			},
+			{
+				name:          "plain call with an optional argument is flagged",
+				when:          `size(base64.decode(config.?registry.orValue("")).orValue(b"")) > 0`,
+				wantReceivers: []string{`base64.decode(config.?registry.orValue(""))`},
+			},
+			{
+				name:          "string literal containing a question mark is flagged",
+				when:          `size(config["?"].orValue([])) > 0`,
+				wantReceivers: []string{`config["?"]`},
+			},
+			{
 				name:          "chained orValue on an already defaulted value is flagged",
 				when:          `jwt.?sub.orValue("").orValue("fallback") == ""`,
 				wantReceivers: []string{`jwt.?sub.orValue("")`},

--- a/internal/policy/source_test.go
+++ b/internal/policy/source_test.go
@@ -1,10 +1,17 @@
 package policy
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
+	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/google/cel-go/cel"
+	celast "github.com/google/cel-go/common/ast"
+	"github.com/google/cel-go/parser"
 )
 
 func TestExtractPolicyName(t *testing.T) {
@@ -156,41 +163,100 @@ func TestExampleBundlesCompile(t *testing.T) {
 	}
 }
 
-// receiverOf returns the receiver expression immediately preceding the
-// ".orValue(" that ends at idx, by walking back over the identifier/selector
-// chain. Stops at anything that cannot be part of a receiver path so that
-// "a && b.orValue(x)" yields "b", not "a && b".
-func receiverOf(expr string, idx int) string {
-	start := idx
-	depth := 0
-	for start > 0 {
-		c := expr[start-1]
-		switch {
-		case c == ')' || c == ']':
-			depth++
-		case c == '(' || c == '[':
-			if depth == 0 {
-				return expr[start:idx]
-			}
-			depth--
-		case depth > 0:
-			// inside a nested call or index; keep consuming
-		case c == '.' || c == '?' || c == '_' ||
-			(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9'):
-			// part of the receiver path
-		default:
-			return expr[start:idx]
+// isOptionalProducing reports whether expr syntactically yields a CEL optional
+// value and is therefore a legal receiver for .orValue(). The accepted set is
+// what the shipped corpus legitimately contains plus the unambiguous optional
+// constructors, matched against cel-go's parsed representation:
+//
+//   - an optional field select such as jwt.?sub (the "_?._" call)
+//   - an optional index such as m[?k] (the "_[?_]" call)
+//   - optional.of / optional.ofNonZeroValue / optional.none, which parse as
+//     member calls on the bare identifier "optional"
+//   - a member .or() call whose receiver is optional, since or() stays optional
+//   - a plain field select on an optional operand, since selection propagates
+//     optionality (vulnerability.?package.direct)
+//
+// Everything else (a plain identifier, an unguarded select, a comprehension
+// result such as filter(...), a non-optional call) does not produce an
+// optional, so .orValue() on it is a violation. If a new legitimate optional
+// producer ever enters the corpus (for example plain indexing into an
+// optional), extend this set deliberately rather than loosening the check.
+func isOptionalProducing(expr celast.Expr) bool {
+	switch expr.Kind() {
+	case celast.CallKind:
+		call := expr.AsCall()
+		switch call.FunctionName() {
+		case "_?._", "_[?_]":
+			return true
+		case "or":
+			return call.IsMemberFunction() && isOptionalProducing(call.Target())
+		case "of", "ofNonZeroValue", "none":
+			return call.IsMemberFunction() &&
+				call.Target().Kind() == celast.IdentKind &&
+				call.Target().AsIdent() == "optional"
 		}
-		start--
+		return false
+	case celast.SelectKind:
+		sel := expr.AsSelect()
+		return !sel.IsTestOnly() && isOptionalProducing(sel.Operand())
+	default:
+		return false
 	}
-	return expr[start:idx]
+}
+
+// orValueViolations parses body with the same environment options the engine
+// compiles policies with (optional syntax, macros, extension libraries) and
+// returns the source text of every .orValue() receiver that is not
+// optional-producing per isOptionalProducing.
+//
+// It walks the parsed AST rather than the checked one on purpose: the property
+// is purely syntactic, the pinned checker accepts the broken form on dyn
+// receivers (so checking adds no signal), and some broken shapes fail the
+// checker outright, which would bury the precise violation under an unrelated
+// type error.
+func orValueViolations(t *testing.T, body string) []string {
+	t.Helper()
+	env, err := envWithNames(nil)
+	if err != nil {
+		t.Fatalf("build CEL env: %v", err)
+	}
+	// Macro call tracking only affects source metadata; it lets the unparser
+	// render a comprehension back as the filter/exists/map call the author
+	// wrote instead of failing on the expanded loop.
+	env, err = env.Extend(cel.EnableMacroCallTracking())
+	if err != nil {
+		t.Fatalf("extend CEL env: %v", err)
+	}
+	parsed, iss := env.Parse(body)
+	if iss != nil && iss.Err() != nil {
+		t.Fatalf("parse policy: %v", iss.Err())
+	}
+	rep := parsed.NativeRep()
+	var violations []string
+	celast.PreOrderVisit(rep.Expr(), celast.NewExprVisitor(func(e celast.Expr) {
+		if e.Kind() != celast.CallKind {
+			return
+		}
+		call := e.AsCall()
+		if call.FunctionName() != "orValue" || !call.IsMemberFunction() {
+			return
+		}
+		if isOptionalProducing(call.Target()) {
+			return
+		}
+		receiver, err := parser.Unparse(call.Target(), rep.SourceInfo())
+		if err != nil {
+			receiver = fmt.Sprintf("(unrenderable expression, kind %d)", call.Target().Kind())
+		}
+		violations = append(violations, receiver)
+	}))
+	return violations
 }
 
 // TestNoOrValueOnNonOptional pins the rule that .orValue() may only be applied
-// to something that is actually optional, meaning the receiver chain contains
-// a ?. select or a [?] index.
+// to an expression that actually produces a CEL optional.
 //
-// Applying it to a plain variable is a silent no-op, not a default: through
+// Applying it to anything else is a silent no-op, not a default: through
 // cel-go v0.26 the runtime handed the receiver back without ever evaluating
 // the argument, and it does not rescue an unbound variable either, because
 // attribute resolution fails before the call. cel-go v0.28 turned the same
@@ -198,42 +264,88 @@ func receiverOf(expr string, idx int) string {
 //
 // Neither a compile check nor an eval check catches this on the pinned
 // version, since the bad form both compiles and evaluates there. A static
-// check is the only thing that holds across cel-go versions.
+// check is the only thing that holds across cel-go versions, so this test
+// walks the parsed AST of every shipped policy (after structured-YAML
+// expansion, the same source the engine evaluates) and classifies every
+// .orValue() receiver. The detector subtests prove the walk both fires on the
+// broken shapes and stays quiet on legitimate ones.
 func TestNoOrValueOnNonOptional(t *testing.T) {
 	t.Parallel()
 	for _, path := range shippedPolicyPaths(t) {
 		t.Run(filepath.Base(path), func(t *testing.T) {
-			body, err := os.ReadFile(path)
+			t.Parallel()
+			sources, err := LoadSources([]string{path})
 			if err != nil {
-				t.Fatalf("read %s: %v", path, err)
+				t.Fatalf("LoadSources(%s): %v", path, err)
 			}
-			for i, line := range strings.Split(string(body), "\n") {
-				if strings.HasPrefix(strings.TrimSpace(line), "#") {
-					continue // comment, not an expression
-				}
-				for _, m := range orValueSites(line) {
-					if !strings.Contains(m, "?") {
-						t.Errorf("%s:%d: .orValue() applied to non-optional receiver %q; "+
-							"guard the hop that can actually be absent (x.?y.orValue(z)) or drop the call",
-							filepath.Base(path), i+1, m)
-					}
+			for _, src := range sources {
+				for _, receiver := range orValueViolations(t, src.Body) {
+					t.Errorf("%s: .orValue() applied to non-optional receiver %q; "+
+						"guard the hop that can actually be absent (x.?y.orValue(z)) or drop the call",
+						src.Name, receiver)
 				}
 			}
 		})
 	}
-}
-
-// orValueSites returns the receiver of every ".orValue(" occurrence in line.
-func orValueSites(line string) []string {
-	const marker = ".orValue("
-	var out []string
-	for off := 0; ; {
-		j := strings.Index(line[off:], marker)
-		if j < 0 {
-			return out
+	t.Run("detector", func(t *testing.T) {
+		t.Parallel()
+		// The corpus above only proves the absence of false positives. These
+		// scratch bundles, expanded through the same structured-YAML path as
+		// shipped policies, prove the detector fires on the broken shapes,
+		// including the nested-lambda shape a line-based scan cannot separate
+		// from its surroundings, and stays quiet on a guarded chain reflowed
+		// across lines.
+		tests := []struct {
+			name          string
+			when          string
+			wantReceivers []string
+		}{
+			{
+				name:          "plain variable receiver is flagged",
+				when:          `size(vulnerabilities.orValue([])) > 0`,
+				wantReceivers: []string{"vulnerabilities"},
+			},
+			{
+				name: "inner guarded lambda does not vouch for outer comprehension",
+				when: `changesList.filter(c, c.?type.orValue("").lowerAscii() == "added").orValue([]) == []`,
+				wantReceivers: []string{
+					`changesList.filter(c, c.?type.orValue("").lowerAscii() == "added")`,
+				},
+			},
+			{
+				name:          "chained orValue on an already defaulted value is flagged",
+				when:          `jwt.?sub.orValue("").orValue("fallback") == ""`,
+				wantReceivers: []string{`jwt.?sub.orValue("")`},
+			},
+			{
+				name: "guarded chain reflowed across lines passes",
+				when: "jwt.?sub\n          .orValue(\"\") == \"\"",
+			},
+			{
+				name: "optional index and or-chain pass",
+				when: `config[?"registry"].or(optional.of("default")).orValue("") == ""`,
+			},
+			{
+				name: "select through optional passes",
+				when: `vulnerability.?package.direct.orValue(false)`,
+			},
 		}
-		at := off + j
-		out = append(out, receiverOf(line, at))
-		off = at + len(marker)
-	}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				t.Parallel()
+				bundleYAML := fmt.Sprintf("policies:\n  - name: scratch\n    rules:\n      - action: deny\n        when: %s\n", strconv.Quote(test.when))
+				sources, err := ParseStructuredSources([]byte(bundleYAML), "scratch.yaml")
+				if err != nil {
+					t.Fatalf("ParseStructuredSources: %v", err)
+				}
+				var got []string
+				for _, src := range sources {
+					got = append(got, orValueViolations(t, src.Body)...)
+				}
+				if !slices.Equal(got, test.wantReceivers) {
+					t.Errorf("orValueViolations() = %q, want %q", got, test.wantReceivers)
+				}
+			})
+		}
+	})
 }

--- a/policy/ci/pr-review.yaml
+++ b/policy/ci/pr-review.yaml
@@ -26,7 +26,7 @@ policies:
     entrypoints: [diff_report]
     rules:
       - action: deny
-        when: vulnerabilities.orValue([]).exists(v, v.advisory.severity.level in [severity.critical, severity.high])
+        when: vulnerabilities.exists(v, v.advisory.severity.level in [severity.critical, severity.high])
         reason: New dependency introduces critical/high severity vulnerabilities
         remediation: Choose a version or package without known vulnerabilities
 

--- a/policy/ci/release-gate.yaml
+++ b/policy/ci/release-gate.yaml
@@ -28,7 +28,7 @@ policies:
     entrypoints: [scan_report]
     rules:
       - action: deny
-        when: vulnerabilities.orValue([]).exists(v, v.advisory.severity.level in [severity.critical, severity.high])
+        when: vulnerabilities.exists(v, v.advisory.severity.level in [severity.critical, severity.high])
         reason: Cannot release with critical/high severity vulnerabilities
         remediation: Resolve all critical and high severity vulnerabilities before release
 
@@ -38,7 +38,7 @@ policies:
     entrypoints: [scan_report]
     rules:
       - action: deny
-        when: vulnerabilities.orValue([]).exists(v, v.package.direct && v.advisory.severity.level == severity.medium)
+        when: vulnerabilities.exists(v, v.package.direct && v.advisory.severity.level == severity.medium)
         reason: Direct dependency has medium severity vulnerability
         remediation: Update or replace the affected direct dependency
 

--- a/policy/ci/security-gate.yaml
+++ b/policy/ci/security-gate.yaml
@@ -26,7 +26,7 @@ policies:
     entrypoints: [scan_report]
     rules:
       - action: deny
-        when: vulnerabilities.orValue([]).exists(v, v.advisory.severity.level == severity.critical)
+        when: vulnerabilities.exists(v, v.advisory.severity.level == severity.critical)
         reason: Critical vulnerability blocks CI pipeline
         remediation: Upgrade affected packages to patched versions
 
@@ -36,7 +36,7 @@ policies:
     entrypoints: [scan_report]
     rules:
       - action: deny
-        when: vulnerabilities.orValue([]).exists(v, v.advisory.severity.level == severity.high && size(v.advisory.fixed_versions) > 0)
+        when: vulnerabilities.exists(v, v.advisory.severity.level == severity.high && size(v.advisory.fixed_versions) > 0)
         reason: High severity vulnerability has an available fix
         remediation: Upgrade to a fixed version
 
@@ -46,6 +46,6 @@ policies:
     entrypoints: [scan_report]
     rules:
       - action: warn
-        when: vulnerabilities.orValue([]).exists(v, v.advisory.severity.level == severity.high && size(v.advisory.fixed_versions) == 0)
+        when: vulnerabilities.exists(v, v.advisory.severity.level == severity.high && size(v.advisory.fixed_versions) == 0)
         reason: High severity vulnerability (no fix available yet)
         remediation: Monitor for upstream fix availability

--- a/policy/examples/container-base-image.yaml
+++ b/policy/examples/container-base-image.yaml
@@ -126,7 +126,7 @@ policies:
         when: |
           pkg.ecosystem == "docker" &&
           pkg.name == "scratch" &&
-          !vulnerabilities.orValue([]).exists(v, v.package.ecosystem == "Go")
+          !vulnerabilities.exists(v, v.package.ecosystem == "Go")
         reason: "Using scratch base image without Go dependencies detected"
         remediation: "Ensure application is statically compiled for scratch images"
 

--- a/policy/examples/dependency-count-guard.yaml
+++ b/policy/examples/dependency-count-guard.yaml
@@ -2,7 +2,7 @@ policies:
   - name: dependency-count-guard
     description: Flag diffs that add or change too many dependencies at once
     vars:
-      changesList: 'changes.orValue([])'
+      changesList: 'changes'
       added: 'changesList.filter(c, c.?type.orValue("").lowerAscii() == "added")'
       total: 'size(changesList)'
       addedCount: 'size(added)'

--- a/policy/examples/diff.yaml
+++ b/policy/examples/diff.yaml
@@ -65,7 +65,7 @@ policies:
     rules:
       - action: deny
         when: |
-          vulnerabilities.orValue([]).exists(v, v.advisory.severity.level == severity.critical)
+          vulnerabilities.exists(v, v.advisory.severity.level == severity.critical)
         reason: "Critical vulnerability introduced by dependency change"
         remediation: "Update to a patched version or choose an alternative package"
 
@@ -75,7 +75,7 @@ policies:
     rules:
       - action: warn
         when: |
-          vulnerabilities.orValue([]).exists(v, v.advisory.severity.level == severity.high)
+          vulnerabilities.exists(v, v.advisory.severity.level == severity.high)
         reason: "High severity vulnerability found in dependency changes"
         remediation: "Review vulnerabilities and update to patched versions"
 

--- a/policy/examples/jwt-anonymous-guard.yaml
+++ b/policy/examples/jwt-anonymous-guard.yaml
@@ -14,7 +14,7 @@ policies:
       - action: deny
         when: |
           jwt.anonymous &&
-          vulnerabilities.orValue([]).exists(v, v.advisory.severity.level == severity.critical)
+          vulnerabilities.exists(v, v.advisory.severity.level == severity.critical)
         reason: "Anonymous users cannot download packages with critical vulnerabilities"
         remediation: "Authenticate with a valid token to download this package"
 

--- a/policy/examples/log4shell.yaml
+++ b/policy/examples/log4shell.yaml
@@ -14,7 +14,7 @@ policies:
         - GHSA-jfh8-c2jp-5v3q
     rules:
       - action: deny
-        when: vulnerabilities.orValue([]).exists(v, v.advisory.?aliases.orValue([]).exists(a, a in log4shellAliases))
+        when: vulnerabilities.exists(v, v.advisory.?aliases.orValue([]).exists(a, a in log4shellAliases))
         reason: dependency still vulnerable to Log4Shell
         status: 451
         headers:

--- a/policy/examples/proxy-critical-advisory.yaml
+++ b/policy/examples/proxy-critical-advisory.yaml
@@ -11,7 +11,7 @@ policies:
     mode: advisory
     entrypoints: ["go_artifact_request", "npm_artifact_request", "pypi_artifact_request", "rubygems_artifact_request"]
     vars:
-      vulns: 'vulnerabilities.orValue([])'
+      vulns: 'vulnerabilities'
     rules:
       - action: deny
         when: vulns.exists(v, v.advisory.severity.level == severity.critical)

--- a/policy/examples/sbom-size-shape-sanity.yaml
+++ b/policy/examples/sbom-size-shape-sanity.yaml
@@ -2,7 +2,7 @@ policies:
   - name: sbom-size-shape-sanity
     description: Flag oversized SBOMs or high rates of missing metadata
     vars:
-      components: 'packages.orValue([])'
+      components: 'packages'
       total: 'size(components)'
       missingVersions: 'components.filter(c, c.?version.orValue("").lowerAscii() == "")'
       missingCount: 'size(missingVersions)'

--- a/policy/examples/severity-guardrail.yaml
+++ b/policy/examples/severity-guardrail.yaml
@@ -10,7 +10,7 @@ policies:
     rules:
       - action: deny
         when: |
-          vulnerabilities.orValue([]).exists(v,
+          vulnerabilities.exists(v,
             v.advisory.severity.level in [severity.critical, severity.high])
         reason: dependency has unresolved high-severity vulnerabilities
         remediation: Apply the vendor patch or upgrade to a remediated release


### PR DESCRIPTION
Closes the unblock half of #126. Part of #125.

## Why

`vulnerabilities.orValue([])` and its two siblings never did anything. Through cel-go v0.26 the runtime returned a non-optional receiver unchanged and never evaluated the argument:

```go
optVal, ok := optLHS.(*types.Optional)
if !ok { return optLHS }   // non-optional, handed back
```

It also never guarded the case it was written for. When a variable is unbound, attribute resolution fails first:

```
$ deputy policy eval --policy 'size(vulnerabilities) > 0' --input <no vulnerabilities key>
no such attribute(s): vulnerabilities
```

cel-go v0.28 ([cel-go#1276](https://github.com/google/cel-go/pull/1276)) made the same expression `no such overload`, which takes out all three gates this repo runs on its own PRs and blocks #52.

## Change

Removed all 15 sites, 6 of them in `policy/ci`. The receivers (`vulnerabilities`, `packages`, `changes`) are declared `Required` in `bindings.go`, where the doc comment already says authors can rely on them without null checks.

Added **`TestNoOrValueOnNonOptional`**, which walks every shipped bundle and rejects `.orValue()` whose receiver chain contains no `?.` select:

```
security-gate.yaml:29: .orValue() applied to non-optional receiver "vulnerabilities";
  guard the hop that can actually be absent (x.?y.orValue(z)) or drop the call
```

A compile or eval test cannot catch this on the pinned version, because the bad form both compiles *and* evaluates there. Only a static check holds across cel-go versions. Verified the test fails when a bad site is reintroduced.

Also widened the bundle corpus to `policy/ci`. It was examples-only, which is why six broken gates went unnoticed.

## Verification against cel-go v0.29.0

Bumped locally, ran, then reverted (the bump itself stays in #52):

- `TestPolicyIntegration_SbomSizeShapeSanity`, the test failing on #52, passes
- Both CI gates evaluate with zero overload errors
- `go test ./...` green

`security-gate` still exits 1 there, but on the go-git advisory that #136 fixes, which is the gate working rather than erroring.

## Not in scope

The other half of #126, guaranteeing every declared variable is bound, is deliberately left out. Seeding empty collections would turn "this variable is not available here" into "there is nothing here", which reads as a pass to a deny rule. That is a fail-open shape and wants the binding-profile work in #129 first. Left the issue open and noted the split there.

## Merge order

Lands before #52 and makes it a no-op diff. #52 is worth pulling in soon: cel-go v0.26.1 carries GHSA-gcjh-h69q-9w9g, fixed in 0.29.0.