### PR TITLE
Re-arm tests that could not fail

### DIFF
--- a/internal/cli/cmd/policy_helpers_test.go
+++ b/internal/cli/cmd/policy_helpers_test.go
@@ -39,9 +39,18 @@ func TestEvaluatePoliciesForCommand_Scan_NoPanic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("evaluatePoliciesForCommand: %v", err)
 	}
+	// Empty licenses trigger the policy's warn rule; asserting the warn fires
+	// also proves the policy was actually evaluated for the scan command.
+	warned := false
 	for _, act := range actions {
 		if act.Type == "deny" {
 			t.Fatalf("unexpected deny for scan payload: %+v", act)
 		}
+		if act.Type == "warn" {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Fatalf("expected warn for missing licenses, got %+v", actions)
 	}
 }

--- a/internal/cli/cmd/policy_integration_test.go
+++ b/internal/cli/cmd/policy_integration_test.go
@@ -40,10 +40,10 @@ func TestPolicyIntegration_ComposedBundleSbomComponent_AllowsPermissive(t *testi
 	if err != nil {
 		t.Fatalf("evaluatePoliciesForCommand: %v", err)
 	}
-	for _, a := range actions {
-		if a.Type == "deny" {
-			t.Fatalf("did not expect deny: %+v", a)
-		}
+	// The bundle only has deny (forbidden license) and warn (missing licenses)
+	// rules; a permissive license must produce no actions at all.
+	if len(actions) != 0 {
+		t.Fatalf("expected no actions for permissive license, got %+v", actions)
 	}
 }
 
@@ -61,10 +61,10 @@ func TestPolicyIntegration_ComposedBundleScanReport_NoDeny(t *testing.T) {
 	if err != nil {
 		t.Fatalf("evaluatePoliciesForCommand: %v", err)
 	}
-	for _, a := range actions {
-		if a.Type == "deny" {
-			t.Fatalf("did not expect deny for scan payload: %+v", a)
-		}
+	// scan is outside the bundle's in_scope commands, so even the empty-license
+	// warn rule must not fire: the guard leaves zero actions.
+	if len(actions) != 0 {
+		t.Fatalf("expected no actions for out-of-scope scan command, got %+v", actions)
 	}
 }
 
@@ -121,12 +121,10 @@ func TestPolicyIntegration_PypiPrefixAllowlist(t *testing.T) {
 	}
 	if actions, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, allowPayload, "proxy", policy.EntrypointPypiArtifactRequest, &bytes.Buffer{}); err != nil {
 		t.Fatalf("unexpected error for approved pypi package: %v", err)
-	} else {
-		for _, a := range actions {
-			if a.Type == "deny" {
-				t.Fatalf("did not expect deny for approved prefix: %+v", actions)
-			}
-		}
+	} else if len(actions) != 0 {
+		// The policy's only rule is the prefix deny; an approved prefix must
+		// produce zero actions.
+		t.Fatalf("expected no actions for approved prefix, got %+v", actions)
 	}
 }
 
@@ -347,12 +345,10 @@ func TestPolicyIntegration_TyposquatLevenshteinGuard(t *testing.T) {
 	}
 	if actions, err := evaluatePoliciesForCommand(t.Context(), []string{pol}, allowPayload, "proxy", policy.EntrypointNpmArtifactRequest, &bytes.Buffer{}); err != nil {
 		t.Fatalf("did not expect error for safe package: %v", err)
-	} else {
-		for _, a := range actions {
-			if a.Type == "deny" {
-				t.Fatalf("did not expect deny for safe package: %+v", actions)
-			}
-		}
+	} else if len(actions) != 0 {
+		// The policy's only rule is the typosquat deny; a distant name must
+		// produce zero actions.
+		t.Fatalf("expected no actions for safe package, got %+v", actions)
 	}
 }
 
@@ -406,10 +402,10 @@ policies:
 	if err != nil {
 		t.Fatalf("unexpected error for safe CWEs: %v", err)
 	}
