### PR TITLE
Fix the starter policy and severity constants the tooling teaches

### DIFF
--- a/internal/cli/cmd/init.go
+++ b/internal/cli/cmd/init.go
@@ -7,8 +7,8 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/temporalio/deputy/internal/ecosystem"
 	"github.com/spf13/cobra"
+	"github.com/temporalio/deputy/internal/ecosystem"
 )
 
 // AddInitCommand adds the init command to the root command.
@@ -199,13 +199,19 @@ const policyTemplate = `
 
 policies:
   # Block critical and high severity vulnerabilities
+  # Severity lives at vulnerability.advisory.severity.level and is compared
+  # against the severity.* constants (severity.critical, severity.high, ...).
+  # The optional guard (.?advisory) keeps the rule safe when no advisory
+  # details are attached to a finding.
   - name: block-critical-high
     description: Prevent critical and high severity vulnerabilities from shipping
     entrypoints:
       - scan_vulnerability
     rules:
       - action: deny
-        when: vulnerability.severity in ["CRITICAL", "HIGH"]
+        when: |
+          vulnerability.?advisory.severity.level.orValue(severity.unspecified)
+            in [severity.critical, severity.high]
         reason: "Critical/High severity vulnerability must be remediated"
         remediation: "Upgrade to a fixed version or apply a patch"
 
@@ -216,7 +222,9 @@ policies:
       - scan_vulnerability
     rules:
       - action: warn
-        when: vulnerability.severity == "MEDIUM"
+        when: |
+          vulnerability.?advisory.severity.level.orValue(severity.unspecified)
+            == severity.medium
         reason: "Medium severity vulnerability should be reviewed"
 
   # Block vulnerabilities in CISA KEV (Known Exploited Vulnerabilities)
@@ -227,7 +235,7 @@ policies:
       - scan_vulnerability
     rules:
       - action: deny
-        when: vulnerability.inKEV == true
+        when: vulnerability.?in_kev.orValue(false)
         reason: "Vulnerability is in CISA Known Exploited Vulnerabilities catalog"
         remediation: "This vulnerability is actively exploited - prioritize immediate remediation"
 

--- a/internal/cli/cmd/init_test.go
+++ b/internal/cli/cmd/init_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	dependencyv1 "github.com/temporalio/deputy/gen/deputy/dependency/v1"
+	vulnerabilityv1 "github.com/temporalio/deputy/gen/deputy/vulnerability/v1"
+	"github.com/temporalio/deputy/internal/policy"
 )
 
 func TestInit(t *testing.T) {
@@ -183,7 +186,7 @@ func TestInit_PolicyContent(t *testing.T) {
 	expectedStrings := []string{
 		"policies:",
 		"block-critical-high",
-		"vulnerability.severity",
+		"vulnerability.?advisory.severity.level",
 		"action: deny",
 	}
 
@@ -191,6 +194,137 @@ func TestInit_PolicyContent(t *testing.T) {
 		if !strings.Contains(string(policyContent), s) {
 			t.Errorf("Policy file missing expected content: %s", s)
 		}
+	}
+}
+
+// TestInit_PolicyTemplateEvaluates is the drift gate for the starter policy:
+// the file that `deputy init` generates must compile AND evaluate cleanly
+// against representative Finding payloads at its declared entrypoint, and the
+// rules must actually fire on the findings they claim to catch. If the
+// template ever references fields that do not exist on the runtime contract
+// (e.g. vulnerability.severity or vulnerability.inKEV), evaluation errors and
+// this test fails.
+func TestInit_PolicyTemplateEvaluates(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	root := &cobra.Command{Use: "deputy"}
+	AddInitCommand(root)
+	root.SetArgs([]string{"init", "--policy-only", tmpDir})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	policyPath := filepath.Join(tmpDir, "policy", "deputy.yaml")
+
+	inKEV := true
+	epss := 0.9
+	tests := []struct {
+		name          string
+		vulnerability *vulnerabilityv1.Finding
+		// wantDenyFrom names the policy expected to deny the finding
+		// (evaluatePoliciesForCommand turns the first deny into an error).
+		// Empty means the finding must pass without a deny.
+		wantDenyFrom string
+		// wantWarn expects exactly one warn action when no deny fires.
+		wantWarn bool
+	}{
+		{
+			name: "critical finding in KEV with high EPSS",
+			vulnerability: &vulnerabilityv1.Finding{
+				AdvisoryId: "CVE-2021-23337",
+				Package:    &dependencyv1.Package{Name: "lodash", Version: "4.17.20", Ecosystem: "npm", Direct: true},
+				Advisory: &vulnerabilityv1.Advisory{
+					Id:            "CVE-2021-23337",
+					FixedVersions: []string{"4.17.21"},
+					Severity:      &vulnerabilityv1.Severity{Level: vulnerabilityv1.SeverityLevel_SEVERITY_LEVEL_CRITICAL},
+				},
+				InKev:    &inKEV,
+				Epss:     &epss,
+				Affected: true,
+			},
+			wantDenyFrom: "block-critical-high",
+		},
+		{
+			name: "high severity finding",
+			vulnerability: &vulnerabilityv1.Finding{
+				AdvisoryId: "CVE-2024-0001",
+				Package:    &dependencyv1.Package{Name: "foo", Version: "1.0.0", Ecosystem: "npm", Direct: true},
+				Advisory: &vulnerabilityv1.Advisory{
+					Id:       "CVE-2024-0001",
+					Severity: &vulnerabilityv1.Severity{Level: vulnerabilityv1.SeverityLevel_SEVERITY_LEVEL_HIGH},
+				},
+				Affected: true,
+			},
+			wantDenyFrom: "block-critical-high",
+		},
+		{
+			name: "medium severity finding without enrichment",
+			vulnerability: &vulnerabilityv1.Finding{
+				AdvisoryId: "CVE-2024-0002",
+				Package:    &dependencyv1.Package{Name: "bar", Version: "1.0.0", Ecosystem: "npm", Direct: true},
+				Advisory: &vulnerabilityv1.Advisory{
+					Id:       "CVE-2024-0002",
+					Severity: &vulnerabilityv1.Severity{Level: vulnerabilityv1.SeverityLevel_SEVERITY_LEVEL_MEDIUM},
+				},
+				Affected: true,
+			},
+			wantWarn: true,
+		},
+		{
+			name: "low severity finding",
+			vulnerability: &vulnerabilityv1.Finding{
+				AdvisoryId: "CVE-2024-0003",
+				Package:    &dependencyv1.Package{Name: "baz", Version: "2.0.0", Ecosystem: "go", Direct: false},
+				Advisory: &vulnerabilityv1.Advisory{
+					Id:       "CVE-2024-0003",
+					Severity: &vulnerabilityv1.Severity{Level: vulnerabilityv1.SeverityLevel_SEVERITY_LEVEL_LOW},
+				},
+				Affected: true,
+			},
+		},
+		{
+			name: "finding without advisory details",
+			vulnerability: &vulnerabilityv1.Finding{
+				AdvisoryId: "CVE-2024-0004",
+				Package:    &dependencyv1.Package{Name: "qux", Version: "3.0.0", Ecosystem: "pypi", Direct: true},
+				Affected:   true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload := map[string]any{"vulnerability": tt.vulnerability}
+			actions, err := evaluatePoliciesForCommand(t.Context(), []string{policyPath}, payload, "scan", policy.EntrypointScanVulnerability, &bytes.Buffer{})
+			if err != nil {
+				// Distinguish an expected policy denial from a template that
+				// references fields missing on the runtime contract.
+				if !strings.Contains(err.Error(), "denied command") {
+					t.Fatalf("generated starter policy failed to evaluate: %v", err)
+				}
+				if tt.wantDenyFrom == "" {
+					t.Fatalf("unexpected deny from starter policy: %v", err)
+				}
+				if !strings.Contains(err.Error(), tt.wantDenyFrom) {
+					t.Errorf("deny error %q does not mention policy %q", err, tt.wantDenyFrom)
+				}
+				return
+			}
+			if tt.wantDenyFrom != "" {
+				t.Fatalf("expected deny from %q, got actions %+v", tt.wantDenyFrom, actions)
+			}
+			var warns int
+			for _, a := range actions {
+				if a.Type == "warn" {
+					warns++
+				}
+			}
+			if tt.wantWarn && warns != 1 {
+				t.Errorf("expected exactly one warn action, got %d (%+v)", warns, actions)
+			}
+			if !tt.wantWarn && warns != 0 {
+				t.Errorf("expected no warn actions, got %d (%+v)", warns, actions)
+			}
+		})
 	}
 }
 

--- a/internal/cli/cmd/policy_repl.go
+++ b/internal/cli/cmd/policy_repl.go
@@ -170,7 +170,7 @@ func handleREPLCommandV2(line string, request map[string]string, entrypoint *str
 		})
 		r.Blank()
 		r.Section("Examples")
-		r.CELExample(`vulnerability.severity == severity.HIGH`)
+		r.CELExample(`finding.advisory.severity.level == severity.high`)
 		r.CELExample(`vulnerability.isDirect && size(vulnerability.fixedVersions) > 0`)
 		r.CELExample(`request.package == "lodash" && request.version == "4.17.20"`)
 		r.CELExample(`severityAtLeast(vulnerability, "HIGH")`)
@@ -213,7 +213,7 @@ func handleREPLCommandV2(line string, request map[string]string, entrypoint *str
 		r.FormatContext("request", toAnyMap(request))
 		r.Blank()
 		r.Section("Available Constants")
-		r.KeyValue("severity", "CRITICAL, HIGH, MEDIUM, LOW, UNSPECIFIED")
+		r.KeyValue("severity", strings.Join(policy.SeverityConstantNames(), ", "))
 		r.KeyValue("scope", "RUNTIME, DEV, TEST, BUILD, OPTIONAL, UNSPECIFIED")
 		return "", nil
 
@@ -296,13 +296,12 @@ func handleREPLCommandV2(line string, request map[string]string, entrypoint *str
 
 	case ":severity":
 		r.Section("Severity Constants")
-		r.Table([]ui.TableRow{
-			{Label: "severity.CRITICAL", Value: "\"CRITICAL\""},
-			{Label: "severity.HIGH", Value: "\"HIGH\""},
-			{Label: "severity.MEDIUM", Value: "\"MEDIUM\""},
-			{Label: "severity.LOW", Value: "\"LOW\""},
-			{Label: "severity.UNSPECIFIED", Value: "\"UNSPECIFIED\""},
-		})
+		consts := policy.SeverityConstants()
+		rows := make([]ui.TableRow, 0, len(consts))
+		for _, name := range policy.SeverityConstantNames() {
+			rows = append(rows, ui.TableRow{Label: "severity." + name, Value: fmt.Sprint(consts[name])})
+		}
+		r.Table(rows)
 		r.Blank()
 		r.Section("Severity Functions")
 		r.CommandHelp("severityAtLeast(vuln, level)", "Check if severity >= level")
@@ -553,7 +552,7 @@ func suggestFix(expr, errMsg string) string {
 	switch {
 	case strings.Contains(errMsg, "undeclared reference"):
 		if strings.Contains(expr, "severity.") && !strings.Contains(errMsg, "severity") {
-			return "severity constants are available: severity.CRITICAL, severity.HIGH, etc."
+			return "severity constants are available: severity.critical, severity.high, etc."
 		}
 		if strings.Contains(expr, ".") {
 			parts := strings.Split(expr, ".")

--- a/internal/docsgen/docsgen.go
+++ b/internal/docsgen/docsgen.go
@@ -64,7 +64,7 @@ func PolicyEntrypointsMarkdown() string {
 			continue
 		}
 		b.WriteString(fmt.Sprintf("### `%s`\n\n", typeName))
-		if comment := firstSentence(descriptorset.Comment(md.FullName())); comment != "" {
+		if comment := descriptorset.Summary(md.FullName()); comment != "" {
 			b.WriteString(comment + "\n\n")
 		}
 		writeFieldTable(&b, md)
@@ -133,7 +133,7 @@ func writeFieldTable(b *strings.Builder, md protoreflect.MessageDescriptor) {
 	slices.Sort(names)
 	for _, name := range names {
 		fd := byName[name]
-		fmt.Fprintf(b, "| `%s` | `%s` | %s |\n", name, fieldTypeString(fd), tableCell(firstSentence(descriptorset.Comment(fd.FullName()))))
+		fmt.Fprintf(b, "| `%s` | `%s` | %s |\n", name, fieldTypeString(fd), tableCell(descriptorset.Summary(fd.FullName())))
 	}
 	b.WriteString("\n")
 }
@@ -166,32 +166,6 @@ func scalarTypeString(fd protoreflect.FieldDescriptor) string {
 		return "double"
 	default:
 		return fd.Kind().String()
-	}
-}
-
-// firstSentence trims a proto comment to its first sentence so it fits a
-// table cell without losing the contract statement. A period only ends the
-// sentence when an uppercase letter follows, so abbreviations, URLs, and
-// version strings mid-sentence do not truncate it.
-func firstSentence(comment string) string {
-	comment = strings.TrimSpace(comment)
-	if comment == "" {
-		return ""
-	}
-	line := strings.ReplaceAll(comment, "\n", " ")
-	for idx := 0; ; {
-		next := strings.Index(line[idx:], ". ")
-		if next == -1 {
-			return line
-		}
-		idx += next
-		rest := strings.TrimLeft(line[idx+1:], " ")
-		if rest != "" {
-			if r := rune(rest[0]); r >= 'A' && r <= 'Z' {
-				return line[:idx+1]
-			}
-		}
-		idx += 2
 	}
 }
 

--- a/internal/policy/evaluator.go
+++ b/internal/policy/evaluator.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"maps"
@@ -118,6 +119,33 @@ func DefaultVariableNames() []string {
 // This allows external packages to use the same constants (severity.critical, etc.)
 func SeverityConstants() map[string]any {
 	return severityConstants
+}
+
+// SeverityConstantNames returns the member names of the severity constants map
+// (critical, high, medium, low, unspecified), ordered from most to least
+// severe. Tooling (REPL, LSP completions) must derive severity member lists
+// from this function so the names they teach can never drift from what the
+// runtime actually binds.
+func SeverityConstantNames() []string {
+	names := make([]string, 0, len(severityConstants))
+	for name := range severityConstants {
+		names = append(names, name)
+	}
+	slices.SortFunc(names, func(a, b string) int {
+		// Descending severity: critical first, unspecified last.
+		return cmp.Compare(severityLevelNumber(b), severityLevelNumber(a))
+	})
+	return names
+}
+
+// severityLevelNumber returns the proto enum number backing a severity
+// constant, used to order constant names by severity rank.
+func severityLevelNumber(name string) int32 {
+	level, ok := severityConstants[name].(vulnerabilityv1.SeverityLevel)
+	if !ok {
+		return -1
+	}
+	return int32(level)
 }
 
 // NewFilterEnv creates a CEL environment suitable for filter expressions.

--- a/internal/policy/lsp/completions.go
+++ b/internal/policy/lsp/completions.go
@@ -224,7 +224,9 @@ func celFieldCompletions(base string) []string {
 	case "request.client":
 		return []string{"ip", "userAgent", "principal"}
 	case "severity":
-		return []string{"CRITICAL", "HIGH", "MEDIUM", "LOW", "UNSPECIFIED"}
+		// Derived from the runtime constants map so completions offer exactly
+		// the members that evaluate (severity.critical, not severity.CRITICAL).
+		return policy.SeverityConstantNames()
 	case "scope":
 		return []string{"RUNTIME", "DEV", "TEST", "BUILD", "OPTIONAL", "UNSPECIFIED"}
 	case "repo":

--- a/internal/policy/lsp/completions_fields_test.go
+++ b/internal/policy/lsp/completions_fields_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	protocol "github.com/sourcegraph/go-lsp"
+	"github.com/temporalio/deputy/internal/policy"
 )
 
 func TestCompletionProvidesPkgFields(t *testing.T) {
@@ -12,5 +13,24 @@ func TestCompletionProvidesPkgFields(t *testing.T) {
 	items := completionItems(line, len(line))
 	if !slices.ContainsFunc(items, func(it protocol.CompletionItem) bool { return it.Label == "version" }) {
 		t.Fatalf("expected pkg field 'version' in completions, got %v", items)
+	}
+}
+
+// TestSeverityCompletionsMatchRuntimeConstants pins the severity member list
+// offered by completions to the runtime constants map: every offered member
+// must be a key of policy.SeverityConstants() and vice versa, so the LSP can
+// never teach identifiers (e.g. severity.CRITICAL) that fail to evaluate.
+func TestSeverityCompletionsMatchRuntimeConstants(t *testing.T) {
+	got := celFieldCompletions("severity")
+	want := policy.SeverityConstantNames()
+	if !slices.Equal(got, want) {
+		t.Fatalf("severity completions = %v, want runtime constant names %v", got, want)
+	}
+
+	wantSet := policy.SeverityConstants()
+	for _, name := range got {
+		if _, ok := wantSet[name]; !ok {
+			t.Errorf("completion offers severity.%s, which is not a runtime constant", name)
+		}
 	}
 }

--- a/internal/proto/descriptorset/descriptorset.go
+++ b/internal/proto/descriptorset/descriptorset.go
@@ -57,6 +57,39 @@ func Comment(name protoreflect.FullName) string {
 	return idx[name]
 }
 
+// Summary returns the first sentence of the proto element's leading comment,
+// for surfaces that need a one-line description (doc tables, completion hints)
+// rather than the full authored paragraph. The trailing period is kept, since
+// it is part of the sentence the proto author wrote.
+func Summary(name protoreflect.FullName) string {
+	return firstSentence(Comment(name))
+}
+
+// firstSentence trims a comment to its first sentence. A period only ends the
+// sentence when an uppercase letter follows, so abbreviations, URLs, and
+// version strings mid-sentence do not truncate it.
+func firstSentence(comment string) string {
+	comment = strings.TrimSpace(comment)
+	if comment == "" {
+		return ""
+	}
+	line := strings.ReplaceAll(comment, "\n", " ")
+	for idx := 0; ; {
+		next := strings.Index(line[idx:], ". ")
+		if next == -1 {
+			return line
+		}
+		idx += next
+		rest := strings.TrimLeft(line[idx+1:], " ")
+		if rest != "" {
+			if r := rune(rest[0]); r >= 'A' && r <= 'Z' {
+				return line[:idx+1]
+			}
+		}
+		idx += 2
+	}
+}
+
 // indexFile walks a file's source-code-info locations and records leading
 // comments for messages (path [4 m]), fields ([4 m 2 f]), enums ([5 e]), and
 // enum values ([5 e 2 v]), including nested messages.

--- a/internal/ui/repl/completion_test.go
+++ b/internal/ui/repl/completion_test.go
@@ -163,19 +163,19 @@ func TestCompletionEngine_EnumAccess(t *testing.T) {
 		t.Fatal("expected enum completions for 'severity.'")
 	}
 
-	// Should include CRITICAL
+	// Should include critical (constant members are lowercase at runtime)
 	found := false
 	for _, c := range completions {
-		if c.Text == "CRITICAL" {
+		if c.Text == "critical" {
 			found = true
 			if c.Kind != CompletionEnum {
-				t.Errorf("expected CompletionEnum for CRITICAL, got %v", c.Kind)
+				t.Errorf("expected CompletionEnum for critical, got %v", c.Kind)
 			}
 			break
 		}
 	}
 	if !found {
-		t.Error("expected 'CRITICAL' in severity enum completions")
+		t.Error("expected 'critical' in severity enum completions")
 	}
 }
 
@@ -183,14 +183,14 @@ func TestCompletionEngine_PartialEnum(t *testing.T) {
 	schema := NewSchemaRegistry()
 	engine := NewCompletionEngine(schema)
 
-	// "severity.HI" should filter to HIGH
-	completions := engine.Complete("severity.HI", 11)
+	// "severity.hi" should filter to high
+	completions := engine.Complete("severity.hi", 11)
 
 	if len(completions) != 1 {
-		t.Errorf("expected 1 completion for 'severity.HI', got %d", len(completions))
+		t.Errorf("expected 1 completion for 'severity.hi', got %d", len(completions))
 	}
-	if len(completions) > 0 && completions[0].Text != "HIGH" {
-		t.Errorf("expected 'HIGH', got %q", completions[0].Text)
+	if len(completions) > 0 && completions[0].Text != "high" {
+		t.Errorf("expected 'high', got %q", completions[0].Text)
 	}
 }
 
@@ -266,9 +266,9 @@ func TestCompletionEngine_GetHint_EnumDescription(t *testing.T) {
 	engine := NewCompletionEngine(schema)
 
 	// Hint for enum value should show description
-	hint := engine.GetHint("severity.CRIT", 14)
+	hint := engine.GetHint("severity.crit", 14)
 	if hint == nil {
-		t.Fatal("expected hint for 'severity.CRIT'")
+		t.Fatal("expected hint for 'severity.crit'")
 	}
 	if hint.Text == "" {
 		t.Error("expected hint with description")

--- a/internal/ui/repl/schema.go
+++ b/internal/ui/repl/schema.go
@@ -21,6 +21,7 @@ import (
 	scanv1 "github.com/temporalio/deputy/gen/deputy/scan/v1"
 	vulnerabilityv1 "github.com/temporalio/deputy/gen/deputy/vulnerability/v1"
 	"github.com/temporalio/deputy/internal/policy"
+	"github.com/temporalio/deputy/internal/proto/descriptorset"
 )
 
 // SchemaRegistry provides proto schema introspection for CEL hints.
@@ -173,21 +174,32 @@ func (r *SchemaRegistry) registerContainerSchemas() {
 		"Container image metadata")
 }
 
-// severityDescriptions documents the severity constant members offered in
-// completions. Keys are the runtime constant names from policy.SeverityConstants().
-var severityDescriptions = map[string]string{
-	"critical":    "Critical severity (CVSS 9.0-10.0)",
-	"high":        "High severity (CVSS 7.0-8.9)",
-	"medium":      "Medium severity (CVSS 4.0-6.9)",
-	"low":         "Low severity (CVSS 0.1-3.9)",
-	"unspecified": "Unknown severity",
+// enumValueDescription returns the description offered for an enum member: the
+// first sentence of the proto comment on the enum value with that number.
+// Descriptions therefore keep the proto's trailing period, unlike the
+// hand-written descriptions elsewhere in this file.
+//
+// The lookup goes through the value descriptor rather than reconstructing the
+// value name from a prefix, so a renamed or renumbered enum value yields "" (a
+// signal, caught by the schema tests) instead of a plausible wrong description.
+func enumValueDescription(enum protoreflect.EnumDescriptor, number protoreflect.EnumNumber) string {
+	value := enum.Values().ByNumber(number)
+	if value == nil {
+		return ""
+	}
+	// The descriptor set keys enum values as <enum full name>.<VALUE_NAME>,
+	// which is not EnumValueDescriptor.FullName(): proto scopes enum values to
+	// the enum's parent, not the enum itself.
+	return descriptorset.Summary(enum.FullName().Append(value.Name()))
 }
 
 // registerEnums adds enum schemas.
 func (r *SchemaRegistry) registerEnums() {
 	// SeverityLevel: member names derive from the runtime constants map so the
 	// REPL completes exactly the identifiers that evaluate (severity.critical,
-	// not severity.CRITICAL).
+	// not severity.CRITICAL), and the descriptions derive from the proto
+	// comments on the enum values those constants carry.
+	severityEnum := vulnerabilityv1.SeverityLevel_SEVERITY_LEVEL_UNSPECIFIED.Descriptor()
 	consts := policy.SeverityConstants()
 	values := make([]EnumValue, 0, len(consts))
 	for _, name := range policy.SeverityConstantNames() {
@@ -195,7 +207,7 @@ func (r *SchemaRegistry) registerEnums() {
 		values = append(values, EnumValue{
 			Name:        name,
 			Number:      int32(level),
-			Description: severityDescriptions[name],
+			Description: enumValueDescription(severityEnum, level.Number()),
 		})
 	}
 	r.enums["severity"] = &EnumSchema{
@@ -205,19 +217,34 @@ func (r *SchemaRegistry) registerEnums() {
 		Values:      values,
 	}
 
-	// Scope
+	// Scope: the runtime binds uppercase member names (scope.RUNTIME) that the
+	// policy package does not export, so the names stay literal here; the
+	// numbers and descriptions come from the proto enum they name.
+	scopeEnum := graphv1.Scope_SCOPE_UNSPECIFIED.Descriptor()
+	scopeMembers := []struct {
+		name  string
+		scope graphv1.Scope
+	}{
+		{"RUNTIME", graphv1.Scope_SCOPE_RUNTIME},
+		{"DEV", graphv1.Scope_SCOPE_DEV},
+		{"TEST", graphv1.Scope_SCOPE_TEST},
+		{"BUILD", graphv1.Scope_SCOPE_BUILD},
+		{"OPTIONAL", graphv1.Scope_SCOPE_OPTIONAL},
+		{"UNSPECIFIED", graphv1.Scope_SCOPE_UNSPECIFIED},
+	}
+	scopeValues := make([]EnumValue, 0, len(scopeMembers))
+	for _, member := range scopeMembers {
+		scopeValues = append(scopeValues, EnumValue{
+			Name:        member.name,
+			Number:      int32(member.scope),
+			Description: enumValueDescription(scopeEnum, member.scope.Number()),
+		})
+	}
 	r.enums["scope"] = &EnumSchema{
 		Name:        "Scope",
 		Description: "Dependency scope",
 		CELPrefix:   "scope.",
-		Values: []EnumValue{
-			{Name: "RUNTIME", Number: 1, Description: "Runtime dependency"},
-			{Name: "DEV", Number: 2, Description: "Development dependency"},
-			{Name: "TEST", Number: 5, Description: "Test dependency"},
-			{Name: "BUILD", Number: 4, Description: "Build-time dependency"},
-			{Name: "OPTIONAL", Number: 3, Description: "Optional dependency"},
-			{Name: "UNSPECIFIED", Number: 0, Description: "Unspecified scope"},
-		},
+		Values:      scopeValues,
 	}
 }
 

--- a/internal/ui/repl/schema.go
+++ b/internal/ui/repl/schema.go
@@ -20,6 +20,7 @@ import (
 	graphv1 "github.com/temporalio/deputy/gen/deputy/graph/v1"
 	scanv1 "github.com/temporalio/deputy/gen/deputy/scan/v1"
 	vulnerabilityv1 "github.com/temporalio/deputy/gen/deputy/vulnerability/v1"
+	"github.com/temporalio/deputy/internal/policy"
 )
 
 // SchemaRegistry provides proto schema introspection for CEL hints.
@@ -61,10 +62,10 @@ type FieldSchema struct {
 
 // EnumSchema describes a proto enum type.
 type EnumSchema struct {
-	Name        string       // Enum type name
-	Description string       // Human-readable description
-	Values      []EnumValue  // Enum values
-	CELPrefix   string       // How to access in CEL (e.g., "severity.")
+	Name        string      // Enum type name
+	Description string      // Human-readable description
+	Values      []EnumValue // Enum values
+	CELPrefix   string      // How to access in CEL (e.g., "severity.")
 }
 
 // EnumValue describes a single enum value.
@@ -172,20 +173,36 @@ func (r *SchemaRegistry) registerContainerSchemas() {
 		"Container image metadata")
 }
 
+// severityDescriptions documents the severity constant members offered in
+// completions. Keys are the runtime constant names from policy.SeverityConstants().
+var severityDescriptions = map[string]string{
+	"critical":    "Critical severity (CVSS 9.0-10.0)",
+	"high":        "High severity (CVSS 7.0-8.9)",
+	"medium":      "Medium severity (CVSS 4.0-6.9)",
+	"low":         "Low severity (CVSS 0.1-3.9)",
+	"unspecified": "Unknown severity",
+}
+
 // registerEnums adds enum schemas.
 func (r *SchemaRegistry) registerEnums() {
-	// SeverityLevel
+	// SeverityLevel: member names derive from the runtime constants map so the
+	// REPL completes exactly the identifiers that evaluate (severity.critical,
+	// not severity.CRITICAL).
+	consts := policy.SeverityConstants()
+	values := make([]EnumValue, 0, len(consts))
+	for _, name := range policy.SeverityConstantNames() {
+		level, _ := consts[name].(vulnerabilityv1.SeverityLevel)
+		values = append(values, EnumValue{
+			Name:        name,
+			Number:      int32(level),
+			Description: severityDescriptions[name],
+		})
+	}
 	r.enums["severity"] = &EnumSchema{
 		Name:        "SeverityLevel",
 		Description: "Vulnerability severity levels",
 		CELPrefix:   "severity.",
-		Values: []EnumValue{
-			{Name: "CRITICAL", Number: 4, Description: "Critical severity (CVSS 9.0-10.0)"},
-			{Name: "HIGH", Number: 3, Description: "High severity (CVSS 7.0-8.9)"},
-			{Name: "MEDIUM", Number: 2, Description: "Medium severity (CVSS 4.0-6.9)"},
-			{Name: "LOW", Number: 1, Description: "Low severity (CVSS 0.1-3.9)"},
-			{Name: "UNSPECIFIED", Number: 0, Description: "Unknown severity"},
-		},
+		Values:      values,
 	}
 
 	// Scope
@@ -322,10 +339,6 @@ func (r *SchemaRegistry) registerFunctions() {
 		{Name: "isHighOrAbove", Signature: "isHighOrAbove(vulnerability) bool",
 			Description: "Check if severity is HIGH or CRITICAL", Parameters: []string{"vulnerability"},
 			ReturnType: "bool", Category: "severity"},
-		{Name: "vulnerabilitySeverity", Signature: "vulnerabilitySeverity(vulnerability) string",
-			Description: "Get severity level string", Parameters: []string{"vulnerability"},
-			ReturnType: "string", Category: "severity"},
-
 		// Graph functions
 		{Name: "isDirectDep", Signature: "isDirectDep(node) bool",
 			Description: "Check if node is direct dependency", Parameters: []string{"node"},

--- a/internal/ui/repl/schema_test.go
+++ b/internal/ui/repl/schema_test.go
@@ -1,7 +1,10 @@
 package repl
 
 import (
+	"slices"
 	"testing"
+
+	"github.com/temporalio/deputy/internal/policy"
 )
 
 func TestNewSchemaRegistry(t *testing.T) {
@@ -63,19 +66,29 @@ func TestSchemaRegistry_Enums(t *testing.T) {
 		t.Errorf("expected 5 severity values, got %d", len(severity.Values))
 	}
 
-	// Check CRITICAL value
+	// Check critical value (constant members are lowercase at runtime)
 	hasCritical := false
 	for _, v := range severity.Values {
-		if v.Name == "CRITICAL" {
+		if v.Name == "critical" {
 			hasCritical = true
 			if v.Number != 4 {
-				t.Errorf("expected CRITICAL number 4, got %d", v.Number)
+				t.Errorf("expected critical number 4, got %d", v.Number)
 			}
 			break
 		}
 	}
 	if !hasCritical {
-		t.Error("expected CRITICAL in severity enum")
+		t.Error("expected critical in severity enum")
+	}
+
+	// The offered member names must match the runtime constants map exactly,
+	// otherwise completions teach identifiers that fail to evaluate.
+	var names []string
+	for _, v := range severity.Values {
+		names = append(names, v.Name)
+	}
+	if want := policy.SeverityConstantNames(); !slices.Equal(names, want) {
+		t.Errorf("severity enum members = %v, want runtime constants %v", names, want)
 	}
 
 	// Should have scope enum
@@ -231,5 +244,23 @@ func TestToCamelCase(t *testing.T) {
 				t.Errorf("toCamelCase(%q) = %q, want %q", tt.input, got, tt.expected)
 			}
 		})
+	}
+}
+
+// TestSchemaFunctions_SeverityHelpersAreRegistered pins the severity helper
+// functions offered in completions to the runtime helper catalog, so the REPL
+// cannot offer functions (e.g. a former vulnerabilitySeverity entry) that are
+// not registered in any CEL environment.
+func TestSchemaFunctions_SeverityHelpersAreRegistered(t *testing.T) {
+	registered := make(map[string]bool)
+	for _, fn := range policy.HelperCatalog() {
+		registered[fn.Name] = true
+	}
+
+	r := NewSchemaRegistry()
+	for _, fn := range r.GetFunctionsByCategory("severity") {
+		if !registered[fn.Name] {
+			t.Errorf("schema offers severity function %q, which is not in the runtime helper catalog", fn.Name)
+		}
 	}
 }

--- a/internal/ui/repl/schema_test.go
+++ b/internal/ui/repl/schema_test.go
@@ -98,6 +98,63 @@ func TestSchemaRegistry_Enums(t *testing.T) {
 	}
 }
 
+// TestSchemaRegistry_EnumDescriptionsComeFromProtoComments pins the enum member
+// descriptions to the proto comments. Every member must carry a description,
+// because an empty one means the descriptor lookup drifted (a renamed or
+// renumbered enum value) rather than that the member deserves no help text. The
+// exact expectations keep the assertion non-vacuous: they are the proto comments
+// verbatim, first sentence and trailing period included, so editing a comment in
+// the .proto surfaces here instead of silently changing REPL hints.
+func TestSchemaRegistry_EnumDescriptionsComeFromProtoComments(t *testing.T) {
+	r := NewSchemaRegistry()
+
+	tests := []struct {
+		enum string
+		want map[string]string // member name -> exact expected description
+	}{
+		{
+			enum: "severity",
+			want: map[string]string{
+				"critical":    "Critical severity (CVSS 9.0-10.0).",
+				"unspecified": "The advisory record Deputy matched carries no rating.",
+			},
+		},
+		{
+			enum: "scope",
+			want: map[string]string{
+				"RUNTIME": "Runtime dependency.",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.enum, func(t *testing.T) {
+			schema := r.GetEnum(tt.enum)
+			if schema == nil {
+				t.Fatalf("expected %s enum", tt.enum)
+			}
+			if len(schema.Values) == 0 {
+				t.Fatalf("expected %s enum members", tt.enum)
+			}
+			for _, v := range schema.Values {
+				if v.Description == "" {
+					t.Errorf("%s.%s has an empty description: the proto comment is missing or the descriptor lookup no longer resolves this member", tt.enum, v.Name)
+				}
+				if want, ok := tt.want[v.Name]; ok && v.Description != want {
+					t.Errorf("%s.%s description = %q, want the proto comment %q", tt.enum, v.Name, v.Description, want)
+				}
+			}
+			// Guard the expectations themselves: a renamed member would make
+			// the exact checks above vacuous.
+			for name := range tt.want {
+				if !slices.ContainsFunc(schema.Values, func(v EnumValue) bool { return v.Name == name }) {
+					t.Errorf("%s enum has no member %q to check", tt.enum, name)
+				}
+			}
+		})
+	}
+}
+
 func TestSchemaRegistry_Functions(t *testing.T) {
 	r := NewSchemaRegistry()
 


### PR DESCRIPTION
`deputy init` shipped a starter policy where three of four rules reference fields that do not exist (`vulnerability.severity`, `vulnerability.inKEV`), so every new user's flagship block-critical rule errored at scan time and enforced nothing. The REPL and LSP taught the same broken syntax: uppercase `severity.CRITICAL` completions when the runtime constants are lowercase, plus a completion for a CEL function that is registered nowhere.

Before: `deputy init` then scan gives `block-critical-high: no such key: severity`.
After: same flow lints OK and denies on a critical finding; medium warns; an advisory-less finding passes cleanly.

The template now uses the real contract (`vulnerability.?advisory.severity.level.orValue(severity.unspecified)`, `vulnerability.?in_kev.orValue(false)`; the advisory hop is the nullable one, verified empirically). LSP and REPL severity members derive from `policy.SeverityConstants()` via a new `SeverityConstantNames()`, so they cannot drift again.

Drift gates included: the generated template must compile and evaluate against representative findings, and the tooling member lists must equal the runtime constant keys. Both fail on main.