### PR TITLE
Derive test corpora from their canonical sources

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/go-git/go-git/v5"
-	"github.com/spf13/cobra"
 )
 
 func TestParseLogLevel(t *testing.T) {
@@ -39,6 +38,11 @@ func TestParseLogLevel(t *testing.T) {
 	}
 }
 
+// TestNewRoot pins the complete set of first-class subcommands registered by
+// cmd.RegisterCommands. The expected set is exhaustive and compared with
+// slices.Equal, so a dropped (or newly added) Add*Command call in
+// internal/cli/cmd/register.go fails this test instead of silently shrinking
+// the CLI surface.
 func TestNewRoot(t *testing.T) {
 	cmd := newRoot()
 	if cmd.Use != "deputy" {
@@ -48,14 +52,23 @@ func TestNewRoot(t *testing.T) {
 		t.Error("expected subcommands to be registered")
 	}
 
-	// Check for specific subcommands
-	expectedCmds := []string{"scan", "fix", "triage", "policy", "proxy", "diff", "list", "sbom"}
-	for _, name := range expectedCmds {
-		if !slices.ContainsFunc(cmd.Commands(), func(c *cobra.Command) bool {
-			return c.Name() == name
-		}) {
-			t.Errorf("expected subcommand %q not found", name)
-		}
+	// The full registration list from cmd.RegisterCommands, sorted. Cobra's
+	// implicit commands (help, completion) are attached at Execute time and
+	// excluded here.
+	want := []string{
+		"cache", "config", "diff", "ecosystems", "exec", "explain", "fix",
+		"graph", "init", "list", "mcp", "pin", "policy", "proxy", "sbom",
+		"scan", "secrets", "server", "triage", "version",
+	}
+
+	got := make([]string, 0, len(cmd.Commands()))
+	for _, c := range cmd.Commands() {
+		got = append(got, c.Name())
+	}
+	slices.Sort(got)
+
+	if !slices.Equal(got, want) {
+		t.Errorf("registered subcommands drifted from cmd.RegisterCommands:\n got: %v\nwant: %v", got, want)
 	}
 }
 

--- a/internal/cli/cmd/policy_examples_test.go
+++ b/internal/cli/cmd/policy_examples_test.go
@@ -2,24 +2,30 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/temporalio/deputy/internal/policy"
 )
 
+// TestPolicyExamplesListUsesCanonicalCategories derives the expected listing
+// from policy.ExampleCategories, so every canonical category (current and
+// future) must appear with its registered description, and the legacy
+// category names must stay absent.
 func TestPolicyExamplesListUsesCanonicalCategories(t *testing.T) {
 	var out bytes.Buffer
 	if err := listPolicyEntrypoints(&out); err != nil {
 		t.Fatalf("listPolicyEntrypoints returned error: %v", err)
 	}
 	text := out.String()
-	for _, want := range []string{
-		"container_diff - Container image policies",
-		"server - API authorization policies",
-		"fix - Remediation planning policies",
-		"triage - Vulnerability triage policies",
-		"sandbox - Sandbox execution control policies",
-	} {
-		if !strings.Contains(text, want) {
+
+	// Sanity floor: 12 canonical categories today.
+	if len(policy.ExampleCategories) < 12 {
+		t.Fatalf("policy.ExampleCategories has %d categories, want at least 12", len(policy.ExampleCategories))
+	}
+	for _, cat := range policy.ExampleCategories {
+		if want := fmt.Sprintf("%s - %s", cat.Name, cat.Description); !strings.Contains(text, want) {
 			t.Fatalf("policy examples list missing %q in:\n%s", want, text)
 		}
 	}

--- a/internal/docsgen/docsgen_test.go
+++ b/internal/docsgen/docsgen_test.go
@@ -1,9 +1,12 @@
 package docsgen
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/temporalio/deputy/internal/policy"
 )
 
 // TestPolicyInputsDocIsGenerated pins the committed policy entrypoint
@@ -33,10 +36,21 @@ func TestPolicyEntrypointsMarkdownCoversEveryEntrypoint(t *testing.T) {
 			t.Fatalf("missing %q heading", heading)
 		}
 	}
-	// A representative registry entrypoint and a proto-comment-derived cell.
-	if !strings.Contains(out, "#### `scan_vulnerability`") {
-		t.Fatal("missing scan_vulnerability entrypoint")
+
+	// Every registered entrypoint must render its own heading. Deriving from
+	// policy.AllEntrypoints means a new entrypoint the renderer skips fails
+	// here instead of silently missing from the reference.
+	// Sanity floor: 37 canonical entrypoints today.
+	if len(policy.AllEntrypoints) < 37 {
+		t.Fatalf("policy.AllEntrypoints has %d entrypoints, want at least 37", len(policy.AllEntrypoints))
 	}
+	for _, ep := range policy.AllEntrypoints {
+		if heading := fmt.Sprintf("#### `%s`", ep); !strings.Contains(out, heading) {
+			t.Errorf("missing %s entrypoint heading", ep)
+		}
+	}
+
+	// A proto-comment-derived cell.
 	if !strings.Contains(out, "### `vulnerabilityv1.Finding`") {
 		t.Fatal("missing vulnerabilityv1.Finding variable type table")
 	}

--- a/internal/ecosystem/ecosystem_test.go
+++ b/internal/ecosystem/ecosystem_test.go
@@ -365,22 +365,33 @@ func TestWantsLicenseLookup(t *testing.T) {
 	}
 }
 
+// TestProxyEntrypoint pins the entrypoint synthesis contract across the whole
+// registry. ProxyEntrypoint mechanically synthesizes "<name>_artifact_request"
+// for every ecosystem, but only proxy-capable ecosystems ever reach it (the
+// proxy handler registry is keyed by proxy support, see
+// internal/proxy/handler_registry.go), so the load-bearing invariant is that
+// every proxy-capable ecosystem synthesizes a canonical policy entrypoint.
+// Non-proxy ecosystems synthesizing unknown names is expected and harmless.
 func TestProxyEntrypoint(t *testing.T) {
-	tests := []struct {
-		eco  Ecosystem
-		want string
-	}{
-		{Go, "go_artifact_request"},
-		{NPM, "npm_artifact_request"},
-		{PyPI, "pypi_artifact_request"},
-	}
-
-	for _, tt := range tests {
-		t.Run(string(tt.eco), func(t *testing.T) {
-			got := string(tt.eco.ProxyEntrypoint())
-			if got != tt.want {
-				t.Errorf("%s.ProxyEntrypoint() = %q, want %q", tt.eco, got, tt.want)
+	proxyCapable := 0
+	for _, eco := range All() {
+		t.Run(string(eco), func(t *testing.T) {
+			got := eco.ProxyEntrypoint()
+			if want := string(eco) + "_artifact_request"; string(got) != want {
+				t.Errorf("%s.ProxyEntrypoint() = %q, want %q", eco, got, want)
+			}
+			if eco.Capabilities().Proxy && !got.IsValid() {
+				t.Errorf("proxy-capable ecosystem %s synthesizes entrypoint %q, which is not a canonical policy entrypoint; proxy policies for it would never match", eco, got)
 			}
 		})
+		if eco.Capabilities().Proxy {
+			proxyCapable++
+		}
+	}
+
+	// Sanity floor: 4 proxy-capable ecosystems today (go, npm, pypi,
+	// rubygems); zero would make the validity assertion above vacuous.
+	if proxyCapable < 4 {
+		t.Errorf("only %d proxy-capable ecosystems in All(), want at least 4", proxyCapable)
 	}
 }

--- a/internal/inventory/inventory_ecosystems_test.go
+++ b/internal/inventory/inventory_ecosystems_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/osv-scalibr/plugin"
+	"github.com/temporalio/deputy/internal/ecosystem"
 )
 
 // TestScalibrEcosystemNames pins the filter vocabulary contract: Deputy's
@@ -39,14 +40,22 @@ func TestScalibrEcosystemNames(t *testing.T) {
 }
 
 // TestResolvePluginsAcceptsCanonicalEcosystemNames pins the end-to-end filter
-// contract: the names Deputy advertises in CLI help and emits in results
-// (cargo, npm, pypi) must resolve to plugins instead of erroring with
-// scalibr's unknown-plugin failure.
+// contract: every canonical ecosystem name Deputy advertises in CLI help and
+// emits in results (ecosystem.All()) must resolve to plugins instead of
+// erroring with scalibr's unknown-plugin failure. Ranging over the registry
+// keeps newly added ecosystems covered automatically.
 func TestResolvePluginsAcceptsCanonicalEcosystemNames(t *testing.T) {
+	all := ecosystem.All()
+	// Sanity floor: 13 canonical ecosystems today; an empty or shrunken
+	// registry would silently hollow out this test.
+	if len(all) < 13 {
+		t.Fatalf("ecosystem.All() returned %d ecosystems, want at least 13", len(all))
+	}
+
 	cap := &plugin.Capabilities{OS: plugin.OSLinux}
-	for _, eco := range []string{"cargo", "npm", "pypi", "maven", "rubygems", "nuget", "hex", "pub", "cocoapods", "packagist"} {
-		t.Run(eco, func(t *testing.T) {
-			plugins, err := resolvePlugins(ScanOptions{Ecosystems: []string{eco}}, cap)
+	for _, eco := range all {
+		t.Run(string(eco), func(t *testing.T) {
+			plugins, err := resolvePlugins(ScanOptions{Ecosystems: []string{string(eco)}}, cap)
 			if err != nil {
 				t.Fatalf("resolvePlugins(%q): %v", eco, err)
 			}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -84,6 +84,12 @@ type Server struct {
 	toolTimeouts        ToolTimeouts // configurable timeouts for tool operations
 	defaultExcludePaths []string
 	startedAt           time.Time
+
+	// registeredTools retains every registered tool definition (name plus the
+	// proto-derived input/output schemas) so tests can walk the complete
+	// schema corpus; the MCP SDK does not expose registered tools for
+	// enumeration.
+	registeredTools []*mcp.Tool
 }
 
 // ServerOption configures a Server.
@@ -138,7 +144,7 @@ const serverInstructions = "Deputy is a supply-chain security engine. Its tools 
 	"- Prefer a PURL (e.g. `pkg:npm/lodash@4.17.21`) for exact matches. Tools also accept `name`, `name@version`, or `name` + `ecosystem`. Ecosystem names are lenient (e.g. `gha` resolves to `github-actions`, `golang` to `go`).\n" +
 	"\n" +
 	"Reading results\n" +
-	"- Severity totals include an `unknown` bucket, so per-severity counts always sum to the total. `UNKNOWN` means the matched advisory record carries no rating (common for Go vuln DB records), not that none exists: pass `enrich: true` to scan and triage tools to resolve ratings from alias advisories (GHSA first), at the cost of extra network lookups. `explain_vulnerability` always resolves across aliases.\n" +
+	"- Severity totals include an `unknown` bucket, so per-severity counts always sum to the total. `UNKNOWN` means the matched advisory record carries no rating (common for Go vuln DB records), not that none exists: pass `enrich: true` to scan and triage tools to resolve ratings from alias advisories (GHSA first), at the cost of extra network lookups. `explain_vulnerability` (and `explain_vulnerabilities` for batches) always resolves across aliases.\n" +
 	"- Sampled outputs (advisory references, graph paths) are capped and set a `*Truncated` flag alongside a full count (e.g. `pathCount` with `pathsTruncated`); check them before assuming a result is complete. Other lists are returned whole. Ordering is deterministic across calls.\n" +
 	"- A clean target reports `clean: true`; this is success, not an error.\n" +
 	"- Absent fields mean empty, zero, or not applicable: results omit empty lists, zero counts, and optional attributes (no `vulnerabilities` key = none found; no `kind` = ordinary vulnerability). Affirmative answers (`clean`, `found`, `direct`, `hasFix`, `migration`, `executable`, `depth`, `isContainerDiff`) are present whenever they apply, even when false or zero; severity count maps always carry all their keys.\n" +
@@ -148,10 +154,12 @@ const serverInstructions = "Deputy is a supply-chain security engine. Its tools 
 	"\n" +
 	"Typical workflow\n" +
 	"- Assess: `scan_directory` then `triage_vulnerabilities` to rank findings by severity and fixability.\n" +
-	"- Investigate: `graph_why` (why a package is present) and `graph_needs` (what depends on it). Set `resolveTransitives` for precise transitive edges (slower, may use the network).\n" +
+	"- Inventory: `list_dependencies` for a plain package inventory; `generate_sbom` for a CycloneDX or SPDX document.\n" +
+	"- Investigate: `graph_why` (why a package is present), `graph_needs` (what depends on it), and `analyze_dependency_graph` (whole-graph stats and paths to a PURL). Set `resolveTransitives` for precise transitive edges (slower, may use the network).\n" +
 	"- Remediate: `get_remediation` for upgrade/migration commands; hints reference these MCP tools by name.\n" +
 	"- Compare: `diff_refs` for two Git refs or two container images.\n" +
-	"- Author policies: `list_policy_entrypoints` returns entrypoints, categories, CEL variables, and helpers."
+	"- Author policies: `list_policy_entrypoints` returns entrypoints, categories, CEL variables, and helpers.\n" +
+	"- Server metadata: `get_server_info` reports build, uptime, and registered tools."
 
 // NewServer creates a new Deputy MCP server with vulnerability analysis tools.
 func NewServer(opts ...ServerOption) *Server {
@@ -396,6 +404,7 @@ func (s *Server) handleInfo(w http.ResponseWriter, r *http.Request) {
 func addTool[T, R any](s *Server, tool *mcp.Tool, handler func(context.Context, *mcp.CallToolRequest, T) (*mcp.CallToolResult, R, error)) {
 	mcp.AddTool(s.server, tool, handler)
 	s.toolNames = append(s.toolNames, tool.Name)
+	s.registeredTools = append(s.registeredTools, tool)
 }
 
 func addReadOnlyTool[T, R any](

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"strings"
 	"testing"
@@ -582,32 +583,89 @@ func TestNewServer_WithOptions(t *testing.T) {
 	}
 }
 
+// TestServerInstructionsReferenceRealTools pins the instructions text to the
+// registered tool set in both directions. Backticked snake_case tokens in the
+// instructions are tool references (field names are camelCase there), so every
+// such token must name a registered tool, and every registered tool must be
+// mentioned: the instructions are the session-level tool catalog an agent
+// navigates by.
 func TestServerInstructionsReferenceRealTools(t *testing.T) {
 	if strings.TrimSpace(serverInstructions) == "" {
 		t.Fatal("serverInstructions is empty")
 	}
+	toolNames := NewServer().toolNames
+	// Sanity floor: 15 registered tools today.
+	if len(toolNames) < 15 {
+		t.Fatalf("registered %d tools, want at least 15: %v", len(toolNames), toolNames)
+	}
 	registered := make(map[string]bool)
-	for _, name := range NewServer().toolNames {
+	for _, name := range toolNames {
 		registered[name] = true
 	}
-	// Tools named in the instructions must exist, so guidance can't reference a
-	// renamed or removed tool.
-	for _, name := range []string{
-		"scan_directory", "triage_vulnerabilities", "graph_why", "graph_needs",
-		"get_remediation", "diff_refs", "scan_container", "scan_package",
-		"list_policy_entrypoints",
-	} {
-		if !strings.Contains(serverInstructions, name) {
-			t.Errorf("serverInstructions does not mention %q", name)
+
+	// Every tool-shaped token in the instructions must be a registered tool,
+	// so guidance can't reference a renamed or removed tool.
+	toolToken := regexp.MustCompile("`([a-z0-9]+(?:_[a-z0-9]+)+)`")
+	mentioned := 0
+	for _, m := range toolToken.FindAllStringSubmatch(serverInstructions, -1) {
+		if !registered[m[1]] {
+			t.Errorf("serverInstructions references %q which is not a registered tool", m[1])
+			continue
 		}
-		if !registered[name] {
-			t.Errorf("serverInstructions references %q which is not a registered tool", name)
+		mentioned++
+	}
+	if mentioned == 0 {
+		t.Error("serverInstructions mentions no registered tools; the token pattern may have gone stale")
+	}
+
+	// Every registered tool must be mentioned, so a newly added tool cannot
+	// stay invisible to agents reading the instructions.
+	for _, name := range toolNames {
+		if !strings.Contains(serverInstructions, "`"+name+"`") {
+			t.Errorf("serverInstructions does not mention registered tool %q", name)
 		}
 	}
+
 	// Key output conventions agents rely on must stay documented.
 	for _, phrase := range []string{"unknown", "Truncated", "clean: true", "found: false", "PURL"} {
 		if !strings.Contains(serverInstructions, phrase) {
 			t.Errorf("serverInstructions should describe %q", phrase)
+		}
+	}
+}
+
+// TestToolSchemasFreeOfClientRejectedKeywords guards the constraint that broke
+// tool loading in production for every registered tool, not a sample: no
+// schema the server advertises may contain $ref or oneOf/anyOf/allOf at any
+// level (checked via the marshaled JSON, which serializes all nesting). The
+// corpus is Server.registeredTools, so tools added later are covered
+// automatically.
+func TestToolSchemasFreeOfClientRejectedKeywords(t *testing.T) {
+	s := NewServer()
+	// Sanity floor: 15 registered tools today.
+	if len(s.registeredTools) < 15 {
+		t.Fatalf("registered %d tools, want at least 15", len(s.registeredTools))
+	}
+
+	for _, tool := range s.registeredTools {
+		for direction, schema := range map[string]any{
+			"input":  tool.InputSchema,
+			"output": tool.OutputSchema,
+		} {
+			raw, err := json.Marshal(schema)
+			if err != nil {
+				t.Errorf("marshal %s %s schema: %v", tool.Name, direction, err)
+				continue
+			}
+			if string(raw) == "null" {
+				t.Errorf("tool %s has no %s schema", tool.Name, direction)
+				continue
+			}
+			for _, banned := range []string{`"$ref"`, `"oneOf"`, `"anyOf"`, `"allOf"`} {
+				if strings.Contains(string(raw), banned) {
+					t.Errorf("tool %s %s schema contains %s, which MCP clients reject", tool.Name, direction, banned)
+				}
+			}
 		}
 	}
 }

--- a/internal/proxy/handler_registry.go
+++ b/internal/proxy/handler_registry.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"fmt"
+	"maps"
 	"net/http"
 	"strings"
 	"sync"
@@ -135,9 +136,12 @@ type HandlerFactory struct {
 }
 
 // NewHandlerFactory creates a factory with the default ecosystem registry.
+// The factory owns a copy of the defaults, so Register extends this factory
+// only instead of mutating the package-level registry shared by every other
+// factory.
 func NewHandlerFactory() *HandlerFactory {
 	return &HandlerFactory{
-		registry: ecosystemRegistry,
+		registry: maps.Clone(ecosystemRegistry),
 	}
 }
 

--- a/internal/proxy/handler_registry_test.go
+++ b/internal/proxy/handler_registry_test.go
@@ -134,6 +134,12 @@ func TestHandlerFactory_Register(t *testing.T) {
 	if !found {
 		t.Error("registered ecosystem not found in supported list")
 	}
+
+	// Registration must extend this factory only, never the package-level
+	// default registry shared by every other factory.
+	if _, ok := ecosystemRegistry[ecosystem.Cargo]; ok {
+		t.Error("Register mutated the package-level default registry; factories must own their registry copy")
+	}
 }
 
 func TestNewHandlerFromString(t *testing.T) {

--- a/internal/proxy/handler_registry_test.go
+++ b/internal/proxy/handler_registry_test.go
@@ -244,3 +244,34 @@ func TestGenericHandler_ServeHTTP(t *testing.T) {
 		}
 	})
 }
+
+// TestEcosystemRegistryEntrypointsAreCanonical pins the call-site invariant of
+// genericHandler.ServeHTTP: every ecosystem registered for proxying must have
+// proxy capability and must synthesize a canonical policy entrypoint,
+// otherwise proxy policies written for it would never match. It also checks
+// the registry covers every proxy-capable ecosystem so download-time policy
+// enforcement cannot silently lose an ecosystem.
+func TestEcosystemRegistryEntrypointsAreCanonical(t *testing.T) {
+	// Sanity floor: 4 proxied ecosystems today (go, npm, pypi, rubygems).
+	if len(ecosystemRegistry) < 4 {
+		t.Fatalf("ecosystemRegistry has %d ecosystems, want at least 4", len(ecosystemRegistry))
+	}
+
+	for eco, config := range ecosystemRegistry {
+		if config.Ecosystem != eco {
+			t.Errorf("ecosystemRegistry[%s].Ecosystem = %s, want key and value to match", eco, config.Ecosystem)
+		}
+		if !eco.Capabilities().Proxy {
+			t.Errorf("ecosystemRegistry contains %s, which does not declare proxy capability", eco)
+		}
+		if ep := eco.ProxyEntrypoint(); !ep.IsValid() {
+			t.Errorf("proxied ecosystem %s synthesizes entrypoint %q, which is not a canonical policy entrypoint", eco, ep)
+		}
+	}
+
+	for _, eco := range ecosystem.WithProxy() {
+		if _, ok := ecosystemRegistry[eco]; !ok {
+			t.Errorf("proxy-capable ecosystem %s is missing from ecosystemRegistry", eco)
+		}
+	}
+}

--- a/internal/secrets/verify.go
+++ b/internal/secrets/verify.go
@@ -208,6 +208,40 @@ func (r *rateLimiter) Wait(ctx context.Context) error {
 	return nil
 }
 
+// upstreamErrorCode narrows a provider-supplied error string down to a
+// machine-readable code, substituting a fixed phrase when the value does not
+// have that shape. Verification results are rendered into reports, logs and
+// SARIF, so text a remote endpoint controls must not reach them verbatim: a
+// hostile, spoofed or misconfigured host can reflect the credential itself
+// back in an error field. Constraining the value to a short lowercase
+// snake_case token keeps the diagnostic worth of documented codes such as
+// invalid_auth while denying the field the capacity to carry arbitrary
+// upstream content. The credential is passed in so a reflection of it is
+// rejected even when it happens to fit that shape.
+func upstreamErrorCode(raw, secret string) string {
+	const (
+		maxCodeLen   = 40
+		unspecified  = "upstream reported an unspecified error"
+		unrecognized = "upstream reported an unrecognized error code"
+	)
+
+	if raw == "" {
+		return unspecified
+	}
+	if len(raw) > maxCodeLen {
+		return unrecognized
+	}
+	if secret != "" && strings.Contains(raw, secret) {
+		return unrecognized
+	}
+	for _, r := range raw {
+		if (r < 'a' || r > 'z') && (r < '0' || r > '9') && r != '_' {
+			return unrecognized
+		}
+	}
+	return raw
+}
+
 // =============================================================================
 // GitHub Token Verifier
 // =============================================================================
@@ -415,7 +449,7 @@ func (v *slackVerifier) Verify(ctx context.Context, secret string, _ SecretType)
 	return VerificationResult{
 		Status:  StatusError,
 		Service: "slack",
-		Error:   result.Error,
+		Error:   upstreamErrorCode(result.Error, secret),
 	}
 }
 

--- a/internal/secrets/verify_test.go
+++ b/internal/secrets/verify_test.go
@@ -1,10 +1,12 @@
 package secrets
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -13,27 +15,84 @@ func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 	return f(r)
 }
 
-func TestGitHubVerifier_DoesNotLeakResponseBody(t *testing.T) {
+// probeSecretTypes is the universe of secret types used to route each
+// registered verifier to a type it handles. It mirrors the SecretType
+// constants in detector.go; if a new verifier matches none of these, the test
+// below fails loudly instead of silently skipping it, so an incomplete list
+// cannot hide a verifier.
+var probeSecretTypes = []SecretType{
+	TypeGCPAPIKey, TypeGCPServiceAccountKey, TypeRubyGemsAPIKey,
+	TypeAWSAccessKey, TypeAWSSecretKey, TypeGitHubToken, TypeGitHubFineGrain,
+	TypeGenericAPIKey, TypePrivateKey, TypeJWT, TypeSlackToken, TypeStripeKey,
+	TypeSendGridKey, TypeNpmToken, TypePyPIToken, TypeDiscordToken,
+	TypeTelegramToken, TypeHerokuAPIKey, TypeMailgunKey, TypeTwilioKey,
+	TypeHighEntropy, TypeSensitiveEnvVar, TypeSlackWebhook, TypeTerraformToken,
+	TypeCloudflareAPIKey, TypeDatadogAPIKey, TypeLinearAPIKey, TypeOpenAIKey,
+	TypeAnthropicKey, TypeAzureSASToken, TypeGitLabToken, TypeBitbucketToken,
+	TypeDigitalOceanToken,
+}
+
+// TestVerifiersDoNotLeakResponseBody pins the credential-disclosure invariant
+// for every registered verifier, not just GitHub: upstream response bodies
+// (which can echo the secret or carry other sensitive detail) must never
+// surface in a VerificationResult. The corpus is engine.verifiers, so a newly
+// registered verifier is covered automatically; each verifier is exercised
+// through every secret type it claims via CanVerify against a transport that
+// plants a marker in the response body.
+func TestVerifiersDoNotLeakResponseBody(t *testing.T) {
 	t.Parallel()
 
-	body := "Token ghp_example123 is expired"
-	client := &http.Client{
-		Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
-			return &http.Response{
-				StatusCode: http.StatusInternalServerError,
-				Body:       io.NopCloser(strings.NewReader(body)),
-				Header:     make(http.Header),
-			}, nil
-		}),
+	const (
+		marker = "RESPONSE-BODY-CANARY-2f8c1d"
+		secret = "canary-secret-value"
+	)
+
+	engine := NewVerificationEngine(&VerificationConfig{Timeout: time.Second})
+	// The verifiers share the engine's HTTP client, so swapping its transport
+	// routes every verifier's requests to the marker response.
+	engine.client.Transport = roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Body:       io.NopCloser(strings.NewReader("Token " + secret + " is expired " + marker)),
+			Header:     make(http.Header),
+		}, nil
+	})
+
+	// Sanity floor: 14 built-in verifiers today; a shrunken registration list
+	// means verification lost coverage, not that this test should pass.
+	if len(engine.verifiers) < 14 {
+		t.Fatalf("engine registered %d verifiers, want at least 14", len(engine.verifiers))
 	}
 
-	verifier := newGitHubVerifier(client)
-	result := verifier.Verify(t.Context(), "ghp_example123", TypeGitHubToken)
+	for _, verifier := range engine.verifiers {
+		var types []SecretType
+		for _, st := range probeSecretTypes {
+			if verifier.CanVerify(st) {
+				types = append(types, st)
+			}
+		}
+		if len(types) == 0 {
+			t.Errorf("verifier %s matches no secret type in probeSecretTypes; extend the probe list so it is exercised", verifier.Name())
+			continue
+		}
 
-	if result.Status != StatusError {
-		t.Fatalf("expected StatusError, got %s", result.Status)
-	}
-	if strings.Contains(result.Error, "ghp_example123") || strings.Contains(result.Error, "Token") {
-		t.Fatalf("error should not include response body; got %q", result.Error)
+		for _, st := range types {
+			t.Run(verifier.Name()+"/"+string(st), func(t *testing.T) {
+				t.Parallel()
+
+				result := verifier.Verify(t.Context(), secret, st)
+
+				raw, err := json.Marshal(result)
+				if err != nil {
+					t.Fatalf("marshal result: %v", err)
+				}
+				if strings.Contains(string(raw), marker) {
+					t.Errorf("verifier leaked the upstream response body into the result: %s", raw)
+				}
+				if strings.Contains(string(raw), secret) {
+					t.Errorf("verifier echoed the secret value into the result: %s", raw)
+				}
+			})
+		}
 	}
 }

--- a/internal/secrets/verify_test.go
+++ b/internal/secrets/verify_test.go
@@ -2,8 +2,10 @@ package secrets
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -32,36 +34,295 @@ var probeSecretTypes = []SecretType{
 	TypeDigitalOceanToken,
 }
 
-// TestVerifiersDoNotLeakResponseBody pins the credential-disclosure invariant
-// for every registered verifier, not just GitHub: upstream response bodies
-// (which can echo the secret or carry other sensitive detail) must never
-// surface in a VerificationResult. The corpus is engine.verifiers, so a newly
-// registered verifier is covered automatically; each verifier is exercised
-// through every secret type it claims via CanVerify against a transport that
-// plants a marker in the response body.
-func TestVerifiersDoNotLeakResponseBody(t *testing.T) {
-	t.Parallel()
+// bodyCanary marks the parts of a staged upstream response that no verifier
+// is entitled to republish: fields its response struct decodes but never
+// emits, fields it does not model at all, and content trailing the JSON
+// document. Values a verifier is meant to surface (logins, e-mail addresses,
+// scopes) are deliberately realistic instead, so the assertion distinguishes
+// "decoded the documented identity" from "echoed whatever the endpoint sent".
+const bodyCanary = "RESPONSE-BODY-CANARY-2f8c1d"
 
-	const (
-		marker = "RESPONSE-BODY-CANARY-2f8c1d"
-		secret = "canary-secret-value"
-	)
+// verifierCanary is one staged upstream exchange for a single verifier: the
+// credential handed to Verify, the response the transport serves back, and
+// the VerificationResult fields the verifier must derive from it.
+type verifierCanary struct {
+	// name labels the scenario in subtest output.
+	name string
+	// secret is the credential passed to Verify. It is provider-shaped so
+	// format-checking verifiers reach their accepting branch, and unique per
+	// scenario so an echo of it into the result is unambiguous.
+	secret string
+	// status is the HTTP status served to the verifier.
+	status int
+	// header is served with the response. Verifiers that read metadata out of
+	// headers (GitHub's X-OAuth-Scopes) need it populated.
+	header map[string]string
+	// body is the response body served to the verifier. It must parse as the
+	// provider payload the verifier expects, otherwise the verifier falls back
+	// to a status-only branch and never touches the body at all.
+	body string
+	// wantStatus is the VerificationStatus the verifier must report. Pinning it
+	// is what proves the body-parsing branch actually ran: a payload the
+	// verifier cannot parse degrades to a status fallback, which would leave
+	// the leak assertions vacuously satisfied.
+	wantStatus VerificationStatus
+	// wantIdentity is the identity the verifier must have decoded out of body.
+	// Empty means the verifier reports none.
+	wantIdentity string
+	// wantScopes are the scopes the verifier must report. Nil means none.
+	wantScopes []string
+}
+
+// verifierCanaries stages, per registered verifier name, the upstream
+// exchanges TestVerifiersDoNotLeakResponseBody drives it through. Each body is
+// provider-appropriate so the verifier's own parser accepts it and the
+// result-populating branch runs; a generic blob would fail every decode and
+// leave the code that copies decoded fields into a VerificationResult
+// unreached. Multiple entries cover verifiers with more than one
+// body-dependent branch.
+func verifierCanaries() map[string][]verifierCanary {
+	return map[string][]verifierCanary{
+		"github": {{
+			name:         "authenticated_user",
+			secret:       "ghp_canarygithubtoken000000000000000",
+			status:       http.StatusOK,
+			header:       map[string]string{"X-OAuth-Scopes": "repo, read:org"},
+			body:         fmt.Sprintf(`{"login":"octocat","id":583231,"type":"User","email":"%[1]s@example.com","node_id":"%[1]s"} %[1]s`, bodyCanary),
+			wantStatus:   StatusValid,
+			wantIdentity: "octocat",
+			wantScopes:   []string{"repo", "read:org"},
+		}},
+		"gitlab": {{
+			name:         "authenticated_user",
+			secret:       "glpat-canarygitlabtoken0",
+			status:       http.StatusOK,
+			body:         fmt.Sprintf(`{"username":"octocat","name":"Octo Cat","id":42,"bio":"%[1]s","web_url":"%[1]s"} %[1]s`, bodyCanary),
+			wantStatus:   StatusValid,
+			wantIdentity: "octocat",
+		}},
+		"aws": {
+			{
+				// AKIA plus sixteen characters: the exact shape the verifier
+				// accepts, so it reaches its non-rejecting branch.
+				name:       "well_formed_access_key",
+				secret:     "AKIACANARY0000000001",
+				status:     http.StatusOK,
+				body:       fmt.Sprintf(`{"note":"%[1]s"} %[1]s`, bodyCanary),
+				wantStatus: StatusUnknown,
+			},
+			{
+				name:       "malformed_access_key",
+				secret:     "canary-aws-wrong-shape",
+				status:     http.StatusOK,
+				body:       fmt.Sprintf(`{"note":"%[1]s"} %[1]s`, bodyCanary),
+				wantStatus: StatusInvalid,
+			},
+		},
+		"slack": {
+			{
+				name:         "authenticated_user",
+				secret:       "xoxb-canary-slack-authenticated",
+				status:       http.StatusOK,
+				body:         fmt.Sprintf(`{"ok":true,"user":"octocat","team":"canaries","url":"%[1]s","user_id":"%[1]s","bot_id":"%[1]s"} %[1]s`, bodyCanary),
+				wantStatus:   StatusValid,
+				wantIdentity: "octocat@canaries",
+			},
+			{
+				// A documented Slack error code: the verifier compares it
+				// against known literals, so surfacing it is safe.
+				name:       "documented_error_code",
+				secret:     "xoxb-canary-slack-revoked",
+				status:     http.StatusOK,
+				body:       fmt.Sprintf(`{"ok":false,"error":"token_revoked","detail":"%[1]s"}`, bodyCanary),
+				wantStatus: StatusInvalid,
+			},
+			{
+				// The disclosure path: an endpoint that answers with free-form
+				// text where a code belongs. Copying it verbatim republishes
+				// whatever the endpoint chose to send, up to the credential.
+				name:       "free_form_error_text",
+				secret:     "xoxb-canary-slack-hostile",
+				status:     http.StatusOK,
+				body:       fmt.Sprintf(`{"ok":false,"error":"%[1]s carrying xoxb-canary-slack-hostile"}`, bodyCanary),
+				wantStatus: StatusError,
+			},
+			{
+				// Slack is the one verifier that decodes the body regardless of
+				// status, so an unparseable body reaches its decode-error path.
+				name:       "unparseable_body",
+				secret:     "xoxb-canary-slack-garbage",
+				status:     http.StatusInternalServerError,
+				body:       fmt.Sprintf("Token xoxb-canary-slack-garbage is expired %s", bodyCanary),
+				wantStatus: StatusError,
+			},
+		},
+		"stripe": {{
+			name:       "test_mode_key",
+			secret:     "sk_test_canarystripekey",
+			status:     http.StatusOK,
+			body:       fmt.Sprintf(`{"object":"balance","livemode":false,"available":[{"amount":0}],"note":"%[1]s"} %[1]s`, bodyCanary),
+			wantStatus: StatusValid,
+		}},
+		"sendgrid": {{
+			name:       "scoped_key",
+			secret:     "SG.canarysendgridkey.canarysendgridsecret",
+			status:     http.StatusOK,
+			body:       fmt.Sprintf(`{"scopes":["mail.send","alerts.read"],"errors":[{"message":"%[1]s"}]} %[1]s`, bodyCanary),
+			wantStatus: StatusValid,
+			wantScopes: []string{"mail.send", "alerts.read"},
+		}},
+		"npm": {{
+			// npm decodes email into its response struct but must not emit it.
+			name:         "authenticated_user",
+			secret:       "npm_canarynpmtoken0000000000000000000000",
+			status:       http.StatusOK,
+			body:         fmt.Sprintf(`{"name":"octocat","email":"%[1]s@example.com","tfa":"%[1]s"} %[1]s`, bodyCanary),
+			wantStatus:   StatusValid,
+			wantIdentity: "octocat",
+		}},
+		"openai": {{
+			name:       "model_list_access",
+			secret:     "sk-canaryopenaikey00000000000000000000",
+			status:     http.StatusOK,
+			body:       fmt.Sprintf(`{"object":"list","data":[{"id":"%[1]s"}]} %[1]s`, bodyCanary),
+			wantStatus: StatusValid,
+		}},
+		"anthropic": {{
+			// Anthropic drains the body for connection reuse; draining must not
+			// become reading it into the result.
+			name:       "messages_accepted",
+			secret:     "sk-ant-canaryanthropickey00000000000",
+			status:     http.StatusOK,
+			body:       fmt.Sprintf(`{"id":"%[1]s","content":[{"type":"text","text":"%[1]s"}]} %[1]s`, bodyCanary),
+			wantStatus: StatusValid,
+		}},
+		"digitalocean": {{
+			name:         "account_details",
+			secret:       "dop_v1_canarydigitaloceantoken",
+			status:       http.StatusOK,
+			body:         fmt.Sprintf(`{"account":{"email":"octocat@example.com","uuid":"%[1]s","droplet_limit":25},"meta":"%[1]s"} %[1]s`, bodyCanary),
+			wantStatus:   StatusValid,
+			wantIdentity: "octocat@example.com",
+		}},
+		"terraform": {{
+			// Terraform Cloud decodes email but must only emit the username.
+			name:         "account_details",
+			secret:       "canaryterraform.atlasv1.canaryterraformtoken",
+			status:       http.StatusOK,
+			body:         fmt.Sprintf(`{"data":{"id":"%[1]s","attributes":{"username":"octocat","email":"%[1]s@example.com"}}} %[1]s`, bodyCanary),
+			wantStatus:   StatusValid,
+			wantIdentity: "octocat",
+		}},
+		"linear": {{
+			name:         "graphql_viewer",
+			secret:       "lin_api_canarylinearkey",
+			status:       http.StatusOK,
+			body:         fmt.Sprintf(`{"data":{"viewer":{"id":"%[1]s","name":"Octo Cat","email":"octocat@example.com"}},"extensions":{"trace":"%[1]s"}} %[1]s`, bodyCanary),
+			wantStatus:   StatusValid,
+			wantIdentity: "octocat@example.com",
+		}},
+		"pypi": {
+			{
+				name:       "well_formed_token",
+				secret:     "pypi-canarypypitoken",
+				status:     http.StatusOK,
+				body:       fmt.Sprintf(`{"note":"%[1]s"} %[1]s`, bodyCanary),
+				wantStatus: StatusUnknown,
+			},
+			{
+				name:       "malformed_token",
+				secret:     "canary-pypi-wrong-prefix",
+				status:     http.StatusOK,
+				body:       fmt.Sprintf(`{"note":"%[1]s"} %[1]s`, bodyCanary),
+				wantStatus: StatusInvalid,
+			},
+		},
+		"datadog": {
+			{
+				name:       "validated_key",
+				secret:     "canarydatadogapikey00000000000000",
+				status:     http.StatusOK,
+				body:       fmt.Sprintf(`{"valid":true,"errors":["%[1]s"]} %[1]s`, bodyCanary),
+				wantStatus: StatusValid,
+			},
+			{
+				name:       "rejected_key",
+				secret:     "canarydatadogapikeyrejected000000",
+				status:     http.StatusOK,
+				body:       fmt.Sprintf(`{"valid":false,"errors":["%[1]s"]} %[1]s`, bodyCanary),
+				wantStatus: StatusInvalid,
+			},
+		},
+	}
+}
+
+// canaryVerifier returns the registered verifier called name, backed by a
+// private verification engine whose HTTP transport answers every request with
+// exchange. Verifiers share their engine's client, so each scenario gets its
+// own engine rather than mutating one shared transport, which lets the
+// subtests run in parallel without racing.
+func canaryVerifier(t *testing.T, name string, exchange verifierCanary) Verifier {
+	t.Helper()
 
 	engine := NewVerificationEngine(&VerificationConfig{Timeout: time.Second})
-	// The verifiers share the engine's HTTP client, so swapping its transport
-	// routes every verifier's requests to the marker response.
-	engine.client.Transport = roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+	engine.client.Transport = roundTripFunc(func(*http.Request) (*http.Response, error) {
+		header := make(http.Header, len(exchange.header))
+		for key, value := range exchange.header {
+			header.Set(key, value)
+		}
 		return &http.Response{
-			StatusCode: http.StatusInternalServerError,
-			Body:       io.NopCloser(strings.NewReader("Token " + secret + " is expired " + marker)),
-			Header:     make(http.Header),
+			StatusCode: exchange.status,
+			Body:       io.NopCloser(strings.NewReader(exchange.body)),
+			Header:     header,
 		}, nil
 	})
 
+	for _, verifier := range engine.verifiers {
+		if verifier.Name() == name {
+			return verifier
+		}
+	}
+	t.Fatalf("no verifier named %s is registered", name)
+	return nil
+}
+
+// TestVerifiersDoNotLeakResponseBody pins the credential-disclosure invariant
+// for every registered verifier, not just GitHub: content an upstream endpoint
+// controls must never be republished in a VerificationResult, because a
+// hostile, spoofed or misconfigured host can reflect the credential straight
+// back in a response field.
+//
+// The corpus is engine.verifiers crossed with verifierCanaries, checked in
+// both directions, so a newly registered verifier is covered automatically and
+// a stale canary cannot linger. Each canary body is provider-appropriate: the
+// verifier's own decoder accepts it, so the branch that copies decoded fields
+// into the result actually runs. The wantStatus, wantIdentity and wantScopes
+// assertions are what keep the leak checks honest, since a body the verifier
+// cannot parse would silently degrade to a status-only branch that never
+// touches the response at all.
+func TestVerifiersDoNotLeakResponseBody(t *testing.T) {
+	t.Parallel()
+
+	canaries := verifierCanaries()
+
+	engine := NewVerificationEngine(&VerificationConfig{Timeout: time.Second})
 	// Sanity floor: 14 built-in verifiers today; a shrunken registration list
 	// means verification lost coverage, not that this test should pass.
 	if len(engine.verifiers) < 14 {
 		t.Fatalf("engine registered %d verifiers, want at least 14", len(engine.verifiers))
+	}
+
+	registered := make(map[string]bool, len(engine.verifiers))
+	for _, verifier := range engine.verifiers {
+		registered[verifier.Name()] = true
+		if len(canaries[verifier.Name()]) == 0 {
+			t.Errorf("verifier %s has no staged canary exchange; add one so its response handling is exercised instead of skipped", verifier.Name())
+		}
+	}
+	for name := range canaries {
+		if !registered[name] {
+			t.Errorf("canary exchange %s names no registered verifier; remove it", name)
+		}
 	}
 
 	for _, verifier := range engine.verifiers {
@@ -77,22 +338,71 @@ func TestVerifiersDoNotLeakResponseBody(t *testing.T) {
 		}
 
 		for _, st := range types {
-			t.Run(verifier.Name()+"/"+string(st), func(t *testing.T) {
-				t.Parallel()
+			for _, exchange := range canaries[verifier.Name()] {
+				t.Run(verifier.Name()+"/"+string(st)+"/"+exchange.name, func(t *testing.T) {
+					t.Parallel()
 
-				result := verifier.Verify(t.Context(), secret, st)
+					result := canaryVerifier(t, verifier.Name(), exchange).Verify(t.Context(), exchange.secret, st)
 
-				raw, err := json.Marshal(result)
-				if err != nil {
-					t.Fatalf("marshal result: %v", err)
-				}
-				if strings.Contains(string(raw), marker) {
-					t.Errorf("verifier leaked the upstream response body into the result: %s", raw)
-				}
-				if strings.Contains(string(raw), secret) {
-					t.Errorf("verifier echoed the secret value into the result: %s", raw)
-				}
-			})
+					raw, err := json.Marshal(result)
+					if err != nil {
+						t.Fatalf("marshal result: %v", err)
+					}
+					if strings.Contains(string(raw), bodyCanary) {
+						t.Errorf("verifier republished upstream response content into the result: %s", raw)
+					}
+					if strings.Contains(string(raw), exchange.secret) {
+						t.Errorf("verifier echoed the secret value into the result: %s", raw)
+					}
+
+					// Without these, an unparseable canary would leave the
+					// verifier on a status-only branch and the assertions above
+					// would hold for the wrong reason.
+					if result.Status != exchange.wantStatus {
+						t.Errorf("status = %q, want %q; the canary body did not reach the intended branch (result: %s)", result.Status, exchange.wantStatus, raw)
+					}
+					if result.Identity != exchange.wantIdentity {
+						t.Errorf("identity = %q, want %q", result.Identity, exchange.wantIdentity)
+					}
+					if !slices.Equal(result.Scopes, exchange.wantScopes) {
+						t.Errorf("scopes = %q, want %q", result.Scopes, exchange.wantScopes)
+					}
+				})
+			}
 		}
+	}
+}
+
+// TestUpstreamErrorCode covers the narrowing applied to provider-supplied
+// error strings before they reach a VerificationResult.
+func TestUpstreamErrorCode(t *testing.T) {
+	t.Parallel()
+
+	const secret = "xoxb-canary-slack-token"
+
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "documented code passes through", raw: "invalid_auth", want: "invalid_auth"},
+		{name: "digits and underscores allowed", raw: "ratelimited_429", want: "ratelimited_429"},
+		{name: "empty reports unspecified", raw: "", want: "upstream reported an unspecified error"},
+		{name: "free-form prose rejected", raw: "the token you sent has expired", want: "upstream reported an unrecognized error code"},
+		{name: "uppercase rejected", raw: "INVALID_AUTH", want: "upstream reported an unrecognized error code"},
+		{name: "punctuation rejected", raw: "invalid-auth", want: "upstream reported an unrecognized error code"},
+		{name: "overlong value rejected", raw: strings.Repeat("a", 41), want: "upstream reported an unrecognized error code"},
+		{name: "reflected secret rejected", raw: secret, want: "upstream reported an unrecognized error code"},
+		{name: "embedded secret rejected", raw: "auth_" + secret, want: "upstream reported an unrecognized error code"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := upstreamErrorCode(tt.raw, secret); got != tt.want {
+				t.Errorf("upstreamErrorCode(%q) = %q, want %q", tt.raw, got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1033,24 +1033,28 @@ func recoveryInterceptor() connect.UnaryInterceptorFunc {
 	}
 }
 
+// procedureToEntrypoint maps RPC procedures to the policy entrypoints that
+// authorize them. Procedures absent from this map are allowed without policy
+// evaluation, so every entry is security-relevant: a stale procedure name
+// silently disables enforcement for that RPC. A drift test checks each key
+// against the procedures the server actually registers.
+var procedureToEntrypoint = map[string]policy.Entrypoint{
+	"/deputy.scan.v1.ScanService/Scan":           policy.EntrypointServiceScanRequest,
+	"/deputy.scan.v1.ScanService/StreamScan":     policy.EntrypointServiceScanRequest,
+	"/deputy.list.v1.ListService/ListPackages":   policy.EntrypointServiceListRequest,
+	"/deputy.list.v1.ListService/ListEcosystems": policy.EntrypointServiceListRequest,
+	"/deputy.sbom.v1.SBOMService/Generate":       policy.EntrypointServiceSBOMRequest,
+	"/deputy.sbom.v1.SBOMService/Diff":           policy.EntrypointServiceSBOMRequest,
+	"/deputy.diff.v1.DiffService/Diff":           policy.EntrypointServiceDiffRequest,
+	"/deputy.secrets.v1.SecretsService/Scan":     policy.EntrypointServiceSecretsRequest,
+	"/deputy.graph.v1.GraphService/Resolve":      policy.EntrypointServiceGraphRequest,
+	"/deputy.graph.v1.GraphService/Why":          policy.EntrypointServiceGraphRequest,
+}
+
 // policyInterceptor evaluates service-level policies for authorization.
 // It maps RPC procedures to policy entrypoints and evaluates policies with
 // JWT claims (jwt.*), request metadata, and target information.
 func policyInterceptor(policies []policy.Source) connect.UnaryInterceptorFunc {
-	// Map RPC procedures to policy entrypoints
-	procedureToEntrypoint := map[string]policy.Entrypoint{
-		"/deputy.scan.v1.ScanService/Scan":           policy.EntrypointServiceScanRequest,
-		"/deputy.scan.v1.ScanService/StreamScan":     policy.EntrypointServiceScanRequest,
-		"/deputy.list.v1.ListService/ListPackages":   policy.EntrypointServiceListRequest,
-		"/deputy.list.v1.ListService/ListEcosystems": policy.EntrypointServiceListRequest,
-		"/deputy.sbom.v1.SBOMService/Generate":       policy.EntrypointServiceSBOMRequest,
-		"/deputy.sbom.v1.SBOMService/Diff":           policy.EntrypointServiceSBOMRequest,
-		"/deputy.diff.v1.DiffService/Diff":           policy.EntrypointServiceDiffRequest,
-		"/deputy.secrets.v1.SecretsService/Scan":     policy.EntrypointServiceSecretsRequest,
-		"/deputy.graph.v1.GraphService/Resolve":      policy.EntrypointServiceGraphRequest,
-		"/deputy.graph.v1.GraphService/Why":          policy.EntrypointServiceGraphRequest,
-	}
-
 	return func(next connect.UnaryFunc) connect.UnaryFunc {
 		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 			procedure := req.Spec().Procedure

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -256,6 +256,12 @@ type Server struct {
 	authenticator jwt.Authenticator // JWT authenticator (nil if auth disabled)
 	policies      []policy.Source   // Loaded policy sources (nil if no policies)
 	egressOptions []network.Option
+
+	// servicePaths records the URL path prefix of every ConnectRPC service
+	// registered on the mux (e.g. "/deputy.scan.v1.ScanService/"). Tests use
+	// it to derive the full procedure corpus from the proto descriptors
+	// instead of hand-maintaining endpoint lists.
+	servicePaths []string
 }
 
 // New creates a new Deputy server with the given configuration.
@@ -391,48 +397,55 @@ func New(cfg Config) (*Server, error) {
 	diffHandler := NewDiffHandler(WithDiffTargetPolicy(targetPolicy))
 	graphHandler := NewGraphHandler(WithGraphTargetPolicy(targetPolicy))
 
-	// Register ConnectRPC handlers
+	// Register ConnectRPC handlers, recording each service path so the
+	// registered service set stays observable (see Server.servicePaths).
+	var servicePaths []string
+	registerService := func(path string, handler http.Handler) {
+		mux.Handle(path, handler)
+		servicePaths = append(servicePaths, path)
+	}
+
 	scanPath, scanConnectHandler := scanv1connect.NewScanServiceHandler(
 		scanHandler,
 		connect.WithInterceptors(interceptors...),
 	)
-	mux.Handle(scanPath, scanConnectHandler)
+	registerService(scanPath, scanConnectHandler)
 
 	sbomPath, sbomConnectHandler := sbomv1connect.NewSBOMServiceHandler(
 		sbomHandler,
 		connect.WithInterceptors(interceptors...),
 	)
-	mux.Handle(sbomPath, sbomConnectHandler)
+	registerService(sbomPath, sbomConnectHandler)
 
 	listPath, listConnectHandler := listv1connect.NewListServiceHandler(
 		listHandler,
 		connect.WithInterceptors(interceptors...),
 	)
-	mux.Handle(listPath, listConnectHandler)
+	registerService(listPath, listConnectHandler)
 
 	remediationPath, remediationConnectHandler := remediationv1connect.NewRemediationServiceHandler(
 		remediationHandler,
 		connect.WithInterceptors(interceptors...),
 	)
-	mux.Handle(remediationPath, remediationConnectHandler)
+	registerService(remediationPath, remediationConnectHandler)
 
 	secretsPath, secretsConnectHandler := secretsv1connect.NewSecretsServiceHandler(
 		secretsHandler,
 		connect.WithInterceptors(interceptors...),
 	)
-	mux.Handle(secretsPath, secretsConnectHandler)
+	registerService(secretsPath, secretsConnectHandler)
 
 	diffPath, diffConnectHandler := diffv1connect.NewDiffServiceHandler(
 		diffHandler,
 		connect.WithInterceptors(interceptors...),
 	)
-	mux.Handle(diffPath, diffConnectHandler)
+	registerService(diffPath, diffConnectHandler)
 
 	graphPath, graphConnectHandler := graphv1connect.NewGraphServiceHandler(
 		graphHandler,
 		connect.WithInterceptors(interceptors...),
 	)
-	mux.Handle(graphPath, graphConnectHandler)
+	registerService(graphPath, graphConnectHandler)
 
 	// Health check endpoint
 	mux.HandleFunc("/health", healthHandler)
@@ -474,6 +487,7 @@ func New(cfg Config) (*Server, error) {
 		authenticator: authenticator,
 		policies:      policies,
 		egressOptions: egressOptions,
+		servicePaths:  servicePaths,
 	}, nil
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4,9 +4,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"connectrpc.com/connect"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
 
 	listv1 "github.com/temporalio/deputy/gen/deputy/list/v1"
 	"github.com/temporalio/deputy/gen/deputy/list/v1/listv1connect"
@@ -235,6 +238,12 @@ func TestListServiceRegistered(t *testing.T) {
 	}
 }
 
+// TestAllServicesRegistered derives the procedure corpus from the services the
+// server actually registers: every recorded service path maps to a proto
+// service descriptor, and every method of every registered service must route
+// (anything but 404). Deriving from srv.servicePaths plus the descriptors
+// keeps the corpus in lockstep with server registration instead of
+// hand-maintaining endpoint strings that silently go stale.
 func TestAllServicesRegistered(t *testing.T) {
 	srv, err := New(DefaultConfig())
 	if err != nil {
@@ -245,43 +254,51 @@ func TestAllServicesRegistered(t *testing.T) {
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()
 
-	// Test that all service endpoints respond (not 404)
-	// We use actual method paths since ConnectRPC routes service/method
-	serviceEndpoints := []struct {
-		path        string
-		contentType string
-	}{
-		// Scan service
-		{"/deputy.scan.v1.ScanService/Scan", "application/json"},
-		// List service
-		{"/deputy.list.v1.ListService/ListPackages", "application/json"},
-		{"/deputy.list.v1.ListService/ListEcosystems", "application/json"},
-		// SBOM service
-		{"/deputy.sbom.v1.SBOMService/Generate", "application/json"},
-		{"/deputy.sbom.v1.SBOMService/Diff", "application/json"},
-		// Remediation service
-		{"/deputy.remediation.v1.RemediationService/GeneratePlan", "application/json"},
-		// Secrets service
-		{"/deputy.secrets.v1.SecretsService/Scan", "application/json"},
-		{"/deputy.secrets.v1.SecretsService/ListDetectors", "application/json"},
+	// Sanity floor: the server currently registers 7 services; fewer means
+	// registration (or path recording) broke, not that the corpus shrank.
+	if len(srv.servicePaths) < 7 {
+		t.Fatalf("server recorded %d service paths, want at least 7: %v", len(srv.servicePaths), srv.servicePaths)
 	}
 
-	for _, ep := range serviceEndpoints {
-		req, err := http.NewRequest(http.MethodPost, ts.URL+ep.path, nil)
+	var procedures []string
+	for _, path := range srv.servicePaths {
+		name := protoreflect.FullName(strings.Trim(path, "/"))
+		desc, err := protoregistry.GlobalFiles.FindDescriptorByName(name)
 		if err != nil {
-			t.Fatalf("failed to create request for %s: %v", ep.path, err)
+			t.Fatalf("registered service %q has no proto descriptor: %v", name, err)
 		}
-		req.Header.Set("Content-Type", ep.contentType)
+		svc, ok := desc.(protoreflect.ServiceDescriptor)
+		if !ok {
+			t.Fatalf("descriptor %q is %T, want a service descriptor", name, desc)
+		}
+		methods := svc.Methods()
+		for i := range methods.Len() {
+			procedures = append(procedures, path+string(methods.Get(i).Name()))
+		}
+	}
+
+	// Sanity floor: 25 procedures across the registered services today.
+	if len(procedures) < 25 {
+		t.Fatalf("derived %d procedures, want at least 25: %v", len(procedures), procedures)
+	}
+
+	for _, procedure := range procedures {
+		req, err := http.NewRequest(http.MethodPost, ts.URL+procedure, nil)
+		if err != nil {
+			t.Fatalf("failed to create request for %s: %v", procedure, err)
+		}
+		req.Header.Set("Content-Type", "application/json")
 
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
-			t.Fatalf("request to %s failed: %v", ep.path, err)
+			t.Fatalf("request to %s failed: %v", procedure, err)
 		}
 		resp.Body.Close()
 
-		// Should not be 404 (service is registered)
+		// Should not be 404 (procedure is registered); streaming procedures
+		// reject the unary content type with a non-404 status, which is fine.
 		if resp.StatusCode == http.StatusNotFound {
-			t.Errorf("endpoint %s returned 404 - not registered", ep.path)
+			t.Errorf("procedure %s returned 404 - not registered", procedure)
 		}
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -254,6 +254,36 @@ func TestAllServicesRegistered(t *testing.T) {
 	ts := httptest.NewServer(srv.Handler())
 	defer ts.Close()
 
+	procedures := registeredProcedures(t, srv)
+
+	for _, procedure := range procedures {
+		req, err := http.NewRequest(http.MethodPost, ts.URL+procedure, nil)
+		if err != nil {
+			t.Fatalf("failed to create request for %s: %v", procedure, err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("request to %s failed: %v", procedure, err)
+		}
+		resp.Body.Close()
+
+		// Should not be 404 (procedure is registered); streaming procedures
+		// reject the unary content type with a non-404 status, which is fine.
+		if resp.StatusCode == http.StatusNotFound {
+			t.Errorf("procedure %s returned 404 - not registered", procedure)
+		}
+	}
+}
+
+// registeredProcedures expands the server's recorded service paths into the
+// complete list of Connect procedure paths via the proto service descriptors,
+// enforcing floors so an empty or shrunken registration set fails instead of
+// hollowing out the callers' corpora.
+func registeredProcedures(t *testing.T, srv *Server) []string {
+	t.Helper()
+
 	// Sanity floor: the server currently registers 7 services; fewer means
 	// registration (or path recording) broke, not that the corpus shrank.
 	if len(srv.servicePaths) < 7 {
@@ -281,24 +311,53 @@ func TestAllServicesRegistered(t *testing.T) {
 	if len(procedures) < 25 {
 		t.Fatalf("derived %d procedures, want at least 25: %v", len(procedures), procedures)
 	}
+	return procedures
+}
 
-	for _, procedure := range procedures {
-		req, err := http.NewRequest(http.MethodPost, ts.URL+procedure, nil)
-		if err != nil {
-			t.Fatalf("failed to create request for %s: %v", procedure, err)
+// stalePolicyProcedures are procedureToEntrypoint keys that do not match any
+// procedure the server registers, meaning server policies for those
+// entrypoints are silently never evaluated (unknown procedures are allowed by
+// default). KNOWN DEFECT, pinned rather than hidden: DiffService's real
+// procedures are DiffPackages/DiffVulnerabilities/DiffContainerImages and
+// GraphService's are BuildGraph/WhyDependency/QueryGraph, so the
+// service_diff_request and service_graph_request entrypoints currently guard
+// nothing. Fixing the map (a behavior change: those RPCs become policy
+// enforced) must remove the entry here, which makes this list self-cleaning.
+var stalePolicyProcedures = map[string]bool{
+	"/deputy.diff.v1.DiffService/Diff":      true,
+	"/deputy.graph.v1.GraphService/Resolve": true,
+	"/deputy.graph.v1.GraphService/Why":     true,
+}
+
+// TestPolicyProcedureMapMatchesRegisteredProcedures checks every key of
+// procedureToEntrypoint against the procedures the server actually registers.
+// Procedures absent from the map bypass policy evaluation entirely, so a
+// stale key silently disables authorization for that RPC. Known-stale keys
+// are pinned in stalePolicyProcedures; this test fails when a new stale key
+// appears or when a pinned one is fixed without unpinning it.
+func TestPolicyProcedureMapMatchesRegisteredProcedures(t *testing.T) {
+	srv, err := New(DefaultConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	registered := make(map[string]bool)
+	for _, procedure := range registeredProcedures(t, srv) {
+		registered[procedure] = true
+	}
+
+	for procedure := range procedureToEntrypoint {
+		switch {
+		case registered[procedure] && stalePolicyProcedures[procedure]:
+			t.Errorf("procedure %s is registered again; remove it from stalePolicyProcedures", procedure)
+		case !registered[procedure] && !stalePolicyProcedures[procedure]:
+			t.Errorf("procedureToEntrypoint key %s matches no registered procedure; its policy entrypoint is silently never evaluated", procedure)
 		}
-		req.Header.Set("Content-Type", "application/json")
+	}
 
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			t.Fatalf("request to %s failed: %v", procedure, err)
-		}
-		resp.Body.Close()
-
-		// Should not be 404 (procedure is registered); streaming procedures
-		// reject the unary content type with a non-404 status, which is fine.
-		if resp.StatusCode == http.StatusNotFound {
-			t.Errorf("procedure %s returned 404 - not registered", procedure)
+	for procedure := range stalePolicyProcedures {
+		if _, ok := procedureToEntrypoint[procedure]; !ok {
+			t.Errorf("stalePolicyProcedures entry %s is no longer in procedureToEntrypoint; remove it", procedure)
 		}
 	}
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
@@ -17,6 +18,7 @@ import (
 	"github.com/temporalio/deputy/gen/deputy/scan/v1/scanv1connect"
 	secretsv1 "github.com/temporalio/deputy/gen/deputy/secrets/v1"
 	"github.com/temporalio/deputy/gen/deputy/secrets/v1/secretsv1connect"
+	"github.com/temporalio/deputy/internal/policy"
 )
 
 func TestHealthEndpoint(t *testing.T) {
@@ -277,11 +279,44 @@ func TestAllServicesRegistered(t *testing.T) {
 	}
 }
 
-// registeredProcedures expands the server's recorded service paths into the
-// complete list of Connect procedure paths via the proto service descriptors,
-// enforcing floors so an empty or shrunken registration set fails instead of
-// hollowing out the callers' corpora.
-func registeredProcedures(t *testing.T, srv *Server) []string {
+// registeredService is a ConnectRPC service the server registers, paired with
+// the policy entrypoint that must authorize it. authorized is false for a
+// service that has no service entrypoint of its own, which is a legitimate
+// state (RemediationService) and not the same thing as a missing mapping.
+type registeredService struct {
+	// procedures are the service's full Connect procedure paths, each already
+	// prefixed with the service's URL path.
+	procedures []string
+	// entrypoint authorizes every procedure of the service.
+	entrypoint policy.Entrypoint
+	// authorized reports whether entrypoint is set.
+	authorized bool
+}
+
+// serviceEntrypoint derives the policy entrypoint that authorizes a proto
+// service from its package segment: deputy.scan.v1.ScanService is authorized
+// by service_scan_request. It reports false when the derived name is not a
+// real service entrypoint, which keeps the derivation honest in both
+// directions: a service with no authorization surface is recognized as such,
+// and a future service whose package diverges from its entrypoint name is
+// caught by the coverage check over policy.EntrypointsService.
+func serviceEntrypoint(name protoreflect.FullName) (policy.Entrypoint, bool) {
+	parts := strings.Split(string(name), ".")
+	if len(parts) < 3 {
+		return "", false
+	}
+	candidate := policy.Entrypoint("service_" + parts[1] + "_request")
+	if !slices.Contains(policy.EntrypointsService, candidate) {
+		return "", false
+	}
+	return candidate, true
+}
+
+// registeredServices expands the server's recorded service paths into proto
+// service descriptors, their full procedure paths, and the policy entrypoint
+// that must authorize each, enforcing floors so an empty or shrunken
+// registration set fails instead of hollowing out the callers' corpora.
+func registeredServices(t *testing.T, srv *Server) []registeredService {
 	t.Helper()
 
 	// Sanity floor: the server currently registers 7 services; fewer means
@@ -290,7 +325,8 @@ func registeredProcedures(t *testing.T, srv *Server) []string {
 		t.Fatalf("server recorded %d service paths, want at least 7: %v", len(srv.servicePaths), srv.servicePaths)
 	}
 
-	var procedures []string
+	services := make([]registeredService, 0, len(srv.servicePaths))
+	total := 0
 	for _, path := range srv.servicePaths {
 		name := protoreflect.FullName(strings.Trim(path, "/"))
 		desc, err := protoregistry.GlobalFiles.FindDescriptorByName(name)
@@ -301,15 +337,32 @@ func registeredProcedures(t *testing.T, srv *Server) []string {
 		if !ok {
 			t.Fatalf("descriptor %q is %T, want a service descriptor", name, desc)
 		}
+
+		entrypoint, authorized := serviceEntrypoint(name)
+		service := registeredService{entrypoint: entrypoint, authorized: authorized}
 		methods := svc.Methods()
 		for i := range methods.Len() {
-			procedures = append(procedures, path+string(methods.Get(i).Name()))
+			service.procedures = append(service.procedures, path+string(methods.Get(i).Name()))
 		}
+		total += len(service.procedures)
+		services = append(services, service)
 	}
 
 	// Sanity floor: 25 procedures across the registered services today.
-	if len(procedures) < 25 {
-		t.Fatalf("derived %d procedures, want at least 25: %v", len(procedures), procedures)
+	if total < 25 {
+		t.Fatalf("derived %d procedures across %d services, want at least 25", total, len(services))
+	}
+	return services
+}
+
+// registeredProcedures is the flat list of Connect procedure paths the server
+// registers, derived from registeredServices.
+func registeredProcedures(t *testing.T, srv *Server) []string {
+	t.Helper()
+
+	var procedures []string
+	for _, service := range registeredServices(t, srv) {
+		procedures = append(procedures, service.procedures...)
 	}
 	return procedures
 }
@@ -329,23 +382,108 @@ var stalePolicyProcedures = map[string]bool{
 	"/deputy.graph.v1.GraphService/Why":     true,
 }
 
-// TestPolicyProcedureMapMatchesRegisteredProcedures checks every key of
-// procedureToEntrypoint against the procedures the server actually registers.
-// Procedures absent from the map bypass policy evaluation entirely, so a
-// stale key silently disables authorization for that RPC. Known-stale keys
-// are pinned in stalePolicyProcedures; this test fails when a new stale key
-// appears or when a pinned one is fixed without unpinning it.
+// unenforcedProcedures are procedures of policy-bearing services that
+// procedureToEntrypoint does not map, so policyInterceptor waves them through
+// with no policy evaluation at all. KNOWN DEFECT, pinned rather than hidden:
+// twelve of the nineteen procedures that should be authorized are not, so a
+// service_diff_request, service_graph_request or service_secrets_request
+// policy covers far less than its name suggests. DiffService and GraphService
+// are unmapped entirely (the map still names their pre-rename procedures, see
+// stalePolicyProcedures) and SecretsService is mapped only for Scan.
+//
+// Mapping these is a behavior change, since they become policy enforced, so
+// it is deliberately left out of this test-only change; closing a gap must
+// remove the entry here, which makes the list self-cleaning. Note that
+// policyInterceptor is a connect.UnaryInterceptorFunc, whose
+// WrapStreamingHandler returns the next handler untouched, so mapping the
+// StreamScan entries alone would not enforce anything either.
+var unenforcedProcedures = map[string]bool{
+	"/deputy.diff.v1.DiffService/DiffContainerImages":    true,
+	"/deputy.diff.v1.DiffService/DiffPackages":           true,
+	"/deputy.diff.v1.DiffService/DiffVulnerabilities":    true,
+	"/deputy.graph.v1.GraphService/BuildGraph":           true,
+	"/deputy.graph.v1.GraphService/QueryGraph":           true,
+	"/deputy.graph.v1.GraphService/WhyDependency":        true,
+	"/deputy.secrets.v1.SecretsService/ListDetectors":    true,
+	"/deputy.secrets.v1.SecretsService/RegisterDetector": true,
+	"/deputy.secrets.v1.SecretsService/ScanDiff":         true,
+	"/deputy.secrets.v1.SecretsService/ScanHistory":      true,
+	"/deputy.secrets.v1.SecretsService/StreamScan":       true,
+	"/deputy.secrets.v1.SecretsService/Verify":           true,
+}
+
+// TestPolicyProcedureMapMatchesRegisteredProcedures checks procedureToEntrypoint
+// against the procedures the server registers, in both directions, because
+// each direction hides a different defect.
+//
+// Outward: a key that matches no registered procedure is dead weight and its
+// entrypoint is never evaluated. Known-stale keys are pinned in
+// stalePolicyProcedures.
+//
+// Inward, and this is the security-relevant direction: unknown procedures are
+// allowed by default, so a procedure of a policy-bearing service that the map
+// omits is authorized by nothing. The expectation is derived rather than
+// hand-pinned, by crossing the registered services with the service
+// entrypoints in policy.EntrypointsService, so deleting or renaming a live
+// mapping fails here instead of silently disabling enforcement. Known gaps are
+// pinned in unenforcedProcedures.
+//
+// Both pin lists are checked for staleness, so closing a gap or fixing a key
+// without unpinning it fails too.
 func TestPolicyProcedureMapMatchesRegisteredProcedures(t *testing.T) {
 	srv, err := New(DefaultConfig())
 	if err != nil {
 		t.Fatal(err)
 	}
 
+	services := registeredServices(t, srv)
+
 	registered := make(map[string]bool)
-	for _, procedure := range registeredProcedures(t, srv) {
-		registered[procedure] = true
+	expected := make(map[string]policy.Entrypoint)
+	claimed := make(map[policy.Entrypoint]bool)
+	for _, service := range services {
+		for _, procedure := range service.procedures {
+			registered[procedure] = true
+			if service.authorized {
+				expected[procedure] = service.entrypoint
+			}
+		}
+		if service.authorized {
+			claimed[service.entrypoint] = true
+		}
 	}
 
+	// Every service entrypoint must belong to some registered service. An
+	// unclaimed one means the entrypoint is unreachable, or that a service
+	// package no longer matches its entrypoint name and so dropped out of the
+	// derived expectation below without anything noticing.
+	for _, entrypoint := range policy.EntrypointsService {
+		if !claimed[entrypoint] {
+			t.Errorf("service entrypoint %s is claimed by no registered service; the derived authorization expectation cannot cover it", entrypoint)
+		}
+	}
+
+	// Sanity floor: 19 procedures across the six policy-bearing services
+	// today. A collapsed expectation would make the inward check vacuous.
+	if len(expected) < 19 {
+		t.Fatalf("derived %d procedures needing authorization, want at least 19", len(expected))
+	}
+
+	// Inward: every procedure that should be authorized is mapped, to the
+	// right entrypoint.
+	for procedure, entrypoint := range expected {
+		mapped, ok := procedureToEntrypoint[procedure]
+		switch {
+		case !ok && !unenforcedProcedures[procedure]:
+			t.Errorf("registered procedure %s has no procedureToEntrypoint mapping, so %s is never evaluated and the RPC is authorized by nothing", procedure, entrypoint)
+		case ok && unenforcedProcedures[procedure]:
+			t.Errorf("procedure %s is mapped now; remove it from unenforcedProcedures", procedure)
+		case ok && mapped != entrypoint:
+			t.Errorf("procedure %s maps to entrypoint %s, want %s derived from its service package", procedure, mapped, entrypoint)
+		}
+	}
+
+	// Outward: every key names a procedure the server registers.
 	for procedure := range procedureToEntrypoint {
 		switch {
 		case registered[procedure] && stalePolicyProcedures[procedure]:
@@ -358,6 +496,12 @@ func TestPolicyProcedureMapMatchesRegisteredProcedures(t *testing.T) {
 	for procedure := range stalePolicyProcedures {
 		if _, ok := procedureToEntrypoint[procedure]; !ok {
 			t.Errorf("stalePolicyProcedures entry %s is no longer in procedureToEntrypoint; remove it", procedure)
+		}
+	}
+
+	for procedure := range unenforcedProcedures {
+		if !registered[procedure] {
+			t.Errorf("unenforcedProcedures entry %s matches no registered procedure; remove it", procedure)
 		}
 	}
 }


### PR DESCRIPTION
A batch of tests enumerated a hand-picked subset of the category they claim to cover, so members could drop out silently: the services test covered 5 of 7 services (dropping DiffService or GraphService registration was invisible), the root-command test 8 of 20 commands, the docsgen test 1 of 37 entrypoints despite being named CoversEveryEntrypoint, the MCP schema-safety test 2 of 30 schemas, the secrets no-body-leak test 1 of 14 verifiers.

Each now derives from its canonical source (proto service descriptors, register.go, `ecosystem.All()`, `policy.AllEntrypoints`, the registered tool set, `engine.verifiers`) with count floors so an emptied source also fails.

Deriving the corpora caught two real bugs:

1. **Fixed here:** `NewHandlerFactory` handed every factory the package-global ecosystem registry by reference, so registering a custom ecosystem on one factory mutated the defaults for all. Now `maps.Clone` per factory, with an isolation test.
2. **Pinned, not fixed:** the server policy interceptor's procedure map keys name procedures that do not exist (`Diff`, `Resolve`, `Why` vs the real `DiffPackages`, `BuildGraph`, ...), and unknown procedures are allowed by default, so diff and graph authorization never runs. That is #90; correcting the map is a behavior change needing review, so this PR adds a self-cleaning allowlist test that fails when #90 is fixed without deleting its entries.

Small production changes, all in service of the tests: a `servicePaths` record on the server, a `registeredTools` field on the MCP server, five missing tool mentions in the MCP instructions, and the registry clone fix.