-	for _, a := range actions {
-		if a.Type == "deny" {
-			t.Fatalf("did not expect deny for vulnerability without injection CWE: %+v", actions)
-		}
+	// The policy's only rule is the injection-CWE deny; safe CWEs must
+	// produce zero actions.
+	if len(actions) != 0 {
+		t.Fatalf("expected no actions for vulnerability without injection CWE, got %+v", actions)
 	}
 
 	payloadNoCWE := map[string]any{
@@ -426,10 +422,8 @@ policies:
 	if err != nil {
 		t.Fatalf("unexpected error for vulnerability without CWEs: %v", err)
 	}
-	for _, a := range actions {
-		if a.Type == "deny" {
-			t.Fatalf("did not expect deny for vulnerability without CWEs: %+v", actions)
-		}
+	if len(actions) != 0 {
+		t.Fatalf("expected no actions for vulnerability without CWEs, got %+v", actions)
 	}
 }
 
@@ -484,10 +478,10 @@ policies:
 	if err != nil {
 		t.Fatalf("unexpected error for vulnerability not in KEV: %v", err)
 	}
-	for _, a := range actions {
-		if a.Type == "deny" {
-			t.Fatalf("did not expect deny for vulnerability not in KEV: %+v", actions)
-		}
+	// The policy's only rule is the KEV deny; a non-KEV vulnerability must
+	// produce zero actions.
+	if len(actions) != 0 {
+		t.Fatalf("expected no actions for vulnerability not in KEV, got %+v", actions)
 	}
 
 	payloadNoKEV := map[string]any{
@@ -505,10 +499,8 @@ policies:
 	if err != nil {
 		t.Fatalf("unexpected error for vulnerability without KEV status: %v", err)
 	}
-	for _, a := range actions {
-		if a.Type == "deny" {
-			t.Fatalf("did not expect deny for vulnerability without KEV status: %+v", actions)
-		}
+	if len(actions) != 0 {
+		t.Fatalf("expected no actions for vulnerability without KEV status, got %+v", actions)
 	}
 }
 
@@ -592,10 +584,10 @@ policies:
 	if err != nil {
 		t.Fatalf("unexpected error for vulnerability with low EPSS: %v", err)
 	}
-	for _, a := range actions {
-		if a.Type == "deny" || a.Type == "warn" {
-			t.Fatalf("did not expect deny/warn for vulnerability with low EPSS: %+v", actions)
-		}
+	// Both rules (deny and warn) require EPSS above the warn threshold; a low
+	// EPSS must produce zero actions.
+	if len(actions) != 0 {
+		t.Fatalf("expected no actions for vulnerability with low EPSS, got %+v", actions)
 	}
 
 	payloadNoEPSS := map[string]any{
@@ -613,10 +605,8 @@ policies:
 	if err != nil {
 		t.Fatalf("unexpected error for vulnerability without EPSS: %v", err)
 	}
-	for _, a := range actions {
-		if a.Type == "deny" || a.Type == "warn" {
-			t.Fatalf("did not expect deny/warn for vulnerability without EPSS: %+v", actions)
-		}
+	if len(actions) != 0 {
+		t.Fatalf("expected no actions for vulnerability without EPSS, got %+v", actions)
 	}
 }
 
@@ -700,9 +690,9 @@ policies:
 	if err != nil {
 		t.Fatalf("unexpected error for Medium + high EPSS: %v", err)
 	}
-	for _, a := range actions {
-		if a.Type == "deny" {
-			t.Fatalf("did not expect deny for Medium severity + high EPSS: %+v", actions)
-		}
+	// Both composite rules require HIGH/CRITICAL severity; a medium-severity
+	// vulnerability must produce zero actions even with high EPSS.
+	if len(actions) != 0 {
+		t.Fatalf("expected no actions for Medium severity + high EPSS, got %+v", actions)
 	}
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -796,6 +796,9 @@ func TestMCPToolInputSchemasAvoidTopLevelComposition(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListTools failed: %v", err)
 	}
+	if len(tools.Tools) == 0 {
+		t.Fatal("expected registered tools, got none; schema checks below would be vacuous")
+	}
 
 	for _, tool := range tools.Tools {
 		schema := toolInputSchema(t, tool)
@@ -1651,6 +1654,10 @@ func TestToolAnnotationsExposeReadOnlySafetyHints(t *testing.T) {
 	tools, err := clientSession.ListTools(ctx, nil)
 	if err != nil {
 		t.Fatalf("ListTools failed: %v", err)
+	}
+
+	if len(tools.Tools) == 0 {
+		t.Fatal("expected registered tools, got none; annotation checks below would be vacuous")
 	}
 
 	closedWorldTools := map[string]bool{
@@ -3588,10 +3595,20 @@ func TestTriageVulnerabilitiesDoesNotRecommendDirectUpdateForTransitiveFix(t *te
 	if result.UnfixableCount != 1 {
 		t.Errorf("unfixable count = %d, want 1", result.UnfixableCount)
 	}
+	// Prove recommendations were produced at all before asserting what they
+	// must not contain: the transitive fixable vulnerability must yield the
+	// transitive review recommendation.
+	foundTransitiveReview := false
 	for _, recommendation := range result.Recommendations {
 		if strings.Contains(recommendation, "Update or migrate direct dependencies") {
 			t.Fatalf("unexpected direct dependency recommendation: %q", recommendation)
 		}
+		if strings.Contains(recommendation, "transitive dependency vulnerability") {
+			foundTransitiveReview = true
+		}
+	}
+	if !foundTransitiveReview {
+		t.Fatalf("expected transitive review recommendation, got %+v", result.Recommendations)
 	}
 }
 

--- a/internal/policy/engine_test.go
+++ b/internal/policy/engine_test.go
@@ -352,9 +352,18 @@ func TestEvaluateAll_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	// Evaluation should still work for simple policies (CEL doesn't check context for simple evals)
-	// This is primarily a smoke test for context passing
-	_, _ = eng.EvaluateAll(ctx, nil, "", "")
+	// The engine compiles programs without cel.InterruptCheckFrequency, so a
+	// cancelled context does not abort evaluation: the policy still runs to
+	// completion and returns its actions. Pin that guarantee so a behavior
+	// change (e.g. cancellation starting to abort evaluation mid-request)
+	// shows up as a deliberate test update rather than silently.
+	actions, err := eng.EvaluateAll(ctx, nil, "", "")
+	if err != nil {
+		t.Fatalf("EvaluateAll() with cancelled context error: %v", err)
+	}
+	if len(actions) != 1 || actions[0].Type != "allow" {
+		t.Fatalf("expected one allow action despite cancelled context, got %+v", actions)
+	}
 }
 
 func TestEvaluateAll_PayloadNotModified(t *testing.T) {

--- a/internal/policy/lsp/diagnostics_vars_test.go
+++ b/internal/policy/lsp/diagnostics_vars_test.go
@@ -1,6 +1,7 @@
 package lsp
 
 import (
+	"slices"
 	"testing"
 
 	protocol "github.com/sourcegraph/go-lsp"
@@ -18,7 +19,7 @@ policies:
     rules:
       - action: deny
         when: pkg.?licenses.orValue([]).exists(l, l in forbidden)
-        reason: package carries a forbidden license
+        reason: package carries a copyleft license
 `
 	engine := newDiagnosticEngine()
 	diag, err := engine.analyze(protocol.DocumentURI("file:///vars.yaml"), text)
@@ -45,19 +46,37 @@ policies:
     rules:
       - action: deny
         when: pkg.?licenses.orValue([]).exists(l, l in fobidden)
-        reason: package carries a forbidden license
+        reason: package carries a copyleft license
 `
+	// Golden expectation: this is verbatim what a policy author sees in their
+	// editor when they misspell a declared var, so all of it is contract, the
+	// "(did you mean 'x'?)" wording, the echoed source line, and the caret
+	// column that lands under the typo. The caret alignment in particular is
+	// behavior nothing else protects, and it breaks silently when the snippet
+	// builder is edited.
+	//
+	// Yes, this is brittle on purpose. Do NOT loosen it back to a code-only or
+	// substring check: that is exactly the assertion this test replaced, and it
+	// let the useful part of the message go unprotected. If the wording or the
+	// snippet layout legitimately changes, read the diff, confirm the new
+	// message is what you want a user to read, and update the string.
+	//
+	// Written as concatenated lines with explicit \n so the caret stays visibly
+	// under the misspelled token here in the source, and so no trailing
+	// whitespace hides at the end of a line where an editor could strip it.
+	const wantMessage = "undeclared reference to 'fobidden' (did you mean 'forbidden'?)\n" +
+		"  pkg.?licenses.orValue([]).exists(l, l in fobidden)\n" +
+		"                                           ^"
+
 	badDiag, err := engine.analyze(protocol.DocumentURI("file:///vars-bad.yaml"), badText)
 	if err != nil {
 		t.Fatalf("analyze (negative control): %v", err)
 	}
-	foundUndeclared := false
-	for _, d := range badDiag {
-		if d.Code == "undeclared" {
-			foundUndeclared = true
-		}
-	}
-	if !foundUndeclared {
+	idx := slices.IndexFunc(badDiag, func(d protocol.Diagnostic) bool { return d.Code == "undeclared" })
+	if idx < 0 {
 		t.Fatalf("expected undeclared diagnostic for misspelled var, got %+v", badDiag)
+	}
+	if got := badDiag[idx].Message; got != wantMessage {
+		t.Errorf("undeclared diagnostic message mismatch\nwant:\n%s\ngot:\n%s\nwant %q\ngot  %q", wantMessage, got, wantMessage, got)
 	}
 }

--- a/internal/policy/lsp/diagnostics_vars_test.go
+++ b/internal/policy/lsp/diagnostics_vars_test.go
@@ -30,4 +30,34 @@ policies:
 			t.Fatalf("expected no undeclared diagnostics, got %+v", diag)
 		}
 	}
+
+	// Negative control: the same policy referencing a genuinely undeclared
+	// variable MUST produce an "undeclared" diagnostic. This proves the
+	// analyzer actually reached CEL compilation above; without it the test
+	// would pass vacuously if analysis never compiled the expression.
+	badText := `
+policies:
+  - name: allow-sans-copyleft
+    vars:
+      forbidden:
+        - SSPL-1.0
+        - AGPL-3.0-only
+    rules:
+      - action: deny
+        when: pkg.?licenses.orValue([]).exists(l, l in fobidden)
+        reason: package carries a forbidden license
+`
+	badDiag, err := engine.analyze(protocol.DocumentURI("file:///vars-bad.yaml"), badText)
+	if err != nil {
+		t.Fatalf("analyze (negative control): %v", err)
+	}
+	foundUndeclared := false
+	for _, d := range badDiag {
+		if d.Code == "undeclared" {
+			foundUndeclared = true
+		}
+	}
+	if !foundUndeclared {
+		t.Fatalf("expected undeclared diagnostic for misspelled var, got %+v", badDiag)
+	}
 }

--- a/internal/policy/policy_entrypoints_newpolicies_test.go
+++ b/internal/policy/policy_entrypoints_newpolicies_test.go
@@ -82,10 +82,10 @@ func TestTyposquatLevenshteinGuard(t *testing.T) {
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
-		for _, a := range actions {
-			if a.Type == "deny" {
-				t.Fatalf("did not expect deny for distant name: %+v", actions)
-			}
+		// The policy's only rule is the typosquat deny; a distant name must
+		// produce zero actions.
+		if len(actions) != 0 {
+			t.Fatalf("expected no actions for distant name, got %+v", actions)
 		}
 	})
 
@@ -99,10 +99,8 @@ func TestTyposquatLevenshteinGuard(t *testing.T) {
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
-		for _, a := range actions {
-			if a.Type == "deny" {
-				t.Fatalf("did not expect deny for scoped package: %+v", actions)
-			}
+		if len(actions) != 0 {
+			t.Fatalf("expected no actions for scoped package, got %+v", actions)
 		}
 	})
 
@@ -116,10 +114,8 @@ func TestTyposquatLevenshteinGuard(t *testing.T) {
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
-		for _, a := range actions {
-			if a.Type == "deny" {
-				t.Fatalf("did not expect deny for numeric suffix: %+v", actions)
-			}
+		if len(actions) != 0 {
+			t.Fatalf("expected no actions for numeric suffix, got %+v", actions)
 		}
 	})
 
@@ -133,10 +129,8 @@ func TestTyposquatLevenshteinGuard(t *testing.T) {
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
-		for _, a := range actions {
-			if a.Type == "deny" {
-				t.Fatalf("did not expect deny outside proxy: %+v", actions)
-			}
+		if len(actions) != 0 {
+			t.Fatalf("expected no actions outside proxy, got %+v", actions)
 		}
 	})
 }
@@ -406,11 +400,10 @@ func TestContainerLayerVulnerabilityPolicies(t *testing.T) {
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
-		// Should not trigger deny or warn (only HIGH and CRITICAL trigger)
-		for _, a := range actions {
-			if a.Type == "deny" || a.Type == "warn" {
-				t.Fatalf("did not expect deny/warn for medium severity vulnerability, got %+v", actions)
-			}
+		// Only HIGH and CRITICAL trigger the bundle's deny/warn rules, so a
+		// medium severity vulnerability must produce zero actions.
+		if len(actions) != 0 {
+			t.Fatalf("expected no actions for medium severity vulnerability, got %+v", actions)
 		}
 	})
 
@@ -434,11 +427,10 @@ func TestContainerLayerVulnerabilityPolicies(t *testing.T) {
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
-		// Should not trigger any action since policies check has(vulnerability.package.layer_details)
-		for _, a := range actions {
-			if a.Type == "deny" || a.Type == "warn" {
-				t.Fatalf("did not expect deny/warn without layer details, got %+v", actions)
-			}
+		// Every rule in the bundle guards on has(vulnerability.package.layer_details),
+		// so a non-container finding must produce zero actions.
+		if len(actions) != 0 {
+			t.Fatalf("expected no actions without layer details, got %+v", actions)
 		}
 	})
 }

--- a/internal/policy/policy_entrypoints_test.go
+++ b/internal/policy/policy_entrypoints_test.go
@@ -91,11 +91,10 @@ func TestLicenseAllowlistEntrypoints(t *testing.T) {
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
-		// The policy may emit a warn for missing licenses; just ensure no deny.
-		for _, act := range actions {
-			if act.Type == "deny" {
-				t.Fatalf("did not expect deny for scan payload: %+v", act)
-			}
+		// The policy has no command scoping, so the missing-license warn rule
+		// fires for scan payloads too; the deny rule must not.
+		if len(actions) != 1 || actions[0].Type != "warn" {
+			t.Fatalf("expected one warn action for scan payload, got %+v", actions)
 		}
 	})
 }
@@ -200,10 +199,10 @@ func TestLicenseAllowlistHappySadPaths(t *testing.T) {
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
-		for _, a := range actions {
-			if strings.EqualFold(a.Type, "deny") {
-				t.Fatalf("did not expect deny: %+v", a)
-			}
+		// Permissive licenses match neither the deny rule nor the
+		// missing-license warn rule, so no actions may fire at all.
+		if len(actions) != 0 {
+			t.Fatalf("expected no actions for permissive license, got %+v", actions)
 		}
 	})
 
@@ -269,10 +268,9 @@ func TestDenyAwsSdkV1Policy(t *testing.T) {
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
-		for _, a := range actions {
-			if a.Type == "deny" {
-				t.Fatalf("did not expect deny for v2: %+v", actions)
-			}
+		// The policy's only rule is the v1 deny; v2 must produce zero actions.
+		if len(actions) != 0 {
+			t.Fatalf("expected no actions for v2, got %+v", actions)
 		}
 	})
 }
@@ -321,10 +319,10 @@ func TestGoModRegistryAllowlist(t *testing.T) {
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
-		for _, a := range actions {
-			if a.Type == "deny" {
-				t.Fatalf("did not expect deny for approved org: %+v", actions)
-			}
+		// The policy's only rule is the org-allowlist deny; an approved org
+		// must produce zero actions.
+		if len(actions) != 0 {
+			t.Fatalf("expected no actions for approved org, got %+v", actions)
 		}
 	})
 }
@@ -394,10 +392,10 @@ func TestGoPseudoVersionDenyPolicy(t *testing.T) {
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
-		for _, a := range actions {
-			if a.Type == "deny" {
-				t.Fatalf("did not expect deny for tagged release: %+v", actions)
-			}
+		// The policy's only rule is the pseudo-version deny; a tagged release
+		// must produce zero actions.
+		if len(actions) != 0 {
+			t.Fatalf("expected no actions for tagged release, got %+v", actions)
 		}
 	})
 }
@@ -434,10 +432,10 @@ func TestPrereleaseGuardPolicy(t *testing.T) {
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
-		for _, a := range actions {
-			if a.Type == "deny" {
-				t.Fatalf("did not expect deny for stable release: %+v", actions)
-			}
+		// The policy's only rule is the pre-release deny; a stable release
+		// must produce zero actions.
+		if len(actions) != 0 {
+			t.Fatalf("expected no actions for stable release, got %+v", actions)
 		}
 	})
 }
@@ -503,10 +501,10 @@ func TestDirectHighFixBlock(t *testing.T) {
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
-		for _, a := range actions {
-			if a.Type == "deny" {
-				t.Fatalf("did not expect deny for medium: %+v", actions)
-			}
+		// The policy's only rule denies HIGH/CRITICAL with a fix; a medium
+		// severity vulnerability must produce zero actions.
+		if len(actions) != 0 {
+			t.Fatalf("expected no actions for medium severity, got %+v", actions)
 		}
 	})
 }
