### PR TITLE
Classify malware in advisory lookups and explain results

### DIFF
--- a/internal/analysis/advisorysource/advisorysource_test.go
+++ b/internal/analysis/advisorysource/advisorysource_test.go
@@ -153,8 +153,8 @@ func TestAdvisoryKind(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := advisoryKind(tt.adv); got != tt.want {
-				t.Fatalf("advisoryKind = %v, want %v", got, tt.want)
+			if got := AdvisoryKind(tt.adv); got != tt.want {
+				t.Fatalf("AdvisoryKind = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/analysis/advisorysource/osv.go
+++ b/internal/analysis/advisorysource/osv.go
@@ -88,14 +88,17 @@ func (s *osvSource) Query(ctx context.Context, pkgs []*dependencyv1.Package) (*R
 		if adv == nil {
 			continue
 		}
-		adv.Kind = advisoryKind(adv)
+		adv.Kind = AdvisoryKind(adv)
 	}
 	return &Result{Findings: findings, Advisories: advisories}, nil
 }
 
-// advisoryKind classifies an advisory as malware or vulnerability. OSV publishes
-// malicious-package records under the "MAL-" identifier prefix.
-func advisoryKind(adv *vulnerabilityv1.Advisory) vulnerabilityv1.FindingKind {
+// AdvisoryKind classifies an advisory as malware or vulnerability. OSV publishes
+// malicious-package records under the "MAL-" identifier prefix, on either the
+// record itself or one of its aliases. It is exported so every surface that
+// serves OSV advisories (scan findings, advisory lookups) classifies them
+// identically.
+func AdvisoryKind(adv *vulnerabilityv1.Advisory) vulnerabilityv1.FindingKind {
 	if isMalwareID(adv.GetId()) || slices.ContainsFunc(adv.GetAliases(), isMalwareID) {
 		return vulnerabilityv1.FindingKind_FINDING_KIND_MALWARE
 	}

--- a/internal/mcp/proto_results.go
+++ b/internal/mcp/proto_results.go
@@ -17,10 +17,12 @@ import (
 	mcpv1 "github.com/temporalio/deputy/gen/deputy/mcp/v1"
 	remediationv1 "github.com/temporalio/deputy/gen/deputy/remediation/v1"
 	vulnerabilityv1 "github.com/temporalio/deputy/gen/deputy/vulnerability/v1"
+	"github.com/temporalio/deputy/internal/analysis/advisorysource"
 	"github.com/temporalio/deputy/internal/mcp/protoschema"
 	"github.com/temporalio/deputy/internal/otel"
 	internalproto "github.com/temporalio/deputy/internal/proto"
 	"github.com/temporalio/deputy/internal/vulnerability"
+	vulnseverity "github.com/temporalio/deputy/internal/vulnerability/severity"
 )
 
 // This file adapts tool handlers to the deputy.mcp.v1 proto contracts: results
@@ -158,20 +160,26 @@ func vulnExplanationProto(v vulnerability.Consolidated, opts vulnExplanationOpti
 
 // advisoryExplanationProto builds the mcp.v1 explanation of a raw advisory for
 // the explain tools: full details are always included, and reference lists are
-// truncated only when the caller asked for a limit. Advisory lookups have no
-// finding context, so kind, sources, and severityType stay absent.
+// truncated only when the caller asked for a limit. Kind and severityType
+// carry over from the advisory so a malicious-package record is never
+// presented as an ordinary vulnerability; sources is always OSV because
+// advisory lookups are served by the OSV-backed vulnerability service.
 func advisoryExplanationProto(advisory *vulnerabilityv1.Advisory, referenceLimit int) *mcpv1.VulnExplanation {
 	if advisory == nil {
 		return &mcpv1.VulnExplanation{Severity: "UNKNOWN"}
 	}
 
+	_, severityType := vulnseverity.Strings(advisory.GetSeverity())
 	refs, truncated := referencesForMCP(advisory.GetReferences(), referenceLimit)
 	out := &mcpv1.VulnExplanation{
 		Id:            advisory.GetId(),
 		Aliases:       stringsForMCP(advisory.GetAliases()),
 		Summary:       advisory.GetSummary(),
 		Details:       advisory.GetDetails(),
+		Kind:          mcpFindingKind(advisory.GetKind()),
 		Severity:      protoSeverityStringForMCP(advisory.GetSeverity()),
+		SeverityType:  strings.TrimSpace(severityType),
+		Sources:       []string{advisorysource.SourceNameOSV},
 		FixedVersions: stringsForMCP(advisory.GetFixedVersions()),
 		PackageFixes:  packageFixesProto(advisory.GetPackageFixes()),
 		ResolvedFix:   protoFixVerdictProto(advisory.GetResolvedFix()),

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -2075,6 +2075,21 @@ func TestExplainVulnerability(t *testing.T) {
 					},
 				},
 			},
+			"MAL-2024-1234": {
+				ID:      "MAL-2024-1234",
+				Summary: "Malicious code in evil-package (npm)",
+				Details: "The package contained a credential-stealing install script.",
+				Aliases: []string{"GHSA-aaaa-bbbb-cccc"},
+				Affected: []osvschema.Affected{
+					{
+						Package: osvschema.Package{Name: "evil-package", Ecosystem: "npm"},
+						Ranges: []osvschema.Range{{
+							Type:   osvschema.RangeSemVer,
+							Events: []osvschema.Event{{Introduced: "0"}},
+						}},
+					},
+				},
+			},
 		},
 	}
 
@@ -2116,6 +2131,15 @@ func TestExplainVulnerability(t *testing.T) {
 		if result.Severity != "CRITICAL" {
 			t.Errorf("expected severity CRITICAL, got %q", result.Severity)
 		}
+		if result.SeverityType != "CVSS_V3" {
+			t.Errorf("severityType = %q, want CVSS_V3", result.SeverityType)
+		}
+		if result.Kind != "vulnerability" {
+			t.Errorf("kind = %q, want vulnerability", result.Kind)
+		}
+		if !slices.Equal(result.Sources, []string{"osv"}) {
+			t.Errorf("sources = %v, want [osv]", result.Sources)
+		}
 		if result.Published != "2021-12-10T10:15:30Z" {
 			t.Errorf("published = %q, want RFC3339 timestamp", result.Published)
 		}
@@ -2136,6 +2160,23 @@ func TestExplainVulnerability(t *testing.T) {
 		}
 		if !slices.Equal(result.PackageFixes[0].FixedVersions, []string{"2.17.0"}) {
 			t.Errorf("expected package fix versions [2.17.0], got %v", result.PackageFixes[0].FixedVersions)
+		}
+	})
+
+	t.Run("malicious package advisory", func(t *testing.T) {
+		result, err := callProtoTool(t, ctx, s.explainVulnerability,
+			&mcpv1.ExplainVulnerabilityRequest{Id: "MAL-2024-1234"}, &mcpv1.VulnExplanation{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if result.Id != "MAL-2024-1234" {
+			t.Errorf("expected ID MAL-2024-1234, got %s", result.Id)
+		}
+		if result.Kind != "malware" {
+			t.Errorf("kind = %q, want malware", result.Kind)
+		}
+		if !slices.Equal(result.Sources, []string{"osv"}) {
+			t.Errorf("sources = %v, want [osv]", result.Sources)
 		}
 	})
 

--- a/internal/server/vulnerability_handler.go
+++ b/internal/server/vulnerability_handler.go
@@ -12,6 +12,7 @@ import (
 
 	vulnerabilityv1 "github.com/temporalio/deputy/gen/deputy/vulnerability/v1"
 	"github.com/temporalio/deputy/gen/deputy/vulnerability/v1/vulnerabilityv1connect"
+	"github.com/temporalio/deputy/internal/analysis/advisorysource"
 	"github.com/temporalio/deputy/internal/analysis/osv"
 	protoconv "github.com/temporalio/deputy/internal/proto"
 	"github.com/temporalio/deputy/internal/vulnerability"
@@ -180,6 +181,11 @@ func osvSchemaToProtoAdvisory(vuln *osvschema.Vulnerability) *vulnerabilityv1.Ad
 	if cve := extractCVEFromOSVSchema(vuln); cve != "" {
 		advisory.Cve = cve
 	}
+
+	// Classify malware vs vulnerability with the same rules as the scan path,
+	// so advisory lookups (explain tools, GetAdvisory) never report a
+	// malicious-package record as an ordinary vulnerability.
+	advisory.Kind = advisorysource.AdvisoryKind(advisory)
 
 	return advisory
 }

--- a/internal/server/vulnerability_handler_test.go
+++ b/internal/server/vulnerability_handler_test.go
@@ -184,3 +184,45 @@ func TestVulnerabilityHandlerHydratesSparseAliasAdvisory(t *testing.T) {
 		t.Fatalf("References = %v, want sparse and alias references", advisory.GetReferences())
 	}
 }
+
+// TestOSVSchemaToProtoAdvisoryClassifiesKind verifies advisory lookups classify
+// malicious-package records the same way the scan path does: a MAL- prefixed
+// identifier on the record itself or on any alias means malware, anything else
+// is an ordinary vulnerability.
+func TestOSVSchemaToProtoAdvisoryClassifiesKind(t *testing.T) {
+	tests := []struct {
+		name string
+		vuln *osvschema.Vulnerability
+		want vulnerabilityv1.FindingKind
+	}{
+		{
+			name: "MAL identifier",
+			vuln: &osvschema.Vulnerability{ID: "MAL-2024-1234"},
+			want: vulnerabilityv1.FindingKind_FINDING_KIND_MALWARE,
+		},
+		{
+			name: "MAL alias",
+			vuln: &osvschema.Vulnerability{
+				ID:      "GHSA-aaaa-bbbb-cccc",
+				Aliases: []string{"MAL-2024-1234"},
+			},
+			want: vulnerabilityv1.FindingKind_FINDING_KIND_MALWARE,
+		},
+		{
+			name: "CVE",
+			vuln: &osvschema.Vulnerability{
+				ID:      "CVE-2021-44228",
+				Aliases: []string{"GHSA-jfh8-c2jp-5v3q"},
+			},
+			want: vulnerabilityv1.FindingKind_FINDING_KIND_VULNERABILITY,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := osvSchemaToProtoAdvisory(tt.vuln).GetKind(); got != tt.want {
+				t.Errorf("Kind = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
`explain_vulnerability` never set `VulnExplanation.kind`, and the contract tells clients absence means ordinary vulnerability. So explaining a MAL- advisory reported it as a normal CVE while the scan tools flag the same advisory as malware. An actively wrong answer on a security surface.

Root cause: `osvSchemaToProtoAdvisory` never set `Advisory.kind` even though the classifier already exists on the scan path. The explain constructor also dropped `severityType` and `sources`, which its sibling `vulnExplanationProto` populates.

Fix: classify kind at the advisory boundary (exported the existing `AdvisoryKind`, import direction verified clean), and populate kind, severityType, and sources in explain results, matching what the scan path emits.

Tests fail on main: MAL ID and MAL alias classify as malware at both layers; live check shows `MAL-2024-1` now yields `kind=FINDING_KIND_MALWARE` (was unspecified). No proto changes.

Note for a follow-up: the CLI `deputy explain` renders from its own `internal/explain` pipeline and has no malware classification either; left out to keep this small.