@@ -555,10 +553,10 @@ func TestNewDependencyReview(t *testing.T) {
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
-		for _, a := range actions {
-			if a.Type == "deny" {
-				t.Fatalf("did not expect deny for approved addition: %+v", actions)
-			}
+		// The policy's only rule is the unapproved-addition deny; an approved
+		// prefix must produce zero actions.
+		if len(actions) != 0 {
+			t.Fatalf("expected no actions for approved addition, got %+v", actions)
 		}
 	})
 }
@@ -605,10 +603,10 @@ func TestFixStepCommandAllowlist(t *testing.T) {
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
-		for _, a := range actions {
-			if a.Type == "deny" {
-				t.Fatalf("did not expect deny for allowed command: %+v", actions)
-			}
+		// The policy's only rule is the command-allowlist deny; a vetted
+		// command must produce zero actions.
+		if len(actions) != 0 {
+			t.Fatalf("expected no actions for allowed command, got %+v", actions)
 		}
 	})
 }
@@ -656,10 +654,10 @@ func TestSbomMetadataQuality(t *testing.T) {
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
-		for _, a := range actions {
-			if a.Type == "warn" || a.Type == "deny" {
-				t.Fatalf("did not expect warn/deny for complete metadata: %+v", actions)
-			}
+		// The policy's only rule is the missing-metadata warn; complete
+		// metadata must produce zero actions.
+		if len(actions) != 0 {
+			t.Fatalf("expected no actions for complete metadata, got %+v", actions)
 		}
 	})
 }
@@ -706,10 +704,10 @@ func TestUnstableMajorGuard(t *testing.T) {
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
-		for _, a := range actions {
-			if a.Type == "warn" || a.Type == "deny" {
-				t.Fatalf("did not expect warn/deny for stable version: %+v", actions)
-			}
+		// The policy's only rule is the unstable-version warn; a stable
+		// version must produce zero actions.
+		if len(actions) != 0 {
+			t.Fatalf("expected no actions for stable version, got %+v", actions)
 		}
 	})
 }
@@ -764,10 +762,10 @@ func TestPypiPrefixAllowlist(t *testing.T) {
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
-		for _, a := range actions {
-			if a.Type == "deny" {
-				t.Fatalf("did not expect deny for approved PyPI package: %+v", actions)
-			}
+		// The policy's only rule is the prefix-allowlist deny; an approved
+		// prefix must produce zero actions.
+		if len(actions) != 0 {
+			t.Fatalf("expected no actions for approved PyPI package, got %+v", actions)
 		}
 	})
 }
@@ -819,12 +817,10 @@ func TestLicensePresentBlocker(t *testing.T) {
 	}
 	if actions, err := EvaluateMap(t.Context(), sources, allowPayload); err != nil {
 		t.Fatalf("EvaluateAll: %v", err)
-	} else {
-		for _, a := range actions {
-			if a.Type == "deny" {
-				t.Fatalf("did not expect deny: %+v", actions)
-			}
-		}
+	} else if len(actions) != 0 {
+		// The policy's only rule is the missing-license deny; present license
+		// metadata must produce zero actions.
+		t.Fatalf("expected no actions for present license metadata, got %+v", actions)
 	}
 }
 
@@ -1017,10 +1013,10 @@ func TestExploitAvailableBlocker(t *testing.T) {
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
-		for _, a := range actions {
-			if a.Type == "deny" {
-				t.Fatalf("did not expect deny without exploit: %+v", actions)
-			}
+		// The policy's only rule is the exploit-indicator deny; a plain
+		// advisory reference must produce zero actions.
+		if len(actions) != 0 {
+			t.Fatalf("expected no actions without exploit indicators, got %+v", actions)
 		}
 	})
 }
@@ -1069,10 +1065,10 @@ func TestDeprecatedModuleBlock(t *testing.T) {
 		if err != nil {
 			t.Fatalf("EvaluateAll: %v", err)
 		}
-		for _, a := range actions {
-			if a.Type == "deny" {
-				t.Fatalf("did not expect deny for non-deprecated issue: %+v", actions)
-			}
+		// The policy's only rule is the deprecated-text deny; a non-deprecated
+		// summary must produce zero actions.
+		if len(actions) != 0 {
+			t.Fatalf("expected no actions for non-deprecated issue, got %+v", actions)
 		}
 	})
 }
@@ -1122,12 +1118,10 @@ func TestGoDowngradeGuard(t *testing.T) {
 	}
 	if actions, err := EvaluateMap(t.Context(), sources, allowPayload); err != nil {
 		t.Fatalf("EvaluateAll: %v", err)
-	} else {
-		for _, a := range actions {
-			if a.Type == "deny" {
-				t.Fatalf("did not expect deny for upgrade: %+v", actions)
-			}
-		}
+	} else if len(actions) != 0 {
+		// The policy's only rule is the downgrade deny; an upgrade must
+		// produce zero actions.
+		t.Fatalf("expected no actions for upgrade, got %+v", actions)
 	}
 }
 
@@ -1231,12 +1225,10 @@ func TestNpmScopeAllowlist(t *testing.T) {
 	}
 	if actions, err := EvaluateMap(t.Context(), sources, allowPayload); err != nil {
 		t.Fatalf("EvaluateAll: %v", err)
-	} else {
-		for _, a := range actions {
-			if a.Type == "deny" {
-				t.Fatalf("did not expect deny for allowlisted package: %+v", actions)
-			}
-		}
+	} else if len(actions) != 0 {
+		// lodash is allowlisted and not an @acme pre-release, so neither the
+		// deny nor the warn rule may fire.
+		t.Fatalf("expected no actions for allowlisted package, got %+v", actions)
 	}
 }
 

--- a/internal/proxy/oci_toctou_test.go
+++ b/internal/proxy/oci_toctou_test.go
@@ -5,8 +5,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"strings"
-	"sync/atomic"
+	"sync"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -281,14 +282,16 @@ func TestOCIConfigEffectiveMethods(t *testing.T) {
 func TestOCIHandler_DigestPinning(t *testing.T) {
 	pinnedDigest := "sha256:" + strings.Repeat("a", 64)
 
-	// Count upstream invocations and capture the proxied path so the digest
-	// rewrite is asserted on a request that provably happened; an in-callback
-	// assertion alone is vacuous if the proxy never reaches upstream.
-	var upstreamCalls atomic.Int32
-	var upstreamPath atomic.Value
+	// Capture every proxied path so the digest rewrite is asserted on
+	// requests that provably happened; an in-callback assertion alone is
+	// vacuous if the proxy never reaches upstream, and keeping only the last
+	// path would let an unrewritten request hide behind a rewritten one.
+	var mu sync.Mutex
+	var upstreamPaths []string
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		upstreamCalls.Add(1)
-		upstreamPath.Store(r.URL.Path)
+		mu.Lock()
+		upstreamPaths = append(upstreamPaths, r.URL.Path)
+		mu.Unlock()
 		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(upstream.Close)
@@ -328,13 +331,18 @@ func TestOCIHandler_DigestPinning(t *testing.T) {
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 
-	// Verify the request was actually proxied and its path rewritten to the
-	// pinned digest.
-	if upstreamCalls.Load() == 0 {
+	// Verify the request was actually proxied and every upstream request used
+	// the pinned digest path.
+	mu.Lock()
+	gotPaths := slices.Clone(upstreamPaths)
+	mu.Unlock()
+	if len(gotPaths) == 0 {
 		t.Fatalf("upstream was never called; digest rewrite was not exercised (status=%d body=%s)", rr.Code, rr.Body.String())
 	}
-	if got, _ := upstreamPath.Load().(string); !strings.Contains(got, pinnedDigest) {
-		t.Errorf("upstream request should use pinned digest, got path: %s", got)
+	for _, path := range gotPaths {
+		if !strings.Contains(path, pinnedDigest) {
+			t.Errorf("upstream request should use pinned digest, got path: %s", path)
+		}
 	}
 
 	// Verify the pinned digest header was set

--- a/internal/proxy/oci_toctou_test.go
+++ b/internal/proxy/oci_toctou_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -14,7 +15,7 @@ import (
 
 func TestIsMutableTag(t *testing.T) {
 	tests := []struct {
-		tag      string
+		tag         string
 		wantMutable bool
 	}{
 		// Explicitly mutable tags
@@ -26,7 +27,7 @@ func TestIsMutableTag(t *testing.T) {
 		{"snapshot", true},
 		{"master", true},
 		{"main", true},
-		{"LATEST", true},  // Case insensitive
+		{"LATEST", true}, // Case insensitive
 		{"Latest", true},
 
 		// Digest references (immutable)
@@ -87,8 +88,8 @@ func TestLooksLikeSemver(t *testing.T) {
 		{"alpine", false},
 		{"v", false},
 		{"", false},
-		{"v1", false},  // Single component
-		{"1", false},   // Single component
+		{"v1", false}, // Single component
+		{"1", false},  // Single component
 	}
 
 	for _, tt := range tests {
@@ -251,7 +252,7 @@ func TestOCIConfigEffectiveMethods(t *testing.T) {
 	t.Run("strict mode overrides", func(t *testing.T) {
 		cfg := &OCIConfig{
 			StrictMode:       true,
-			AllowMutableTags: true, // Should be overridden
+			AllowMutableTags: true,  // Should be overridden
 			PinDigests:       false, // Should be overridden
 		}
 		if cfg.EffectiveAllowMutableTags() {
@@ -280,11 +281,14 @@ func TestOCIConfigEffectiveMethods(t *testing.T) {
 func TestOCIHandler_DigestPinning(t *testing.T) {
 	pinnedDigest := "sha256:" + strings.Repeat("a", 64)
 
+	// Count upstream invocations and capture the proxied path so the digest
+	// rewrite is asserted on a request that provably happened; an in-callback
+	// assertion alone is vacuous if the proxy never reaches upstream.
+	var upstreamCalls atomic.Int32
+	var upstreamPath atomic.Value
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Verify the request path was rewritten to use the digest
-		if !strings.Contains(r.URL.Path, pinnedDigest) {
-			t.Errorf("upstream request should use pinned digest, got path: %s", r.URL.Path)
-		}
+		upstreamCalls.Add(1)
+		upstreamPath.Store(r.URL.Path)
 		w.WriteHeader(http.StatusOK)
 	}))
 	t.Cleanup(upstream.Close)
@@ -323,6 +327,15 @@ func TestOCIHandler_DigestPinning(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "http://deputy.local/v2/library/nginx/manifests/latest", nil)
 	rr := httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
+
+	// Verify the request was actually proxied and its path rewritten to the
+	// pinned digest.
+	if upstreamCalls.Load() == 0 {
+		t.Fatalf("upstream was never called; digest rewrite was not exercised (status=%d body=%s)", rr.Code, rr.Body.String())
+	}
+	if got, _ := upstreamPath.Load().(string); !strings.Contains(got, pinnedDigest) {
+		t.Errorf("upstream request should use pinned digest, got path: %s", got)
+	}
 
 	// Verify the pinned digest header was set
 	if got := rr.Header().Get(HeaderPinnedDigest); got != pinnedDigest {

--- a/internal/scanning/filter_test.go
+++ b/internal/scanning/filter_test.go
@@ -1,6 +1,7 @@
 package scanning
 
 import (
+	"slices"
 	"testing"
 
 	vulnerabilityv1 "github.com/temporalio/deputy/gen/deputy/vulnerability/v1"
@@ -387,34 +388,49 @@ func TestFilterByCEL_DocumentedExamples(t *testing.T) {
 	ctx := t.Context()
 	result := testResult()
 
-	// These are the exact examples from docs/commands/scan.md
+	// These are the exact examples from docs/commands/scan.md, each with its
+	// expected outcome against the testResult fixture so a filter that
+	// silently matches nothing (or everything) fails the test.
 	documentedExamples := []struct {
-		name   string
-		filter string
+		name    string
+		filter  string
+		wantIDs []string
 	}{
 		{
-			name:   "critical severity (from docs)",
-			filter: "vulnerability.advisory.severity.level == severity.critical",
+			name:    "critical severity (from docs)",
+			filter:  "vulnerability.advisory.severity.level == severity.critical",
+			wantIDs: []string{"CVE-2024-0001"},
 		},
 		{
-			name:   "high and critical (from docs)",
-			filter: "vulnerability.advisory.severity.level in [severity.critical, severity.high]",
+			name:    "high and critical (from docs)",
+			filter:  "vulnerability.advisory.severity.level in [severity.critical, severity.high]",
+			wantIDs: []string{"CVE-2024-0001", "CVE-2024-0002"},
 		},
 		{
-			name:   "direct dependencies (from docs)",
-			filter: "vulnerability.package.direct == true",
+			name:    "direct dependencies (from docs)",
+			filter:  "vulnerability.package.direct == true",
+			wantIDs: []string{"CVE-2024-0001", "CVE-2024-0003"},
 		},
 		{
-			name:   "fix available (from docs)",
-			filter: "size(vulnerability.advisory.fixed_versions) > 0",
+			name:    "fix available (from docs)",
+			filter:  "size(vulnerability.advisory.fixed_versions) > 0",
+			wantIDs: []string{"CVE-2024-0001", "CVE-2024-0002", "CVE-2024-0004"},
 		},
 	}
 
 	for _, ex := range documentedExamples {
 		t.Run(ex.name, func(t *testing.T) {
-			_, err := FilterByCEL(ctx, result, ex.filter)
+			filtered, err := FilterByCEL(ctx, result, ex.filter)
 			if err != nil {
-				t.Errorf("documented example failed: %v", err)
+				t.Fatalf("documented example failed: %v", err)
+			}
+			gotIDs := make([]string, 0, len(filtered.Findings))
+			for _, f := range filtered.Findings {
+				gotIDs = append(gotIDs, f.AdvisoryID)
+			}
+			slices.Sort(gotIDs)
+			if !slices.Equal(gotIDs, ex.wantIDs) {
+				t.Errorf("filtered advisory IDs = %v, want %v", gotIDs, ex.wantIDs)
 			}
 		})
 	}

--- a/internal/secrets/detector_test.go
+++ b/internal/secrets/detector_test.go
@@ -425,6 +425,10 @@ token: ghp_ABCDEFghijklmnopqrstuvwxyz0123456789
 stripe: sk_live_abcdefghijklmnopqrstuvwxyz
 `)
 
+	// The fixture yields exactly two findings from the raw engine: a GitHub
+	// token (confidence 0.99) and a Stripe key (confidence 0.95). Each
+	// subtest asserts a floor on what must survive filtering so a scanner
+	// regression that produces nothing cannot pass vacuously.
 	t.Run("allow types", func(t *testing.T) {
 		filtered := NewFilteringScanner(engine, WithAllowedTypes(TypeGitHubToken))
 		findings, err := filtered.Scan(t.Context(), content)
@@ -432,6 +436,9 @@ stripe: sk_live_abcdefghijklmnopqrstuvwxyz
 			t.Fatalf("Scan() error = %v", err)
 		}
 
+		if len(findings) == 0 {
+			t.Fatal("expected the GitHub token finding to pass the allowlist, got none")
+		}
 		for _, f := range findings {
 			if f.Type != TypeGitHubToken {
 				t.Errorf("unexpected type %s, only TypeGitHubToken should pass", f.Type)
@@ -446,10 +453,17 @@ stripe: sk_live_abcdefghijklmnopqrstuvwxyz
 			t.Fatalf("Scan() error = %v", err)
 		}
 
+		foundStripe := false
 		for _, f := range findings {
 			if f.Type == TypeGitHubToken {
 				t.Error("TypeGitHubToken should be filtered out")
 			}
+			if f.Type == TypeStripeKey {
+				foundStripe = true
+			}
+		}
+		if !foundStripe {
+			t.Fatalf("expected the non-denied Stripe key finding to remain, got %+v", findings)
 		}
 	})
 
@@ -460,6 +474,9 @@ stripe: sk_live_abcdefghijklmnopqrstuvwxyz
 			t.Fatalf("Scan() error = %v", err)
 		}
 
+		if len(findings) == 0 {
+			t.Fatal("expected the 0.99-confidence GitHub token to pass the threshold, got none")
+		}
 		for _, f := range findings {
 			if f.Confidence < 0.98 {
 				t.Errorf("finding %s has confidence %f, expected >= 0.98", f.Type, f.Confidence)

--- a/internal/server/handler_trace_test.go
+++ b/internal/server/handler_trace_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -39,14 +38,26 @@ func setupTraceRecorder(t *testing.T) *tracetest.SpanRecorder {
 	return recorder
 }
 
-// findSpan finds a span whose name contains the given substring.
-func findSpan(spans []sdktrace.ReadOnlySpan, nameContains string) sdktrace.ReadOnlySpan {
+// findSpan finds the span with the exact given name. otelconnect names RPC
+// spans after the full procedure (e.g. "deputy.scan.v1.ScanService/Scan"), so
+// exact matching prevents a test from accidentally latching onto a span from
+// a different service that shares a method name.
+func findSpan(spans []sdktrace.ReadOnlySpan, name string) sdktrace.ReadOnlySpan {
 	for _, span := range spans {
-		if strings.Contains(span.Name(), nameContains) {
+		if span.Name() == name {
 			return span
 		}
 	}
 	return nil
+}
+
+// spanNames lists the recorded span names for failure messages.
+func spanNames(spans []sdktrace.ReadOnlySpan) []string {
+	names := make([]string, 0, len(spans))
+	for _, span := range spans {
+		names = append(names, span.Name())
+	}
+	return names
 }
 
 // spanHasAttribute checks if span has an attribute with the given key.
@@ -80,12 +91,12 @@ func TestScanHandler_Trace_InvalidArgument(t *testing.T) {
 
 	spans := recorder.Ended()
 	if len(spans) == 0 {
-		t.Skip("no spans recorded")
+		t.Fatal("no spans recorded")
 	}
 
-	scanSpan := findSpan(spans, "Scan")
+	scanSpan := findSpan(spans, "deputy.scan.v1.ScanService/Scan")
 	if scanSpan == nil {
-		t.Skip("Scan span not found")
+		t.Fatalf("Scan span not found, got %v", spanNames(spans))
 	}
 
 	if scanSpan.Status().Code != codes.Error {
@@ -112,12 +123,12 @@ func TestScanHandler_Trace_TargetAttribute(t *testing.T) {
 
 	spans := recorder.Ended()
 	if len(spans) == 0 {
-		t.Skip("no spans recorded")
+		t.Fatal("no spans recorded")
 	}
 
-	scanSpan := findSpan(spans, "Scan")
+	scanSpan := findSpan(spans, "deputy.scan.v1.ScanService/Scan")
 	if scanSpan == nil {
-		t.Skip("Scan span not found")
+		t.Fatalf("Scan span not found, got %v", spanNames(spans))
 	}
 
 	if !spanHasAttribute(scanSpan, "deputy.target.path") {
@@ -147,12 +158,12 @@ func TestListHandler_Trace_Ecosystems(t *testing.T) {
 
 	spans := recorder.Ended()
 	if len(spans) == 0 {
-		t.Skip("no spans recorded")
+		t.Fatal("no spans recorded")
 	}
 
-	span := findSpan(spans, "ListEcosystems")
+	span := findSpan(spans, "deputy.list.v1.ListService/ListEcosystems")
 	if span == nil {
-		t.Skip("ListEcosystems span not found")
+		t.Fatalf("ListEcosystems span not found, got %v", spanNames(spans))
 	}
 
 	if span.Status().Code == codes.Error {
@@ -182,12 +193,12 @@ func TestSecretsHandler_Trace_ListDetectors(t *testing.T) {
 
 	spans := recorder.Ended()
 	if len(spans) == 0 {
-		t.Skip("no spans recorded")
+		t.Fatal("no spans recorded")
 	}
 
-	span := findSpan(spans, "ListDetectors")
+	span := findSpan(spans, "deputy.secrets.v1.SecretsService/ListDetectors")
 	if span == nil {
-		t.Skip("ListDetectors span not found")
+		t.Fatalf("ListDetectors span not found, got %v", spanNames(spans))
 	}
 
 	if span.Status().Code == codes.Error {
@@ -216,12 +227,14 @@ func TestSecretsHandler_Trace_ScanError(t *testing.T) {
 
 	spans := recorder.Ended()
 	if len(spans) == 0 {
-		t.Skip("no spans recorded")
+		t.Fatal("no spans recorded")
 	}
 
-	span := findSpan(spans, "Scan")
+	// Exact name: a bare "Scan" substring would also match the scan
+	// service's span, which is not the RPC under test here.
+	span := findSpan(spans, "deputy.secrets.v1.SecretsService/Scan")
 	if span == nil {
-		t.Skip("Scan span not found")
+		t.Fatalf("secrets Scan span not found, got %v", spanNames(spans))
 	}
 
 	if span.Status().Code != codes.Error {
@@ -248,7 +261,7 @@ func TestHandler_Trace_SpanParenting(t *testing.T) {
 
 	spans := recorder.Ended()
 	if len(spans) == 0 {
-		t.Skip("no spans recorded")
+		t.Fatal("no spans recorded")
 	}
 
 	for _, span := range spans {
@@ -281,23 +294,19 @@ func TestOtelconnect_Integration(t *testing.T) {
 
 	spans := recorder.Ended()
 	if len(spans) == 0 {
-		t.Skip("no spans recorded")
+		t.Fatal("no spans recorded")
 	}
 
-	var scanSpans, listSpans, secretsSpans int
-	for _, span := range spans {
-		name := span.Name()
-		switch {
-		case strings.Contains(name, "ScanService") || (strings.Contains(name, "Scan") && !strings.Contains(name, "Secrets")):
-			scanSpans++
-		case strings.Contains(name, "ListService") || strings.Contains(name, "ListEcosystems"):
-			listSpans++
-		case strings.Contains(name, "SecretsService") || strings.Contains(name, "ListDetectors"):
-			secretsSpans++
+	// Each RPC must have produced its otelconnect server span.
+	for _, want := range []string{
+		"deputy.scan.v1.ScanService/Scan",
+		"deputy.list.v1.ListService/ListEcosystems",
+		"deputy.secrets.v1.SecretsService/ListDetectors",
+	} {
+		if findSpan(spans, want) == nil {
+			t.Errorf("expected span %q, got %v", want, spanNames(spans))
 		}
 	}
-
-	t.Logf("spans: scan=%d list=%d secrets=%d total=%d", scanSpans, listSpans, secretsSpans, len(spans))
 }
 
 func TestScanHandler_Direct_Trace(t *testing.T) {

--- a/internal/server/handler_trace_test.go
+++ b/internal/server/handler_trace_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -38,10 +39,19 @@ func setupTraceRecorder(t *testing.T) *tracetest.SpanRecorder {
 	return recorder
 }
 
-// findSpan finds the span with the exact given name. otelconnect names RPC
-// spans after the full procedure (e.g. "deputy.scan.v1.ScanService/Scan"), so
-// exact matching prevents a test from accidentally latching onto a span from
-// a different service that shares a method name.
+// rpcSpanName derives the otelconnect server span name from a generated
+// Connect procedure constant. otelconnect names RPC spans after the full
+// procedure minus the leading slash (verified against a live recorder:
+// "/deputy.scan.v1.ScanService/Scan" produces the span
+// "deputy.scan.v1.ScanService/Scan"). Deriving from the generated constants
+// keeps these tests in sync if a proto service or RPC is renamed.
+func rpcSpanName(procedure string) string {
+	return strings.TrimPrefix(procedure, "/")
+}
+
+// findSpan finds the span with the exact given name. Exact matching prevents
+// a test from accidentally latching onto a span from a different service that
+// shares a method name.
 func findSpan(spans []sdktrace.ReadOnlySpan, name string) sdktrace.ReadOnlySpan {
 	for _, span := range spans {
 		if span.Name() == name {
@@ -94,7 +104,7 @@ func TestScanHandler_Trace_InvalidArgument(t *testing.T) {
 		t.Fatal("no spans recorded")
 	}
 
-	scanSpan := findSpan(spans, "deputy.scan.v1.ScanService/Scan")
+	scanSpan := findSpan(spans, rpcSpanName(scanv1connect.ScanServiceScanProcedure))
 	if scanSpan == nil {
 		t.Fatalf("Scan span not found, got %v", spanNames(spans))
 	}
@@ -126,7 +136,7 @@ func TestScanHandler_Trace_TargetAttribute(t *testing.T) {
 		t.Fatal("no spans recorded")
 	}
 
-	scanSpan := findSpan(spans, "deputy.scan.v1.ScanService/Scan")
+	scanSpan := findSpan(spans, rpcSpanName(scanv1connect.ScanServiceScanProcedure))
 	if scanSpan == nil {
 		t.Fatalf("Scan span not found, got %v", spanNames(spans))
 	}
@@ -161,7 +171,7 @@ func TestListHandler_Trace_Ecosystems(t *testing.T) {
 		t.Fatal("no spans recorded")
 	}
 
-	span := findSpan(spans, "deputy.list.v1.ListService/ListEcosystems")
+	span := findSpan(spans, rpcSpanName(listv1connect.ListServiceListEcosystemsProcedure))
 	if span == nil {
 		t.Fatalf("ListEcosystems span not found, got %v", spanNames(spans))
 	}
@@ -196,7 +206,7 @@ func TestSecretsHandler_Trace_ListDetectors(t *testing.T) {
 		t.Fatal("no spans recorded")
 	}
 
-	span := findSpan(spans, "deputy.secrets.v1.SecretsService/ListDetectors")
+	span := findSpan(spans, rpcSpanName(secretsv1connect.SecretsServiceListDetectorsProcedure))
 	if span == nil {
 		t.Fatalf("ListDetectors span not found, got %v", spanNames(spans))
 	}
@@ -232,7 +242,7 @@ func TestSecretsHandler_Trace_ScanError(t *testing.T) {
 
 	// Exact name: a bare "Scan" substring would also match the scan
 	// service's span, which is not the RPC under test here.
-	span := findSpan(spans, "deputy.secrets.v1.SecretsService/Scan")
+	span := findSpan(spans, rpcSpanName(secretsv1connect.SecretsServiceScanProcedure))
 	if span == nil {
 		t.Fatalf("secrets Scan span not found, got %v", spanNames(spans))
 	}
@@ -299,9 +309,9 @@ func TestOtelconnect_Integration(t *testing.T) {
 
 	// Each RPC must have produced its otelconnect server span.
 	for _, want := range []string{
-		"deputy.scan.v1.ScanService/Scan",
-		"deputy.list.v1.ListService/ListEcosystems",
-		"deputy.secrets.v1.SecretsService/ListDetectors",
+		rpcSpanName(scanv1connect.ScanServiceScanProcedure),
+		rpcSpanName(listv1connect.ListServiceListEcosystemsProcedure),
+		rpcSpanName(secretsv1connect.SecretsServiceListDetectorsProcedure),
 	} {
 		if findSpan(spans, want) == nil {
 			t.Errorf("expected span %q, got %v", want, spanNames(spans))

--- a/internal/ui/repl/completion_test.go
+++ b/internal/ui/repl/completion_test.go
@@ -145,6 +145,9 @@ func TestCompletionEngine_PartialFieldAccess(t *testing.T) {
 
 	// "vulnerability.adv" should filter to advisory-related fields
 	completions := engine.Complete("vulnerability.adv", 17)
+	if len(completions) == 0 {
+		t.Fatal("expected completions for 'vulnerability.adv'")
+	}
 
 	for _, c := range completions {
 		if c.Text != "advisoryId" && c.Text != "advisory" {


### PR DESCRIPTION
A batch of negative assertions had the shape `for _, x := range items { if bad(x) { t.Fatal } }` with no floor on `len(items)`: when the code under test regresses to producing nothing, the loop never runs and the test passes.

Demonstrated before fixing, then reverted each breakage:

- gutting `FilteringScanner.Scan` to `return nil, nil` passed all three of its subtests
- removing MCP tool registration passed the read-only safety annotations test with zero tools
- the OCI digest-pinning assertion lived in an upstream callback nothing guaranteed was invoked

Three commits, test files only, no production changes:

1. Policy allow-halves in three files now assert the exact expected outcome (`len(actions) == 0` for pure-deny fixtures, positive warn where a warn is expected), plus a negative control proving the LSP analyzer actually reaches CEL.
2. Floors for secrets filtering, MCP annotations and schema tests, triage recommendations, OCI upstream invocation (atomic counter), REPL completions, and exact expected advisory sets for the documented CEL filter examples.
3. The server trace tests fail instead of skip when spans are missing: "no spans recorded" was the exact regression they exist to catch. `findSpan` is exact-match now, so the secrets test cannot latch onto a Scan span.

Every re-armed test passes against unmodified production code. One observation pinned rather than fixed: CEL programs compile without `InterruptCheckFrequency`, so evaluation does not actually stop on a cancelled context; the cancellation test now documents that so any change is deliberate.