### PR TITLE
Reject invalid policy values instead of silently ignoring them

### DIFF
--- a/docs/commands/policy.md
+++ b/docs/commands/policy.md
@@ -102,6 +102,13 @@ checked like any other.
 An optional field written as an explicit null (`mode:`, `mode: null`, `mode:
 ~`) is read as unset, exactly as loading the bundle reads it.
 
+A compiled bundle and a raw CEL source are checked for more than their CEL. Each
+carries its `policy.mode` and `policy.entrypoints` as `//!` metadata comments,
+naming the same closed vocabularies an authored bundle names as fields, so lint
+refuses a value the engine refuses when it loads the source. A misspelled
+`advsiory` is caught here rather than at load time in production, because a lint
+that passes an artifact the loader rejects is worse than no lint.
+
 ```
 deputy policy lint <policy.yaml> [policy2.yaml ...]
 ```

--- a/docs/commands/policy.md
+++ b/docs/commands/policy.md
@@ -78,12 +78,19 @@ policy that lints clean is a policy the editor considers clean:
 - YAML anchors, aliases, and merge keys, which bundles do not support (see
   [policy-spec](../reference/policy-spec.md#yaml-anchors-are-not-supported))
 - YAML that does not parse, reported with the offending line rather than as an
-  unrecognized file, for any document that writes a top-level `policies` key
+  unrecognized file, for any document that writes a top-level `policies` key,
+  bare or quoted (`policies:`, `"policies":`, `'policies':`)
 
-Every policy is checked, not just the first: a defect in one policy suppresses
-only that policy's expanded CEL, so a bundle reports all of its mistakes in one
-run. An optional field written as an explicit null (`mode:`, `mode: null`,
-`mode: ~`) is read as unset, exactly as loading the bundle reads it.
+Every policy is checked, not just the first, and one run reports every
+independent defect so a file is fixed once instead of a lint at a time. Each
+policy is walked and expanded on its own, so nothing about one policy withholds
+another policy's diagnostics: a field only the decoder refuses, such as a rule
+`status` written as a string, and an anchor written anywhere in the document
+are both reported alongside the rest of the bundle. What a defect does suppress
+is that one policy's expanded CEL, whose failure would only restate it.
+
+An optional field written as an explicit null (`mode:`, `mode: null`, `mode:
+~`) is read as unset, exactly as loading the bundle reads it.
 
 ```
 deputy policy lint <policy.yaml> [policy2.yaml ...]

--- a/docs/commands/policy.md
+++ b/docs/commands/policy.md
@@ -104,10 +104,12 @@ An optional field written as an explicit null (`mode:`, `mode: null`, `mode:
 
 A compiled bundle and a raw CEL source are checked for more than their CEL. Each
 carries its `policy.mode` and `policy.entrypoints` as `//!` metadata comments,
-naming the same closed vocabularies an authored bundle names as fields, so lint
-refuses a value the engine refuses when it loads the source. A misspelled
-`advsiory` is caught here rather than at load time in production, because a lint
-that passes an artifact the loader rejects is worse than no lint.
+naming the same closed vocabularies an authored bundle names as fields, so a
+value the engine refuses when it loads the source is refused here. A misspelled
+`advsiory` is caught by lint rather than at load time in production, because a
+lint that passes an artifact the loader rejects is worse than no lint. Loading a
+bundle means the same thing in both formats, so `bundle` and `inspect` refuse
+the same value rather than repackaging or describing a policy that cannot run.
 
 ```
 deputy policy lint <policy.yaml> [policy2.yaml ...]

--- a/docs/commands/policy.md
+++ b/docs/commands/policy.md
@@ -72,6 +72,8 @@ policy that lints clean is a policy the editor considers clean:
 - duplicate policy names
 - rules missing `when` or `action`, and `deny`/`warn` rules with no `reason`
 - invalid `mode`, malformed `vars`, and conditions that do not compile
+- YAML anchors, aliases, and merge keys, which bundles do not support (see
+  [policy-spec](../reference/policy-spec.md#yaml-anchors-are-not-supported))
 
 ```
 deputy policy lint <policy.yaml> [policy2.yaml ...]

--- a/docs/commands/policy.md
+++ b/docs/commands/policy.md
@@ -77,6 +77,13 @@ policy that lints clean is a policy the editor considers clean:
   reveals, so a bundle that lints clean is one `deputy policy bundle` compiles
 - YAML anchors, aliases, and merge keys, which bundles do not support (see
   [policy-spec](../reference/policy-spec.md#yaml-anchors-are-not-supported))
+- YAML that does not parse, reported with the offending line rather than as an
+  unrecognized file, for any document that writes a top-level `policies` key
+
+Every policy is checked, not just the first: a defect in one policy suppresses
+only that policy's expanded CEL, so a bundle reports all of its mistakes in one
+run. An optional field written as an explicit null (`mode:`, `mode: null`,
+`mode: ~`) is read as unset, exactly as loading the bundle reads it.
 
 ```
 deputy policy lint <policy.yaml> [policy2.yaml ...]

--- a/docs/commands/policy.md
+++ b/docs/commands/policy.md
@@ -76,8 +76,9 @@ policy that lints clean is a policy the editor considers clean:
 - invalid `mode`, malformed `vars`, and conditions that do not compile
 - vars that break the CEL a policy expands into, which no single condition
   reveals, so a bundle that lints clean is one `deputy policy bundle` compiles
-- YAML anchors, aliases, and merge keys, which bundles do not support (see
-  [policy-spec](../reference/policy-spec.md#yaml-anchors-are-not-supported))
+- YAML anchors, aliases, merge keys, and tags that rewrite a scalar, which
+  bundles do not support (see
+  [policy-spec](../reference/policy-spec.md#yaml-anchors-and-rewriting-tags-are-not-supported))
 - YAML that does not parse, reported with the offending line rather than as an
   unrecognized file, for any document that writes a top-level `policies` key,
   bare or quoted (`policies:`, `"policies":`, `'policies':`)
@@ -103,6 +104,16 @@ An optional field written as an explicit null (`mode:`, `mode: null`, `mode:
 
 ```
 deputy policy lint <policy.yaml> [policy2.yaml ...]
+```
+
+A path of `-` reads the policy from stdin. The format is chosen from the bytes,
+not from how they arrived, so a bundle piped in is validated exactly as the
+identical file is; raw CEL on stdin is still compiled as the one expression it
+is.
+
+```console
+$ deputy policy lint - < policies/deny-critical.yaml
+stdin OK
 ```
 
 ### Flags

--- a/docs/commands/policy.md
+++ b/docs/commands/policy.md
@@ -69,9 +69,12 @@ policy that lints clean is a policy the editor considers clean:
 
 - `action` values outside `allow|deny|warn`
 - unknown `entrypoints` and `commands`
-- duplicate policy names
+- duplicate policy names, compared with surrounding whitespace trimmed
+- a `policies` key that is missing, empty, or not a list
 - rules missing `when` or `action`, and `deny`/`warn` rules with no `reason`
 - invalid `mode`, malformed `vars`, and conditions that do not compile
+- vars that break the CEL a policy expands into, which no single condition
+  reveals, so a bundle that lints clean is one `deputy policy bundle` compiles
 - YAML anchors, aliases, and merge keys, which bundles do not support (see
   [policy-spec](../reference/policy-spec.md#yaml-anchors-are-not-supported))
 

--- a/docs/commands/policy.md
+++ b/docs/commands/policy.md
@@ -63,7 +63,15 @@ $ deputy policy eval \
 
 ## `lint`
 
-Validate CEL policy syntax and type safety.
+Validate policy bundles: CEL syntax and type safety plus the surrounding
+structure. Lint runs the same checks the editor language server runs, so a
+policy that lints clean is a policy the editor considers clean:
+
+- `action` values outside `allow|deny|warn`
+- unknown `entrypoints` and `commands`
+- duplicate policy names
+- rules missing `when` or `action`, and `deny`/`warn` rules with no `reason`
+- invalid `mode`, malformed `vars`, and conditions that do not compile
 
 ```
 deputy policy lint <policy.yaml> [policy2.yaml ...]
@@ -81,6 +89,14 @@ deputy policy lint <policy.yaml> [policy2.yaml ...]
 $ deputy policy lint policies/*.yaml
 policies/deny-critical.yaml OK
 policies/require-license.yaml OK
+```
+
+Problems are reported one per line, anchored to the file, line, column, policy,
+and rule, and the command exits non-zero:
+
+```console
+$ deputy policy lint policies/typo.yaml
+policies/typo.yaml:5:17: error: policy "block-critical" rule[0]: invalid action "dney" (expected allow|deny|warn)
 ```
 
 The linter provides helpful diagnostics with caret pointers:

--- a/docs/commands/policy.md
+++ b/docs/commands/policy.md
@@ -69,7 +69,8 @@ policy that lints clean is a policy the editor considers clean:
 
 - `action` values outside `allow|deny|warn`
 - unknown `entrypoints` and `commands`
-- duplicate policy names, compared with surrounding whitespace trimmed
+- duplicate policy names and duplicate var names, compared with surrounding
+  whitespace trimmed, since that is the name CEL binds and loading reads
 - a `policies` key that is missing, empty, or not a list
 - rules missing `when` or `action`, and `deny`/`warn` rules with no `reason`
 - invalid `mode`, malformed `vars`, and conditions that do not compile
@@ -86,8 +87,16 @@ independent defect so a file is fixed once instead of a lint at a time. Each
 policy is walked and expanded on its own, so nothing about one policy withholds
 another policy's diagnostics: a field only the decoder refuses, such as a rule
 `status` written as a string, and an anchor written anywhere in the document
-are both reported alongside the rest of the bundle. What a defect does suppress
-is that one policy's expanded CEL, whose failure would only restate it.
+are both reported alongside the rest of the bundle, as are the bundle-level
+fields that belong to no single policy.
+
+What a defect suppresses is narrow. A policy the walk already reported is not
+expanded as a whole, since that failure would only restate the defect in
+generated CEL, but its vars are still compiled because they are wrong or right
+on their own. And a policy is skipped only where lint cannot read it: an alias
+or a merge key puts part of the policy somewhere else, while an anchor
+definition says what it says where it is written, so the policy around it is
+checked like any other.
 
 An optional field written as an explicit null (`mode:`, `mode: null`, `mode:
 ~`) is read as unset, exactly as loading the bundle reads it.

--- a/docs/reference/policy-spec.md
+++ b/docs/reference/policy-spec.md
@@ -95,8 +95,32 @@ Canonical entrypoints (snake_case):
 - Empty `policies` or missing `rules` is invalid; each policy must have at least one rule.
 - Policy names must be unique within a bundle.
 - String vars are CEL expressions; non-string values are treated as literals. Rules must include `action` and `when`.
+- `action` must be `allow`, `deny`, or `warn`.
 - `mode`, if set, must be `enforce` or `advisory`.
 - Canonical ecosystem strings used by built-in entrypoints: `go`, `npm`, `pypi`, `rubygems`, `oci`.
+- YAML anchors, aliases, and merge keys are rejected. See below.
+
+### YAML anchors are not supported
+
+A bundle may not use YAML anchors (`&name`), aliases (`*name`), or merge keys
+(`<<:`). Both `deputy policy lint` and bundle loading refuse them, naming the
+line and the alternatives.
+
+This is closed for now, not closed forever. Nothing prevents Deputy from
+resolving these constructs, and the decision can be revisited if a real need
+appears. Two reasons to say no today:
+
+- A policy bundle is a security control, and its job is to state plainly what it
+  blocks. An aliased policy means the text a reviewer reads is not the policy
+  that runs, and merge-key precedence adds a resolution rule the reviewer has to
+  know before they can tell what a policy does.
+- Every YAML feature the format allows has to be implemented identically by
+  every reader of a bundle, and several read the document as nodes rather than
+  decoding it. That divergence is not hypothetical: it once let an aliased
+  bundle compile fine and lint as broken.
+
+To share rules across bundles, pass a separate file with `--policy`, which is
+repeatable. To reuse an expression within a bundle, use `vars:`.
 
 ## Examples
 

--- a/docs/reference/policy-spec.md
+++ b/docs/reference/policy-spec.md
@@ -108,7 +108,9 @@ A bundle may not use YAML anchors (`&name`), aliases (`*name`), or merge keys
 line and the alternatives. That includes a bundle whose `policies` key is not
 written directly but arrives through a top-level merge key. A refused anchor
 does not stop the rest of the checks: lint reports it alongside any unrelated
-defect in the policies written plainly.
+defect in the policies written plainly, including the CEL those policies expand
+into. Removing the anchor is not a prerequisite for seeing the rest of the
+report.
 
 This is closed for now, not closed forever. Nothing prevents Deputy from
 resolving these constructs, and the decision can be revisited if a real need

--- a/docs/reference/policy-spec.md
+++ b/docs/reference/policy-spec.md
@@ -104,7 +104,10 @@ Canonical entrypoints (snake_case):
 
 A bundle may not use YAML anchors (`&name`), aliases (`*name`), or merge keys
 (`<<:`). Both `deputy policy lint` and bundle loading refuse them, naming the
-line and the alternatives.
+line and the alternatives. That includes a bundle whose `policies` key is not
+written directly but arrives through a top-level merge key. A refused anchor
+does not stop the rest of the checks: lint reports it alongside any unrelated
+defect in the policies written plainly.
 
 This is closed for now, not closed forever. Nothing prevents Deputy from
 resolving these constructs, and the decision can be revisited if a real need

--- a/docs/reference/policy-spec.md
+++ b/docs/reference/policy-spec.md
@@ -98,6 +98,7 @@ Canonical entrypoints (snake_case):
 - `action` must be `allow`, `deny`, or `warn`.
 - `mode`, if set, must be `enforce` or `advisory`.
 - Canonical ecosystem strings used by built-in entrypoints: `go`, `npm`, `pypi`, `rubygems`, `oci`.
+- An optional field written as an explicit YAML null (`mode:`, `mode: null`, `mode: ~`) is unset, not a value to validate.
 - YAML anchors, aliases, and merge keys are rejected. See below.
 
 ### YAML anchors are not supported

--- a/docs/reference/policy-spec.md
+++ b/docs/reference/policy-spec.md
@@ -94,6 +94,9 @@ Canonical entrypoints (snake_case):
 ### Validation
 - Empty `policies` or missing `rules` is invalid; each policy must have at least one rule.
 - Policy names must be unique within a bundle.
+- Policy names and var names are read with surrounding whitespace trimmed, so
+  `blocked` and `" blocked "` are one name and declaring both is a duplicate. A
+  var name is a CEL identifier, which is why the two spellings cannot differ.
 - String vars are CEL expressions; non-string values are treated as literals. Rules must include `action` and `when`.
 - `action` must be `allow`, `deny`, or `warn`.
 - `mode`, if set, must be `enforce` or `advisory`.
@@ -109,8 +112,15 @@ line and the alternatives. That includes a bundle whose `policies` key is not
 written directly but arrives through a top-level merge key. A refused anchor
 does not stop the rest of the checks: lint reports it alongside any unrelated
 defect in the policies written plainly, including the CEL those policies expand
-into. Removing the anchor is not a prerequisite for seeing the rest of the
-report.
+into and the bundle-level fields around them. Removing the anchor is not a
+prerequisite for seeing the rest of the report.
+
+What lint does skip is only what it cannot read. An alias, and a mapping that
+merges another one in, say part of what they mean somewhere else, so lint has
+nothing at hand to describe and reports the construct alone. An anchor
+definition (`description: &text foo`) is not that: the value is written where a
+reader looks for it, so it is refused and everything around it is still
+checked.
 
 This is closed for now, not closed forever. Nothing prevents Deputy from
 resolving these constructs, and the decision can be revisited if a real need

--- a/docs/reference/policy-spec.md
+++ b/docs/reference/policy-spec.md
@@ -102,9 +102,9 @@ Canonical entrypoints (snake_case):
 - `mode`, if set, must be `enforce` or `advisory`.
 - Canonical ecosystem strings used by built-in entrypoints: `go`, `npm`, `pypi`, `rubygems`, `oci`.
 - An optional field written as an explicit YAML null (`mode:`, `mode: null`, `mode: ~`) is unset, not a value to validate.
-- YAML anchors, aliases, and merge keys are rejected. See below.
+- YAML anchors, aliases, merge keys, and tags that rewrite a scalar are rejected. See below.
 
-### YAML anchors are not supported
+### YAML anchors and rewriting tags are not supported
 
 A bundle may not use YAML anchors (`&name`), aliases (`*name`), or merge keys
 (`<<:`). Both `deputy policy lint` and bundle loading refuse them, naming the
@@ -114,6 +114,13 @@ does not stop the rest of the checks: lint reports it alongside any unrelated
 defect in the policies written plainly, including the CEL those policies expand
 into and the bundle-level fields around them. Removing the anchor is not a
 prerequisite for seeing the rest of the report.
+
+A bundle may also not use a YAML tag that makes a scalar's value differ from the
+text the document writes for it, such as `action: !!binary ZGVueQ==`, which
+reviews as base64 and denies. The refusal keys off that divergence rather than
+off a list of tags, so every plain spelling still loads: quoted, folded, and
+block scalars, an explicit null, and a tag that leaves the text alone
+(`!!str deny`) are all accepted.
 
 What lint does skip is only what it cannot read. An alias, and a mapping that
 merges another one in, say part of what they mean somewhere else, so lint has
@@ -129,14 +136,17 @@ appears. Two reasons to say no today:
 - A policy bundle is a security control, and its job is to state plainly what it
   blocks. An aliased policy means the text a reviewer reads is not the policy
   that runs, and merge-key precedence adds a resolution rule the reviewer has to
-  know before they can tell what a policy does.
+  know before they can tell what a policy does. A rewriting tag is the same
+  defect spelled shorter.
 - Every YAML feature the format allows has to be implemented identically by
   every reader of a bundle, and several read the document as nodes rather than
   decoding it. That divergence is not hypothetical: it once let an aliased
-  bundle compile fine and lint as broken.
+  bundle compile fine and lint as broken, and a tagged action lint as invalid
+  and compile as `deny`.
 
 To share rules across bundles, pass a separate file with `--policy`, which is
-repeatable. To reuse an expression within a bundle, use `vars:`.
+repeatable. To reuse an expression within a bundle, use `vars:`. To write a
+value the format would otherwise read as another type, quote it.
 
 ## Examples
 

--- a/internal/cli/cmd/policy.go
+++ b/internal/cli/cmd/policy.go
@@ -323,21 +323,16 @@ func newPolicyLintCommand() *cobra.Command {
 			stdinUsed := false
 			failures := 0
 			for _, path := range args {
-				if path == "-" {
-					data, err := readPathOrStdinOnce(cmd.InOrStdin(), path, &stdinUsed)
-					if err != nil {
-						return fmt.Errorf("read %q: %w", path, err)
-					}
-					if err := policy.Compile(string(data), extraVars); err != nil {
-						known := append(policy.DefaultVariableNames(), extraVars...)
-						return fmt.Errorf("%s: %s", path, formatCelCompileError(err, string(data), known))
-					}
-					fmt.Fprintf(cmd.OutOrStdout(), "%s OK\n", labelPath(path))
-					continue
+				data, err := readPathOrStdinOnce(cmd.InOrStdin(), path, &stdinUsed)
+				if err != nil {
+					return fmt.Errorf("read %q: %w", path, err)
 				}
 				// Prefer structured lint for YAML bundles: it validates the whole
-				// bundle, not just the CEL, and reports clearer errors.
-				handled, problems, err := lintStructuredBundle(path, extraVars, cmd.OutOrStdout())
+				// bundle, not just the CEL, and reports clearer errors. The choice is
+				// made from the bytes, so a bundle reaches the same checks however it
+				// is supplied; deciding it from the path used to lint a piped bundle
+				// as raw CEL and fail on its first key.
+				handled, problems, err := lintStructuredBundle(data, path, extraVars, cmd.OutOrStdout())
 				if err != nil {
 					return err
 				}
@@ -345,15 +340,37 @@ func newPolicyLintCommand() *cobra.Command {
 					failures += problems
 					continue
 				}
+				// A compiled bundle holds its policies as compiled CEL, so it is loaded
+				// as the policies it carries rather than compiled as one expression.
+				// Loading it from the bytes is what makes stdin behave as the
+				// identical file does, since stdin has no path to reread.
+				if policy.IsCompiledBundle(data) {
+					sources, err := policy.LoadSourcesFromBytes(data, path)
+					if err != nil {
+						return err
+					}
+					if err := compileSources(sources, extraVars); err != nil {
+						return err
+					}
+					fmt.Fprintf(cmd.OutOrStdout(), "%s OK\n", labelPath(path))
+					continue
+				}
+				// Raw CEL. Stdin is compiled as the one source it is, while a file is
+				// loaded, since it may hold several.
+				if path == "-" {
+					if err := policy.Compile(string(data), extraVars); err != nil {
+						known := append(policy.DefaultVariableNames(), extraVars...)
+						return fmt.Errorf("%s: %s", path, formatCelCompileError(err, string(data), known))
+					}
+					fmt.Fprintf(cmd.OutOrStdout(), "%s OK\n", labelPath(path))
+					continue
+				}
 				sources, err := policy.LoadSources([]string{path})
 				if err != nil {
 					return err
 				}
-				for _, src := range sources {
-					if err := policy.Compile(src.Body, extraVars); err != nil {
-						known := append(policy.DefaultVariableNames(), extraVars...)
-						return fmt.Errorf("%s: %s", src.Name, formatCelCompileError(err, src.Body, known))
-					}
+				if err := compileSources(sources, extraVars); err != nil {
+					return err
 				}
 				fmt.Fprintf(cmd.OutOrStdout(), "%s OK\n", labelPath(path))
 			}
@@ -367,16 +384,29 @@ func newPolicyLintCommand() *cobra.Command {
 	return cmd
 }
 
+// compileSources compiles every source a policy file loaded into, stopping at
+// the first that does not compile and rendering it with the caret snippet lint
+// uses for a condition. A file may hold several policies, and a compiled bundle
+// holds one source per policy it was built from.
+func compileSources(sources []policy.Source, extraVars []string) error {
+	for _, src := range sources {
+		if err := policy.Compile(src.Body, extraVars); err != nil {
+			known := append(policy.DefaultVariableNames(), extraVars...)
+			return fmt.Errorf("%s: %s", src.Name, formatCelCompileError(err, src.Body, known))
+		}
+	}
+	return nil
+}
+
 // lintStructuredBundle validates a YAML structured bundle with the same checks
 // the editor runs, printing every issue it finds instead of stopping at the
-// first. It reports handled=false when the file is not a structured bundle so
+// first. It reports handled=false when the data is not a structured bundle so
 // the caller can fall back to compiling it as raw CEL, and returns the number of
 // issues serious enough to fail the run (hints are advice, not failures).
-func lintStructuredBundle(path string, extraVars []string, out io.Writer) (handled bool, problems int, err error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return false, 0, fmt.Errorf("read %q: %w", path, err)
-	}
+//
+// It takes the bytes rather than reading them, so stdin and a file are linted
+// the same way; path only names the source in the issues it prints.
+func lintStructuredBundle(data []byte, path string, extraVars []string, out io.Writer) (handled bool, problems int, err error) {
 	// Gate on the bundle's shape, not on whether it decodes: a policy with a
 	// mistyped field must reach validation and be told which field is wrong,
 	// rather than falling through to the generic unrecognized-format error.

--- a/internal/cli/cmd/policy.go
+++ b/internal/cli/cmd/policy.go
@@ -967,6 +967,19 @@ func inspectPolicyPath(w io.Writer, path string) error {
 		return err
 	}
 	if bundle, ok := policy.ParseBundle(data); ok {
+		// Describing a bundle is not the same question as loading one, and inspect
+		// used to answer only the first: it read the bundle's shape and reported the
+		// policies it holds, so a bundle whose `//! policy.mode` the loader refuses
+		// was described as if Deputy could run it. Ask the loader for its verdict
+		// before reporting anything, so every command that reads a compiled bundle
+		// agrees about which ones are bundles Deputy will load.
+		//
+		// The shape is still read separately because the loader returns the policy
+		// sources and not the schema version or the generation time, which are what
+		// inspect exists to show.
+		if _, err := policy.LoadSourcesFromBytes(data, path); err != nil {
+			return err
+		}
 		fmt.Fprintf(w, "Bundle: %s\n", path)
 		fmt.Fprintf(w, "  Schema: %s\n", bundle.SchemaVersion)
 		if bundle.Generated != "" {

--- a/internal/cli/cmd/policy.go
+++ b/internal/cli/cmd/policy.go
@@ -532,6 +532,14 @@ func formatCelCompileError(err error, src string, known []string) string {
 		return celDetail(msg)
 	}
 	line := strings.ReplaceAll(lines[lineNum-1], "\t", " ")
+	// A caret needs a character to sit under. CEL names a line with none when the
+	// source is empty, as a compiled bundle carrying no source for a policy is, and
+	// when the error falls on a blank line inside one. Clamping the column to the
+	// end of that line put it before the line's start and panicked the process, so
+	// the detail is reported without a snippet, as the editor's formatter does.
+	if line == "" {
+		return celDetail(msg)
+	}
 	target := colNum - 1
 	if name := extractUndeclaredName(msg); name != "" {
 		if idx := strings.Index(line, name); idx >= 0 {

--- a/internal/cli/cmd/policy.go
+++ b/internal/cli/cmd/policy.go
@@ -41,7 +41,7 @@ Deputy uses the Common Expression Language (CEL) to define security policies for
 
 SUBCOMMANDS:
 • eval:    Evaluate a policy against a JSON input
-• lint:    Check policy syntax and types
+• lint:    Check policy structure, syntax, and types
 • test:    Run unit tests for policies
 • bundle:  Package multiple policies into a single file
 • repl:    Interactive policy development shell
@@ -315,12 +315,13 @@ func newPolicyLintCommand() *cobra.Command {
 	var extraVars []string
 	cmd := &cobra.Command{
 		Use:           "lint <policy.yaml> [policy2.yaml ...]",
-		Short:         "Lint CEL policies for syntax/type issues",
+		Short:         "Lint policy bundles for structure, syntax, and type issues",
 		SilenceErrors: true,
 		SilenceUsage:  true,
 		Args:          cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			stdinUsed := false
+			failures := 0
 			for _, path := range args {
 				if path == "-" {
 					data, err := readPathOrStdinOnce(cmd.InOrStdin(), path, &stdinUsed)
@@ -334,12 +335,14 @@ func newPolicyLintCommand() *cobra.Command {
 					fmt.Fprintf(cmd.OutOrStdout(), "%s OK\n", labelPath(path))
 					continue
 				}
-				// Prefer structured lint for YAML bundles for clearer CEL errors.
-				ok, err := lintStructuredBundle(path, extraVars, cmd.OutOrStdout())
+				// Prefer structured lint for YAML bundles: it validates the whole
+				// bundle, not just the CEL, and reports clearer errors.
+				handled, problems, err := lintStructuredBundle(path, extraVars, cmd.OutOrStdout())
 				if err != nil {
 					return err
 				}
-				if ok {
+				if handled {
+					failures += problems
 					continue
 				}
 				sources, err := policy.LoadSources([]string{path})
@@ -354,6 +357,9 @@ func newPolicyLintCommand() *cobra.Command {
 				}
 				fmt.Fprintf(cmd.OutOrStdout(), "%s OK\n", labelPath(path))
 			}
+			if failures > 0 {
+				return fmt.Errorf("%d policy problem(s) found", failures)
+			}
 			return nil
 		},
 	}
@@ -361,33 +367,63 @@ func newPolicyLintCommand() *cobra.Command {
 	return cmd
 }
 
-// lintStructuredBundle lints a YAML structured bundle with friendlier CEL errors.
-// Returns ok=true if the bundle was structured and handled here.
-func lintStructuredBundle(path string, extraVars []string, out io.Writer) (ok bool, err error) {
+// lintStructuredBundle validates a YAML structured bundle with the same checks
+// the editor runs, printing every issue it finds instead of stopping at the
+// first. It reports handled=false when the file is not a structured bundle so
+// the caller can fall back to compiling it as raw CEL, and returns the number of
+// issues serious enough to fail the run (hints are advice, not failures).
+func lintStructuredBundle(path string, extraVars []string, out io.Writer) (handled bool, problems int, err error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return false, err
+		return false, 0, fmt.Errorf("read %q: %w", path, err)
 	}
-	bundle, parsed, err := policy.TryParseStructuredBundleBytes(data)
-	if err != nil {
-		return true, err
+	if _, parsed, err := policy.TryParseStructuredBundleBytes(data); err != nil || !parsed {
+		return false, 0, err
 	}
-	if !parsed {
-		return false, nil
-	}
-	for pi, pol := range bundle.Policies {
-		declared := append(extraVars, pol.Vars.Names()...)
-		known := append(policy.DefaultVariableNames(), declared...)
-		for ri, rule := range pol.Rules {
-			if err := policy.Compile(rule.When, declared); err != nil {
-				pref := fmt.Sprintf("%s::%s rule[%d]", path, pol.Name, ri)
-				return true, fmt.Errorf("%s: %s", pref, formatCelCompileError(err, rule.When, known))
+	issues, err := policy.ValidateBundle(string(data), policy.ValidateOptions{
+		Source:    path,
+		ExtraVars: extraVars,
+		CheckWhen: func(when policy.RuleWhen) []policy.Issue {
+			compileErr := policy.Compile(when.Expr, when.DeclaredVars)
+			if compileErr == nil {
+				return nil
 			}
-		}
-		_ = pi
+			known := append(policy.DefaultVariableNames(), when.DeclaredVars...)
+			return []policy.Issue{{
+				Policy:    when.Policy,
+				RuleIndex: when.RuleIndex,
+				Line:      when.Line,
+				Column:    when.Column,
+				Severity:  policy.IssueError,
+				Code:      "cel-error",
+				Message:   formatCelCompileError(compileErr, when.Expr, known),
+			}}
+		},
+	})
+	if err != nil {
+		return true, 0, fmt.Errorf("lint %q: %w", path, err)
 	}
-	fmt.Fprintf(out, "%s OK\n", labelPath(path))
-	return true, nil
+	for _, issue := range issues {
+		if issue.Severity != policy.IssueHint {
+			problems++
+		}
+		fmt.Fprintf(out, "%s\n", formatLintIssue(path, issue))
+	}
+	if problems == 0 {
+		fmt.Fprintf(out, "%s OK\n", labelPath(path))
+	}
+	return true, problems, nil
+}
+
+// formatLintIssue renders one issue as a file-anchored line an editor or a human
+// can jump to. Bundle-wide issues already carry the path in their message, so it
+// is not repeated.
+func formatLintIssue(path string, issue policy.Issue) string {
+	text := issue.String()
+	if issue.Line <= 0 {
+		return fmt.Sprintf("%s: %s", labelPath(path), strings.Replace(text, path+"/", "", 1))
+	}
+	return fmt.Sprintf("%s:%s", labelPath(path), text)
 }
 
 // readPathOrStdin reads data from the given path or stdin if path is "-".

--- a/internal/cli/cmd/policy.go
+++ b/internal/cli/cmd/policy.go
@@ -349,18 +349,18 @@ func newPolicyLintCommand() *cobra.Command {
 					if err != nil {
 						return err
 					}
-					if err := compileSources(sources, extraVars); err != nil {
+					if err := lintSources(sources, extraVars); err != nil {
 						return err
 					}
 					fmt.Fprintf(cmd.OutOrStdout(), "%s OK\n", labelPath(path))
 					continue
 				}
-				// Raw CEL. Stdin is compiled as the one source it is, while a file is
-				// loaded, since it may hold several.
+				// Raw CEL. Stdin is checked as the one source it is, while a file is
+				// loaded, since it may hold several. Both go through lintSources, so a
+				// source piped in is asked the same questions as the identical file.
 				if path == "-" {
-					if err := policy.Compile(string(data), extraVars); err != nil {
-						known := append(policy.DefaultVariableNames(), extraVars...)
-						return fmt.Errorf("%s: %s", path, formatCelCompileError(err, string(data), known))
+					if err := lintSources([]policy.Source{{Name: path, Body: string(data)}}, extraVars); err != nil {
+						return err
 					}
 					fmt.Fprintf(cmd.OutOrStdout(), "%s OK\n", labelPath(path))
 					continue
@@ -369,7 +369,7 @@ func newPolicyLintCommand() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				if err := compileSources(sources, extraVars); err != nil {
+				if err := lintSources(sources, extraVars); err != nil {
 					return err
 				}
 				fmt.Fprintf(cmd.OutOrStdout(), "%s OK\n", labelPath(path))
@@ -384,15 +384,29 @@ func newPolicyLintCommand() *cobra.Command {
 	return cmd
 }
 
-// compileSources compiles every source a policy file loaded into, stopping at
-// the first that does not compile and rendering it with the caret snippet lint
-// uses for a condition. A file may hold several policies, and a compiled bundle
-// holds one source per policy it was built from.
-func compileSources(sources []policy.Source, extraVars []string) error {
+// lintSources checks every source a policy file loaded into the way loading it to
+// run it does: the CEL has to compile, and the `//!` metadata beside it has to name
+// vocabularies Deputy recognizes. It stops at the first source that fails, in the
+// order the engine asks the same two questions, and renders a compiler failure with
+// the caret snippet lint uses for a condition. A file may hold several policies, and
+// a compiled bundle holds one source per policy it was built from.
+//
+// The metadata check is the engine's own (policy.ValidateSourceMetadata) rather than
+// a second reading of it. Checking only the CEL let lint certify an artifact the
+// loader refuses: a compiled bundle carrying `//! policy.mode = advsiory` reported
+// OK and then failed to load in production, and a lint that passes what the loader
+// rejects is worse than no lint, since it is Deputy telling an operator their policy
+// is fine. An authored bundle reaches these vocabularies through the node walk
+// instead (see policy.ValidateBundle), which is why this is the compiled and raw
+// paths only.
+func lintSources(sources []policy.Source, extraVars []string) error {
 	for _, src := range sources {
 		if err := policy.Compile(src.Body, extraVars); err != nil {
 			known := append(policy.DefaultVariableNames(), extraVars...)
 			return fmt.Errorf("%s: %s", src.Name, formatCelCompileError(err, src.Body, known))
+		}
+		if err := policy.ValidateSourceMetadata(src); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/internal/cli/cmd/policy.go
+++ b/internal/cli/cmd/policy.go
@@ -392,13 +392,13 @@ func newPolicyLintCommand() *cobra.Command {
 // a compiled bundle holds one source per policy it was built from.
 //
 // The metadata check is the engine's own (policy.ValidateSourceMetadata) rather than
-// a second reading of it. Checking only the CEL let lint certify an artifact the
-// loader refuses: a compiled bundle carrying `//! policy.mode = advsiory` reported
-// OK and then failed to load in production, and a lint that passes what the loader
-// rejects is worse than no lint, since it is Deputy telling an operator their policy
-// is fine. An authored bundle reaches these vocabularies through the node walk
-// instead (see policy.ValidateBundle), which is why this is the compiled and raw
-// paths only.
+// a second reading of it, and it is here for the raw source lint reads off stdin,
+// which is the one source that reaches this without a loader having refused it
+// already. A loaded source is checked as it is loaded, and an authored bundle
+// reaches the same vocabularies through the node walk (see policy.ValidateBundle),
+// so every path lint takes asks what loading the source to run it asks. Checking
+// only the CEL let lint certify an artifact the loader refuses, which is worse than
+// no lint: it is Deputy telling an operator their policy is fine.
 func lintSources(sources []policy.Source, extraVars []string) error {
 	for _, src := range sources {
 		if err := policy.Compile(src.Body, extraVars); err != nil {

--- a/internal/cli/cmd/policy.go
+++ b/internal/cli/cmd/policy.go
@@ -377,8 +377,11 @@ func lintStructuredBundle(path string, extraVars []string, out io.Writer) (handl
 	if err != nil {
 		return false, 0, fmt.Errorf("read %q: %w", path, err)
 	}
-	if _, parsed, err := policy.TryParseStructuredBundleBytes(data); err != nil || !parsed {
-		return false, 0, err
+	// Gate on the bundle's shape, not on whether it decodes: a policy with a
+	// mistyped field must reach validation and be told which field is wrong,
+	// rather than falling through to the generic unrecognized-format error.
+	if !policy.LooksLikeStructuredBundle(data) {
+		return false, 0, nil
 	}
 	issues, err := policy.ValidateBundle(string(data), policy.ValidateOptions{
 		Source:    path,
@@ -416,12 +419,13 @@ func lintStructuredBundle(path string, extraVars []string, out io.Writer) (handl
 }
 
 // formatLintIssue renders one issue as a file-anchored line an editor or a human
-// can jump to. Bundle-wide issues already carry the path in their message, so it
-// is not repeated.
+// can jump to. Issues that come from loading the bundle name the file in their
+// own message, so that prefix is dropped rather than printed twice.
 func formatLintIssue(path string, issue policy.Issue) string {
-	text := issue.String()
+	text := strings.Replace(issue.String(), path+"/", "", 1)
+	text = strings.Replace(text, path+": ", "", 1)
 	if issue.Line <= 0 {
-		return fmt.Sprintf("%s: %s", labelPath(path), strings.Replace(text, path+"/", "", 1))
+		return fmt.Sprintf("%s: %s", labelPath(path), text)
 	}
 	return fmt.Sprintf("%s:%s", labelPath(path), text)
 }

--- a/internal/cli/cmd/policy_lint_test.go
+++ b/internal/cli/cmd/policy_lint_test.go
@@ -381,3 +381,155 @@ func TestPolicyLintReportsYAMLSyntaxErrors(t *testing.T) {
 		})
 	}
 }
+
+// lintStdin pipes a policy to `lint -` and returns the output plus whether the
+// run failed, so a document can be linted the way a pipeline supplies it.
+func lintStdin(t *testing.T, document string) (string, error) {
+	t.Helper()
+	root := &cobra.Command{Use: "deputy"}
+	root.AddCommand(newPolicyLintCommand())
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetIn(strings.NewReader(document))
+	root.SetArgs([]string{"lint", "-"})
+	err := root.Execute()
+	return out.String(), err
+}
+
+// TestPolicyLintReadsStdinAsTheFormatItIs pins that lint picks a format from the
+// bytes rather than from how they arrived. Before this, `lint -` compiled
+// whatever it read as raw CEL, so piping a bundle failed on its first key while
+// the identical file linted clean.
+func TestPolicyLintReadsStdinAsTheFormatItIs(t *testing.T) {
+	cases := []struct {
+		name     string
+		document string
+		wantFail bool
+		wantText []string
+	}{
+		{
+			name: "an authored bundle is validated, not compiled as CEL",
+			document: `policies:
+  - name: ok
+    rules:
+      - when: "true"
+        action: deny
+        reason: "always"
+`,
+			wantText: []string{"OK"},
+		},
+		{
+			name: "an authored bundle's defects are reported with their lines",
+			document: `policies:
+  - name: broken
+    entrypoints: ["nope_entrypoint"]
+    rules:
+      - when: "true"
+        action: dney
+        reason: "r"
+`,
+			wantFail: true,
+			wantText: []string{
+				`invalid entrypoint "nope_entrypoint"`,
+				`invalid action "dney"`,
+			},
+		},
+		{
+			name: "a refused construct is refused on stdin too",
+			document: `policies:
+  - name: tagged
+    rules:
+      - when: "true"
+        action: !!binary ZGVueQ==
+        reason: "r"
+`,
+			wantFail: true,
+			wantText: []string{"do not support YAML tags that rewrite a scalar"},
+		},
+		{
+			name:     "raw CEL is still compiled as the one expression it is",
+			document: `pkg.name == "left-pad"`,
+			wantText: []string{"OK"},
+		},
+		{
+			name:     "raw CEL that does not compile still fails",
+			document: `pkg.name ==`,
+			wantFail: true,
+			wantText: []string{"Syntax error"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := lintStdin(t, tc.document)
+			combined := out
+			if err != nil {
+				combined += "\n" + err.Error()
+			}
+			if tc.wantFail && err == nil {
+				t.Fatalf("expected lint to fail, got output %q", combined)
+			}
+			if !tc.wantFail && err != nil {
+				t.Fatalf("expected lint to pass, got %v with output %q", err, combined)
+			}
+			for _, want := range tc.wantText {
+				if !strings.Contains(combined, want) {
+					t.Fatalf("output %q should contain %q", combined, want)
+				}
+			}
+		})
+	}
+}
+
+// TestPolicyLintAgreesAcrossStdinAndPath pins the equivalence directly: the same
+// bytes have to produce the same verdict whether they are piped or named, since
+// a pipeline and a file are the same policy.
+func TestPolicyLintAgreesAcrossStdinAndPath(t *testing.T) {
+	cases := []struct {
+		name     string
+		document string
+	}{
+		{
+			name: "a clean bundle",
+			document: `policies:
+  - name: ok
+    rules:
+      - when: "true"
+        action: deny
+        reason: "always"
+`,
+		},
+		{
+			name: "a bundle with a bad action",
+			document: `policies:
+  - name: broken
+    rules:
+      - when: "true"
+        action: dney
+        reason: "r"
+`,
+		},
+		{
+			name: "a bundle missing its rules",
+			document: `policies:
+  - name: ruleless
+`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pathOut, pathErr := runPolicyLint(t, tc.document)
+			stdinOut, stdinErr := lintStdin(t, tc.document)
+			if (pathErr == nil) != (stdinErr == nil) {
+				t.Fatalf("verdicts differ: path err=%v out=%q, stdin err=%v out=%q", pathErr, pathOut, stdinErr, stdinOut)
+			}
+			// The two name their source differently and are otherwise the same
+			// report, so compare with the source label removed.
+			wantBody := strings.ReplaceAll(pathOut, "POLICY", "")
+			gotBody := strings.ReplaceAll(stdinOut, "stdin", "")
+			if wantBody != gotBody {
+				t.Fatalf("reports differ:\n path: %q\nstdin: %q", wantBody, gotBody)
+			}
+		})
+	}
+}

--- a/internal/cli/cmd/policy_lint_test.go
+++ b/internal/cli/cmd/policy_lint_test.go
@@ -88,6 +88,23 @@ func TestPolicyLintValidatesBeyondCEL(t *testing.T) {
 			wantText: []string{`policy "unbound" rule[0]`, "undeclared reference"},
 		},
 		{
+			name: "unrelated defects are all reported in one run",
+			bundle: `policies:
+  - name: two-defects
+    mode: enfroce
+    rules:
+      - when: "true"
+        action: dney
+        reason: "x"
+`,
+			wantFail: true,
+			wantText: []string{
+				`policy "two-defects": invalid mode "enfroce"`,
+				`policy "two-defects" rule[0]: invalid action "dney"`,
+				"2 policy problem(s) found",
+			},
+		},
+		{
 			name: "duplicate policy names fail",
 			bundle: `policies:
   - name: same
@@ -114,9 +131,15 @@ func TestPolicyLintValidatesBeyondCEL(t *testing.T) {
 			if !tc.wantFail && err != nil {
 				t.Fatalf("lint failed unexpectedly: %v\n%s", err, out)
 			}
+			// The per-issue lines go to stdout and the summary comes back as the
+			// command error, so both are what the user sees.
+			reported := out
+			if err != nil {
+				reported += err.Error()
+			}
 			for _, want := range tc.wantText {
-				if !strings.Contains(out, want) {
-					t.Fatalf("output missing %q:\n%s", want, out)
+				if !strings.Contains(reported, want) {
+					t.Fatalf("output missing %q:\n%s", want, reported)
 				}
 			}
 		})

--- a/internal/cli/cmd/policy_lint_test.go
+++ b/internal/cli/cmd/policy_lint_test.go
@@ -179,6 +179,88 @@ func TestPolicyLintValidatesBeyondCEL(t *testing.T) {
 	}
 }
 
+// TestPolicyAnchorsRejectedByBothCommands pins that lint and bundle refuse the
+// same YAML constructs with the same message. Anchors are deliberately not part
+// of the bundle format, and the two commands must not disagree about that: a
+// bundle that compiles but does not lint, or the reverse, is the divergence this
+// restriction exists to prevent.
+func TestPolicyAnchorsRejectedByBothCommands(t *testing.T) {
+	cases := []struct {
+		name     string
+		bundle   string
+		wantText string
+	}{
+		{
+			name: "aliased policy",
+			bundle: `base: &base
+  name: aliased
+  rules:
+    - when: "true"
+      action: deny
+      reason: "r"
+
+policies:
+  - *base
+`,
+			wantText: "do not support YAML anchors and aliases",
+		},
+		{
+			name: "merge key",
+			bundle: `defaults: &defaults
+  rules:
+    - when: "true"
+      action: deny
+      reason: "r"
+
+policies:
+  - <<: *defaults
+    name: inherits
+`,
+			wantText: "do not support YAML merge keys",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "policy.yaml")
+			if err := os.WriteFile(path, []byte(tc.bundle), 0o600); err != nil {
+				t.Fatalf("write policy: %v", err)
+			}
+
+			lintOut, lintErr := runPolicyLint(t, tc.bundle)
+			if lintErr == nil {
+				t.Fatalf("expected lint to fail, output:\n%s", lintOut)
+			}
+			if !strings.Contains(lintOut, tc.wantText) {
+				t.Fatalf("lint output missing %q:\n%s", tc.wantText, lintOut)
+			}
+			if !strings.Contains(lintOut, "--policy file") || !strings.Contains(lintOut, "vars:") {
+				t.Fatalf("lint output should point at the alternatives:\n%s", lintOut)
+			}
+
+			bundleRoot := &cobra.Command{Use: "deputy"}
+			bundleRoot.AddCommand(newPolicyBundleCommand())
+			var bundleOut bytes.Buffer
+			bundleRoot.SetOut(&bundleOut)
+			bundleRoot.SetErr(&bundleOut)
+			bundleRoot.SetArgs([]string{"bundle", "--output", filepath.Join(dir, "out.json"), path})
+			err := bundleRoot.Execute()
+			if err == nil {
+				t.Fatalf("expected bundle to fail, output:\n%s", bundleOut.String())
+			}
+			// Lint lists every construct it finds while the loader stops at the
+			// first, so the loader's message has to be one lint also printed.
+			_, message, found := strings.Cut(err.Error(), "policy bundles do not support YAML")
+			if !found {
+				t.Fatalf("bundle error %q should refuse the construct by name", err)
+			}
+			if !strings.Contains(lintOut, "policy bundles do not support YAML"+message) {
+				t.Fatalf("bundle error %q is not among the messages lint printed:\n%s", err, lintOut)
+			}
+		})
+	}
+}
+
 // TestPolicyLintAcceptsCompiledBundle pins the round trip documented in the
 // policy framework reference: what `deputy policy bundle` writes must lint
 // clean. A compiled bundle is JSON, and JSON is valid YAML with a "policies"

--- a/internal/cli/cmd/policy_lint_test.go
+++ b/internal/cli/cmd/policy_lint_test.go
@@ -764,3 +764,82 @@ func TestPolicyBundleRefusesMetadataTheEngineRefuses(t *testing.T) {
 		})
 	}
 }
+
+// TestPolicyInspectRefusesMetadataTheEngineRefuses pins that describing a compiled
+// bundle and loading one agree about which bundles Deputy will load. Inspect read
+// the bundle's shape and reported the policies it holds, which is a different
+// question from whether the loader accepts it, so it described a bundle declaring
+// `advsiory` as if it would run and exited 0. That is the same defect as a lint or a
+// writer waving one through, reached from the command whose whole job is to tell an
+// operator what an artifact is.
+//
+// A bundle Deputy accepts still has to be described in full, since refusing to
+// describe anything would satisfy the first half of this and be useless.
+func TestPolicyInspectRefusesMetadataTheEngineRefuses(t *testing.T) {
+	cases := []struct {
+		name     string
+		source   string
+		wantFail bool
+		wantText string
+	}{
+		{
+			name:     "a misspelled mode",
+			source:   "//! policy.mode = advsiory\n[]",
+			wantFail: true,
+			wantText: `invalid mode "advsiory"`,
+		},
+		{
+			name:     "a misspelled entrypoint",
+			source:   `//! policy.entrypoints = "scan_vulnerabilities"` + "\n[]",
+			wantFail: true,
+			wantText: `invalid entrypoint "scan_vulnerabilities"`,
+		},
+		{
+			name:     "metadata Deputy recognizes",
+			source:   `//! policy.mode = "advisory"` + "\n[]",
+			wantText: "described",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := json.Marshal(tc.source)
+			if err != nil {
+				t.Fatalf("marshal source: %v", err)
+			}
+			path := filepath.Join(t.TempDir(), "bundle.json")
+			document := `{"schemaVersion":"policy.deputy.sh/v1alpha1","generated":"2026-01-01T00:00:00Z","policies":[{"name":"p","source":` + string(body) + `}]}`
+			if err := os.WriteFile(path, []byte(document), 0o600); err != nil {
+				t.Fatalf("write bundle: %v", err)
+			}
+
+			var out bytes.Buffer
+			err = inspectPolicyPath(&out, path)
+
+			if !tc.wantFail {
+				if err != nil {
+					t.Fatalf("inspecting a bundle Deputy accepts failed: %v\n%s", err, out.String())
+				}
+				// The fields inspect exists to show come from the bundle's shape
+				// rather than from its sources, so asking the loader for a verdict
+				// must not cost any of them.
+				for _, want := range []string{"policy.deputy.sh/v1alpha1", "2026-01-01T00:00:00Z", "p"} {
+					if !strings.Contains(out.String(), want) {
+						t.Fatalf("inspect output should still report %q, got:\n%s", want, out.String())
+					}
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected inspect to refuse a bundle the loader refuses, got:\n%s", out.String())
+			}
+			if !strings.Contains(err.Error(), tc.wantText) {
+				t.Fatalf("error %q should name the offending value as %q", err, tc.wantText)
+			}
+			// Reporting nothing is what keeps a refusal from reading as a
+			// description with a warning attached.
+			if out.Len() != 0 {
+				t.Fatalf("a refused bundle should be described as nothing, got:\n%s", out.String())
+			}
+		})
+	}
+}

--- a/internal/cli/cmd/policy_lint_test.go
+++ b/internal/cli/cmd/policy_lint_test.go
@@ -123,6 +123,51 @@ func TestPolicyLintValidatesBeyondCEL(t *testing.T) {
 	}
 }
 
+// TestPolicyLintAcceptsCompiledBundle pins the round trip documented in the
+// policy framework reference: what `deputy policy bundle` writes must lint
+// clean. A compiled bundle is JSON, and JSON is valid YAML with a "policies"
+// array, so the structured probe has to tell the two shapes apart.
+func TestPolicyLintAcceptsCompiledBundle(t *testing.T) {
+	dir := t.TempDir()
+	authored := filepath.Join(dir, "authored.yaml")
+	if err := os.WriteFile(authored, []byte(`policies:
+  - name: block-left-pad
+    entrypoints: ["scan_vulnerability"]
+    vars:
+      blocked: '["left-pad"]'
+    rules:
+      - when: "pkg.name in blocked"
+        action: deny
+        reason: "blocked package"
+`), 0o600); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+	compiled := filepath.Join(dir, "compiled.json")
+
+	bundleRoot := &cobra.Command{Use: "deputy"}
+	bundleRoot.AddCommand(newPolicyBundleCommand())
+	var bundleOut bytes.Buffer
+	bundleRoot.SetOut(&bundleOut)
+	bundleRoot.SetErr(&bundleOut)
+	bundleRoot.SetArgs([]string{"bundle", "--output", compiled, authored})
+	if err := bundleRoot.Execute(); err != nil {
+		t.Fatalf("policy bundle: %v\n%s", err, bundleOut.String())
+	}
+
+	lintRoot := &cobra.Command{Use: "deputy"}
+	lintRoot.AddCommand(newPolicyLintCommand())
+	var lintOut bytes.Buffer
+	lintRoot.SetOut(&lintOut)
+	lintRoot.SetErr(&lintOut)
+	lintRoot.SetArgs([]string{"lint", compiled})
+	if err := lintRoot.Execute(); err != nil {
+		t.Fatalf("lint of compiled bundle failed: %v\n%s", err, lintOut.String())
+	}
+	if !strings.Contains(lintOut.String(), "OK") {
+		t.Fatalf("expected compiled bundle to lint OK, got:\n%s", lintOut.String())
+	}
+}
+
 // TestPolicyLintAcceptsDeclaredVars pins that --var keeps caller-declared names
 // from being reported as unbound.
 func TestPolicyLintAcceptsDeclaredVars(t *testing.T) {

--- a/internal/cli/cmd/policy_lint_test.go
+++ b/internal/cli/cmd/policy_lint_test.go
@@ -218,6 +218,27 @@ policies:
 `,
 			wantText: "do not support YAML merge keys",
 		},
+		{
+			// The list a root merge key supplies is what makes the document a
+			// bundle, so how well formed that list is cannot decide whether the
+			// construct supplying it is refused.
+			name: "root merge key supplying an empty list",
+			bundle: `defaults: &defaults
+  policies: []
+
+<<: *defaults
+`,
+			wantText: "do not support YAML merge keys",
+		},
+		{
+			name: "root merge key supplying a malformed list",
+			bundle: `defaults: &defaults
+  policies: {}
+
+<<: *defaults
+`,
+			wantText: "do not support YAML merge keys",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/cli/cmd/policy_lint_test.go
+++ b/internal/cli/cmd/policy_lint_test.go
@@ -324,3 +324,50 @@ func TestPolicyLintAcceptsDeclaredVars(t *testing.T) {
 		t.Fatalf("expected OK, got:\n%s", out)
 	}
 }
+
+// TestPolicyLintReportsYAMLSyntaxErrors pins that a bundle whose YAML does not
+// parse is reported as the syntax error it is, naming the offending line, rather
+// than dismissed as an unrecognized format. The editor validates the same
+// document directly and has always named the line, so anything else leaves the
+// CLI and the editor disagreeing about a file the author plainly wrote as a
+// policy.
+func TestPolicyLintReportsYAMLSyntaxErrors(t *testing.T) {
+	cases := []struct {
+		name     string
+		bundle   string
+		wantText []string
+	}{
+		{
+			name:     "an unterminated rules list",
+			bundle:   "policies:\n  - name: broken\n    rules: [\n",
+			wantText: []string{"line 3"},
+		},
+		{
+			name:     "an unterminated policies list",
+			bundle:   "policies: [\n  - name: broken\n",
+			wantText: []string{"line 1"},
+		},
+		{
+			name:     "a value the parser cannot read",
+			bundle:   "policies:\n  - name: broken\n     rules: []\n",
+			wantText: []string{"line 3"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := runPolicyLint(t, tc.bundle)
+			if err == nil {
+				t.Fatalf("expected lint to fail, got:\n%s", out)
+			}
+			combined := out + err.Error()
+			if strings.Contains(combined, "unrecognized policy format") {
+				t.Fatalf("expected a YAML syntax error, got the unknown-format fallback:\n%s", combined)
+			}
+			for _, want := range tc.wantText {
+				if !strings.Contains(combined, want) {
+					t.Fatalf("expected %q in output, got:\n%s", want, combined)
+				}
+			}
+		})
+	}
+}

--- a/internal/cli/cmd/policy_lint_test.go
+++ b/internal/cli/cmd/policy_lint_test.go
@@ -403,6 +403,45 @@ func TestPolicyLintReportsYAMLSyntaxErrors(t *testing.T) {
 	}
 }
 
+// TestPolicyLintReportsErrorsWithNothingToPointAt pins that lint reports a CEL
+// error naming a line that holds no characters instead of crashing on it. The
+// caret is drawn under the offending column, and clamping that column to the end
+// of an empty line put it before the start of the line, which panicked the
+// process on input a user can pipe in: a compiled bundle whose policy carries no
+// source, and a policy whose error falls on a blank line. A malformed policy has
+// to be refused, and a refusal is a message.
+func TestPolicyLintReportsErrorsWithNothingToPointAt(t *testing.T) {
+	const compiledHeader = `{"schemaVersion":"policy.deputy.sh/v1alpha1","generated":"2026-01-01T00:00:00Z","policies":[`
+	cases := []struct {
+		name     string
+		document string
+	}{
+		{
+			name:     "a compiled bundle whose policy has an empty source",
+			document: compiledHeader + `{"name":"empty","source":""}]}`,
+		},
+		{
+			name:     "a compiled bundle whose policy has no source at all",
+			document: compiledHeader + `{"name":"sourceless"}]}`,
+		},
+		{
+			name:     "raw CEL whose error falls on a blank line",
+			document: "true &&\n\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := lintStdin(t, tc.document)
+			if err == nil {
+				t.Fatalf("expected the document to be refused, got output %q", out)
+			}
+			if strings.TrimSpace(err.Error()) == "" {
+				t.Fatalf("expected the refusal to say something, got %q with output %q", err, out)
+			}
+		})
+	}
+}
+
 // lintStdin pipes a policy to `lint -` and returns the output plus whether the
 // run failed, so a document can be linted the way a pipeline supplies it.
 func lintStdin(t *testing.T, document string) (string, error) {

--- a/internal/cli/cmd/policy_lint_test.go
+++ b/internal/cli/cmd/policy_lint_test.go
@@ -1,0 +1,143 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// runPolicyLint writes a bundle to a temp file, lints it, and returns the
+// command output plus whether the run failed.
+func runPolicyLint(t *testing.T, bundle string, args ...string) (string, error) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "policy.yaml")
+	if err := os.WriteFile(path, []byte(bundle), 0o600); err != nil {
+		t.Fatalf("write policy: %v", err)
+	}
+	root := &cobra.Command{Use: "deputy"}
+	root.AddCommand(newPolicyLintCommand())
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs(append([]string{"lint", path}, args...))
+	err := root.Execute()
+	return strings.ReplaceAll(out.String(), path, "POLICY"), err
+}
+
+// TestPolicyLintValidatesBeyondCEL pins that lint fails on the vocabulary and
+// structure mistakes a CEL-only check waves through, and that its output names
+// the file, the policy, and the rule.
+func TestPolicyLintValidatesBeyondCEL(t *testing.T) {
+	cases := []struct {
+		name     string
+		bundle   string
+		wantFail bool
+		wantText []string
+	}{
+		{
+			name: "valid policy reports OK",
+			bundle: `policies:
+  - name: ok
+    entrypoints: ["scan_vulnerability"]
+    rules:
+      - when: "true"
+        action: deny
+        reason: "always"
+`,
+			wantText: []string{"POLICY OK"},
+		},
+		{
+			name: "unknown action fails",
+			bundle: `policies:
+  - name: typo-action
+    rules:
+      - when: "true"
+        action: dney
+        reason: "should deny"
+`,
+			wantFail: true,
+			wantText: []string{"POLICY:5:17", `policy "typo-action" rule[0]`, `invalid action "dney"`, "allow|deny|warn"},
+		},
+		{
+			name: "unknown entrypoint fails",
+			bundle: `policies:
+  - name: typo-entrypoint
+    entrypoints: ["scan_vulnerabilities"]
+    rules:
+      - when: "true"
+        action: deny
+        reason: "x"
+`,
+			wantFail: true,
+			wantText: []string{`policy "typo-entrypoint"`, `invalid entrypoint "scan_vulnerabilities"`},
+		},
+		{
+			name: "unbound variable fails",
+			bundle: `policies:
+  - name: unbound
+    rules:
+      - when: "vulnerabilty.advisory.id != ''"
+        action: deny
+        reason: "x"
+`,
+			wantFail: true,
+			wantText: []string{`policy "unbound" rule[0]`, "undeclared reference"},
+		},
+		{
+			name: "duplicate policy names fail",
+			bundle: `policies:
+  - name: same
+    rules:
+      - when: "true"
+        action: deny
+        reason: "x"
+  - name: same
+    rules:
+      - when: "true"
+        action: warn
+        reason: "y"
+`,
+			wantFail: true,
+			wantText: []string{`duplicate policy name "same"`},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := runPolicyLint(t, tc.bundle)
+			if tc.wantFail && err == nil {
+				t.Fatalf("expected lint to fail, output:\n%s", out)
+			}
+			if !tc.wantFail && err != nil {
+				t.Fatalf("lint failed unexpectedly: %v\n%s", err, out)
+			}
+			for _, want := range tc.wantText {
+				if !strings.Contains(out, want) {
+					t.Fatalf("output missing %q:\n%s", want, out)
+				}
+			}
+		})
+	}
+}
+
+// TestPolicyLintAcceptsDeclaredVars pins that --var keeps caller-declared names
+// from being reported as unbound.
+func TestPolicyLintAcceptsDeclaredVars(t *testing.T) {
+	bundle := `policies:
+  - name: extra
+    rules:
+      - when: "custom_input == 1"
+        action: warn
+        reason: "custom"
+`
+	out, err := runPolicyLint(t, bundle, "--var", "custom_input")
+	if err != nil {
+		t.Fatalf("lint failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "POLICY OK") {
+		t.Fatalf("expected OK, got:\n%s", out)
+	}
+}

--- a/internal/cli/cmd/policy_lint_test.go
+++ b/internal/cli/cmd/policy_lint_test.go
@@ -675,15 +675,91 @@ func TestPolicyLintRefusesMetadataTheEngineRefuses(t *testing.T) {
 					t.Fatalf("output missing %q:\n%s", want, reported)
 				}
 			}
-			// Whatever lint says, the engine has to agree: that equivalence is the
-			// whole point of the check, and it is what the fix restored.
+			// Whatever lint says, loading the document to run it has to agree, which
+			// is the equivalence the check exists for. Loading is asked as one
+			// question, since the refusal may come from either half of it: a
+			// compiled bundle's metadata is refused as it is loaded, and a source
+			// handed straight to the engine is refused there.
 			sources, loadErr := policy.LoadSourcesFromBytes([]byte(tc.document), "b.json")
-			if loadErr != nil {
-				t.Fatalf("LoadSourcesFromBytes: %v", loadErr)
+			runErr := loadErr
+			if loadErr == nil {
+				_, runErr = policy.NewEngine(sources)
 			}
-			_, engineErr := policy.NewEngine(sources)
-			if (err == nil) != (engineErr == nil) {
-				t.Fatalf("lint and the engine disagree: lint=%v, NewEngine=%v", err, engineErr)
+			if (err == nil) != (runErr == nil) {
+				t.Fatalf("lint and loading it to run disagree: lint=%v, load+NewEngine=%v", err, runErr)
+			}
+		})
+	}
+}
+
+// TestPolicyBundleRefusesMetadataTheEngineRefuses pins that the writer refuses what
+// the engine refuses. `deputy policy bundle` given a compiled bundle repackages the
+// sources it holds, and it compiled the CEL and stopped, so it rewrote a policy
+// declaring `advsiory` into a fresh artifact that would not load. A writer that
+// produces something Deputy cannot run is the same defect as a lint that passes it,
+// reached from the other side.
+func TestPolicyBundleRefusesMetadataTheEngineRefuses(t *testing.T) {
+	cases := []struct {
+		name     string
+		source   string
+		wantFail bool
+		wantText string
+	}{
+		{
+			name:     "a misspelled mode",
+			source:   "//! policy.mode = advsiory\n[]",
+			wantFail: true,
+			wantText: `invalid mode "advsiory"`,
+		},
+		{
+			name:     "a misspelled entrypoint",
+			source:   `//! policy.entrypoints = "scan_vulnerabilities"` + "\n[]",
+			wantFail: true,
+			wantText: `invalid entrypoint "scan_vulnerabilities"`,
+		},
+		{
+			name:   "metadata Deputy recognizes",
+			source: `//! policy.mode = "advisory"` + "\n[]",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := json.Marshal(tc.source)
+			if err != nil {
+				t.Fatalf("marshal source: %v", err)
+			}
+			dir := t.TempDir()
+			in := filepath.Join(dir, "in.json")
+			document := `{"schemaVersion":"policy.deputy.sh/v1alpha1","policies":[{"name":"p","source":` + string(body) + `}]}`
+			if err := os.WriteFile(in, []byte(document), 0o600); err != nil {
+				t.Fatalf("write bundle: %v", err)
+			}
+			out := filepath.Join(dir, "out.json")
+
+			root := &cobra.Command{Use: "deputy"}
+			root.AddCommand(newPolicyBundleCommand())
+			var stdout bytes.Buffer
+			root.SetOut(&stdout)
+			root.SetErr(&stdout)
+			root.SetArgs([]string{"bundle", "--output", out, in})
+			err = root.Execute()
+
+			if !tc.wantFail {
+				if err != nil {
+					t.Fatalf("bundling a policy Deputy accepts failed: %v\n%s", err, stdout.String())
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected bundling to be refused, output:\n%s", stdout.String())
+			}
+			if !strings.Contains(err.Error(), tc.wantText) {
+				t.Fatalf("error %q should name the offending value as %q", err, tc.wantText)
+			}
+			// A refused bundle must not leave an artifact behind: a file that would
+			// not load is worse on disk than absent, since the next reader trusts it.
+			if _, statErr := os.Stat(out); statErr == nil {
+				t.Fatalf("a refused bundle still wrote %s", out)
 			}
 		})
 	}

--- a/internal/cli/cmd/policy_lint_test.go
+++ b/internal/cli/cmd/policy_lint_test.go
@@ -536,6 +536,18 @@ func TestPolicyLintAgreesAcrossStdinAndPath(t *testing.T) {
   - name: ruleless
 `,
 		},
+		{
+			// A flow mapping keying the bundle key is the one document that is
+			// both a bundle and a compilable CEL expression. Arrival cannot break
+			// the tie: reading it as raw CEL because it was piped is how the same
+			// bytes used to pass on stdin and fail as a file.
+			name:     "a flow mapping that is also a CEL map literal",
+			document: `{"policies": []}`,
+		},
+		{
+			name:     "a flow mapping keying the bundle key beside an action",
+			document: `{"policies": [], "action": "deny"}`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/cli/cmd/policy_lint_test.go
+++ b/internal/cli/cmd/policy_lint_test.go
@@ -352,6 +352,16 @@ func TestPolicyLintReportsYAMLSyntaxErrors(t *testing.T) {
 			bundle:   "policies:\n  - name: broken\n     rules: []\n",
 			wantText: []string{"line 3"},
 		},
+		{
+			name:     "a double-quoted policies key above an unterminated rules list",
+			bundle:   "\"policies\":\n  - name: broken\n    rules: [\n",
+			wantText: []string{"line 3"},
+		},
+		{
+			name:     "a single-quoted policies key above an unterminated rules list",
+			bundle:   "'policies':\n  - name: broken\n    rules: [\n",
+			wantText: []string{"line 3"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/cli/cmd/policy_lint_test.go
+++ b/internal/cli/cmd/policy_lint_test.go
@@ -2,12 +2,15 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
+
+	"github.com/temporalio/deputy/internal/policy"
 )
 
 // runPolicyLint writes a bundle to a temp file, lints it, and returns the
@@ -601,6 +604,86 @@ func TestPolicyLintAgreesAcrossStdinAndPath(t *testing.T) {
 			gotBody := strings.ReplaceAll(stdinOut, "stdin", "")
 			if wantBody != gotBody {
 				t.Fatalf("reports differ:\n path: %q\nstdin: %q", wantBody, gotBody)
+			}
+		})
+	}
+}
+
+// TestPolicyLintRefusesMetadataTheEngineRefuses pins that lint asks a compiled
+// bundle, and a raw source, the metadata questions loading one to run it asks. A
+// compiled bundle holds its policies as compiled CEL with their `//!` metadata in
+// comments, so compiling the CEL was the only question lint put to one: a bundle
+// declaring `advsiory` reported OK and then failed to load, and a misspelled mode is
+// exactly the mistake lint exists to catch before production does. A lint that
+// passes an artifact the loader rejects is worse than no lint.
+//
+// The valid spellings are here too, so the refusal cannot pass by rejecting
+// everything, and `deputy policy bundle` output still has to lint clean (see
+// TestPolicyLintAcceptsCompiledBundle).
+func TestPolicyLintRefusesMetadataTheEngineRefuses(t *testing.T) {
+	compiled := func(source string) string {
+		body, err := json.Marshal(source)
+		if err != nil {
+			t.Fatalf("marshal source: %v", err)
+		}
+		return `{"schemaVersion":"policy.deputy.sh/v1alpha1","policies":[{"name":"p","source":` + string(body) + `}]}`
+	}
+	cases := []struct {
+		name     string
+		document string
+		wantFail bool
+		wantText []string
+	}{
+		{
+			name:     "a compiled bundle whose mode is misspelled",
+			document: compiled("//! policy.mode = advsiory\n[]"),
+			wantFail: true,
+			wantText: []string{`invalid mode "advsiory"`, "advisory|enforce"},
+		},
+		{
+			name:     "a compiled bundle whose entrypoint is misspelled",
+			document: compiled(`//! policy.entrypoints = "scan_vulnerabilities"` + "\n[]"),
+			wantFail: true,
+			wantText: []string{`invalid entrypoint "scan_vulnerabilities"`},
+		},
+		{
+			name:     "a compiled bundle whose metadata is right",
+			document: compiled(`//! policy.mode = "advisory"` + "\n" + `//! policy.entrypoints = "scan_vulnerability"` + "\n[]"),
+			wantText: []string{"OK"},
+		},
+		{
+			name:     "a compiled bundle declaring no metadata",
+			document: compiled("[]"),
+			wantText: []string{"OK"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := runPolicyLint(t, tc.document)
+			if tc.wantFail && err == nil {
+				t.Fatalf("expected lint to refuse what the engine refuses, got:\n%s", out)
+			}
+			if !tc.wantFail && err != nil {
+				t.Fatalf("lint failed unexpectedly: %v\n%s", err, out)
+			}
+			reported := out
+			if err != nil {
+				reported += err.Error()
+			}
+			for _, want := range tc.wantText {
+				if !strings.Contains(reported, want) {
+					t.Fatalf("output missing %q:\n%s", want, reported)
+				}
+			}
+			// Whatever lint says, the engine has to agree: that equivalence is the
+			// whole point of the check, and it is what the fix restored.
+			sources, loadErr := policy.LoadSourcesFromBytes([]byte(tc.document), "b.json")
+			if loadErr != nil {
+				t.Fatalf("LoadSourcesFromBytes: %v", loadErr)
+			}
+			_, engineErr := policy.NewEngine(sources)
+			if (err == nil) != (engineErr == nil) {
+				t.Fatalf("lint and the engine disagree: lint=%v, NewEngine=%v", err, engineErr)
 			}
 		})
 	}

--- a/internal/cli/cmd/policy_lint_test.go
+++ b/internal/cli/cmd/policy_lint_test.go
@@ -105,6 +105,24 @@ func TestPolicyLintValidatesBeyondCEL(t *testing.T) {
 			},
 		},
 		{
+			name: "a mistyped field still yields located errors",
+			bundle: `policies:
+  - name: typed-error
+    mode: enfroce
+    rules:
+      - when: "true"
+        action: dney
+        reason: "x"
+        status: "four-oh-three"
+`,
+			wantFail: true,
+			wantText: []string{
+				`policy "typed-error": invalid mode "enfroce"`,
+				`policy "typed-error" rule[0]: invalid action "dney"`,
+				"line 8: cannot unmarshal",
+			},
+		},
+		{
 			name: "a missing when does not hide a bad action",
 			bundle: `policies:
   - name: both-defects

--- a/internal/cli/cmd/policy_lint_test.go
+++ b/internal/cli/cmd/policy_lint_test.go
@@ -105,6 +105,21 @@ func TestPolicyLintValidatesBeyondCEL(t *testing.T) {
 			},
 		},
 		{
+			name: "a missing when does not hide a bad action",
+			bundle: `policies:
+  - name: both-defects
+    rules:
+      - action: dney
+        reason: "no when and a bad action"
+`,
+			wantFail: true,
+			wantText: []string{
+				"rule missing 'when' expression",
+				`invalid action "dney"`,
+				"2 policy problem(s) found",
+			},
+		},
+		{
 			name: "duplicate policy names fail",
 			bundle: `policies:
   - name: same

--- a/internal/policy/actions.go
+++ b/internal/policy/actions.go
@@ -1,19 +1,26 @@
 package policy
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
 	"math"
+	"slices"
 	"strings"
 
 	"github.com/google/cel-go/common/types/ref"
+	policyv1 "github.com/temporalio/deputy/gen/deputy/policy/v1"
 	"github.com/temporalio/deputy/internal/collections"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
-// Action type constants represent the standard policy decision types.
-// These are case-insensitive when compared (use ActionTypeIs for comparison).
+// Action type constants are the canonical spelling of each
+// deputy.policy.v1.ActionType value, which is what policies write and what the
+// engine switches on. They are constants because callers need them at compile
+// time; TestActionTypesMatchProtoDescriptor pins them to the enum so a rename in
+// the proto cannot leave them behind.
 const (
 	// ActionDeny blocks the operation and returns an error to the caller.
 	ActionDeny = "deny"
@@ -25,6 +32,38 @@ const (
 	ActionAllow = "allow"
 )
 
+// actionTypePrefix is the generated enum's value prefix. Policies write the bare
+// action ("deny"), not the proto spelling.
+const actionTypePrefix = "ACTION_TYPE_"
+
+// actionTypes is the action vocabulary derived from the generated ActionType
+// descriptor.
+var actionTypes = newActionVocabulary()
+
+// newActionVocabulary reads the deputy.policy.v1.ActionType descriptor once at
+// startup and returns the actions a policy may write, lowercased and ordered by
+// enum number so messages read the same way every time. Deriving the list means
+// the proto stays the single source of truth for the vocabulary. The zero value
+// is skipped: UNSPECIFIED means no action was set, which is not something an
+// author can ask for.
+func newActionVocabulary() []string {
+	values := policyv1.ActionType(0).Descriptor().Values()
+	byNumber := make([]protoreflect.EnumValueDescriptor, 0, values.Len())
+	for i := range values.Len() {
+		if value := values.Get(i); value.Number() != 0 {
+			byNumber = append(byNumber, value)
+		}
+	}
+	slices.SortFunc(byNumber, func(a, b protoreflect.EnumValueDescriptor) int {
+		return cmp.Compare(a.Number(), b.Number())
+	})
+	names := make([]string, 0, len(byNumber))
+	for _, value := range byNumber {
+		names = append(names, strings.ToLower(strings.TrimPrefix(string(value.Name()), actionTypePrefix)))
+	}
+	return names
+}
+
 // ActionTypeIs returns true if the action type matches the expected type (case-insensitive).
 func ActionTypeIs(actionType, expected string) bool {
 	return strings.EqualFold(actionType, expected)
@@ -34,7 +73,7 @@ func ActionTypeIs(actionType, expected string) bool {
 // used by error messages and editor surfaces. The slice is freshly allocated so
 // callers cannot mutate the vocabulary.
 func ActionTypes() []string {
-	return []string{ActionAllow, ActionDeny, ActionWarn}
+	return slices.Clone(actionTypes)
 }
 
 // NormalizeActionType folds an authored action value into its canonical form by
@@ -54,12 +93,10 @@ func NormalizeActionType(actionType string) string {
 // into a silently permissive rule.
 func ValidateActionType(actionType string) (string, error) {
 	normalized := NormalizeActionType(actionType)
-	switch normalized {
-	case ActionAllow, ActionDeny, ActionWarn:
+	if slices.Contains(actionTypes, normalized) {
 		return normalized, nil
-	default:
-		return "", fmt.Errorf("invalid action %q (expected %s)", actionType, strings.Join(ActionTypes(), "|"))
 	}
+	return "", fmt.Errorf("invalid action %q (expected %s)", actionType, strings.Join(actionTypes, "|"))
 }
 
 // Action represents a normalized policy decision emitted by a CEL program.

--- a/internal/policy/actions.go
+++ b/internal/policy/actions.go
@@ -30,6 +30,38 @@ func ActionTypeIs(actionType, expected string) bool {
 	return strings.EqualFold(actionType, expected)
 }
 
+// ActionTypes returns the action vocabulary a policy rule may emit, in the order
+// used by error messages and editor surfaces. The slice is freshly allocated so
+// callers cannot mutate the vocabulary.
+func ActionTypes() []string {
+	return []string{ActionAllow, ActionDeny, ActionWarn}
+}
+
+// NormalizeActionType folds an authored action value into its canonical form by
+// trimming surrounding whitespace and lowercasing it. "DENY", "Deny" and " deny "
+// all mean deny: evaluation already compares action types case-insensitively
+// (see ActionTypeIs), so parsing accepts exactly what the runtime accepts and
+// everything downstream sees the canonical lowercase spelling. This mirrors how
+// a policy's mode field is normalized before validation.
+func NormalizeActionType(actionType string) string {
+	return strings.ToLower(strings.TrimSpace(actionType))
+}
+
+// ValidateActionType returns the canonical form of an authored action value, or
+// an error naming the offending value and the valid vocabulary. A typo such as
+// "dney" is otherwise accepted verbatim and yields a rule that can never deny
+// anything, so an unknown action must fail at load time instead of degrading
+// into a silently permissive rule.
+func ValidateActionType(actionType string) (string, error) {
+	normalized := NormalizeActionType(actionType)
+	switch normalized {
+	case ActionAllow, ActionDeny, ActionWarn:
+		return normalized, nil
+	default:
+		return "", fmt.Errorf("invalid action %q (expected %s)", actionType, strings.Join(ActionTypes(), "|"))
+	}
+}
+
 // Action represents a normalized policy decision emitted by a CEL program.
 type Action struct {
 	Source      string            // Source is the name of the policy that generated this action.

--- a/internal/policy/actions_test.go
+++ b/internal/policy/actions_test.go
@@ -1,0 +1,102 @@
+package policy
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	policyv1 "github.com/temporalio/deputy/gen/deputy/policy/v1"
+)
+
+// TestActionTypesMatchProtoDescriptor pins the authored action vocabulary to
+// deputy.policy.v1.ActionType: every non-zero enum value must be accepted, in
+// enum-number order, and the exported constants must spell those values. A
+// rename in the proto fails here instead of leaving policy loading rejecting an
+// action the API considers valid.
+func TestActionTypesMatchProtoDescriptor(t *testing.T) {
+	values := policyv1.ActionType(0).Descriptor().Values()
+	var want []string
+	for i := range values.Len() {
+		value := values.Get(i)
+		if value.Number() == 0 {
+			continue
+		}
+		want = append(want, strings.ToLower(strings.TrimPrefix(string(value.Name()), actionTypePrefix)))
+	}
+	if got := ActionTypes(); !slices.Equal(got, want) {
+		t.Fatalf("ActionTypes() = %v, want the enum values %v", got, want)
+	}
+	for _, name := range want {
+		t.Run(name, func(t *testing.T) {
+			normalized, err := ValidateActionType(name)
+			if err != nil {
+				t.Fatalf("ValidateActionType rejects declared action %q: %v", name, err)
+			}
+			if normalized != name {
+				t.Fatalf("ValidateActionType(%q) = %q, want the canonical spelling", name, normalized)
+			}
+		})
+	}
+	constants := map[string]string{
+		strings.ToLower(strings.TrimPrefix(policyv1.ActionType_ACTION_TYPE_ALLOW.String(), actionTypePrefix)): ActionAllow,
+		strings.ToLower(strings.TrimPrefix(policyv1.ActionType_ACTION_TYPE_DENY.String(), actionTypePrefix)):  ActionDeny,
+		strings.ToLower(strings.TrimPrefix(policyv1.ActionType_ACTION_TYPE_WARN.String(), actionTypePrefix)):  ActionWarn,
+	}
+	for enumName, constant := range constants {
+		if enumName != constant {
+			t.Fatalf("constant %q does not spell its enum value %q", constant, enumName)
+		}
+	}
+}
+
+// TestActionVocabularyIsImplemented pins the vocabulary against what the engine
+// actually does with an action. Deriving the list from the proto keeps it from
+// drifting, but an action the engine does not implement would be accepted by
+// lint and then quietly do nothing at evaluation time, which is the failure this
+// validation exists to prevent. Wire a new action up, then widen this list.
+func TestActionVocabularyIsImplemented(t *testing.T) {
+	implemented := []string{ActionAllow, ActionDeny, ActionWarn}
+	if got := ActionTypes(); !slices.Equal(got, implemented) {
+		t.Fatalf("action vocabulary is %v but the engine implements %v: implement the new action before accepting it", got, implemented)
+	}
+}
+
+// TestValidateActionType covers the vocabulary boundaries: the zero enum value
+// is not an authored action, and casing and padding are normalized rather than
+// rejected.
+func TestValidateActionType(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{name: "deny", input: "deny", want: ActionDeny},
+		{name: "uppercase", input: "WARN", want: ActionWarn},
+		{name: "padded", input: "  allow\t", want: ActionAllow},
+		{name: "unspecified is not authorable", input: "unspecified", wantErr: true},
+		{name: "proto spelling is not authorable", input: "ACTION_TYPE_DENY", wantErr: true},
+		{name: "typo", input: "dney", wantErr: true},
+		{name: "empty", input: "", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ValidateActionType(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got %q", tc.input, got)
+				}
+				if !strings.Contains(err.Error(), strings.Join(ActionTypes(), "|")) {
+					t.Fatalf("error %q should quote the vocabulary", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ValidateActionType(%q): %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Fatalf("ValidateActionType(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/policy/bundle_structured.go
+++ b/internal/policy/bundle_structured.go
@@ -57,8 +57,19 @@ func (kv varKV) exprString() string {
 	return string(b)
 }
 
+// normalizeVarName trims surrounding whitespace from a variable name, so that
+// "blocked" and " blocked " are the one name they read as. A var name becomes a
+// CEL identifier, and CEL reads the padded spelling as the bare one, so the two
+// bind the same variable and the second shadows the first. Validation reports
+// that as a duplicate, so every reader has to fold them together or a bundle the
+// linter rejects would still compile.
+func normalizeVarName(name string) string {
+	return strings.TrimSpace(name)
+}
+
 // UnmarshalYAML implements the yaml.Unmarshaler interface to decode a mapping
-// into an ordered list of key-value pairs.
+// into an ordered list of key-value pairs. Variable names are normalized as they
+// are read, so every reader of a bundle sees the name CEL will bind.
 func (o *orderedVars) UnmarshalYAML(node *yaml.Node) error {
 	if node == nil {
 		return nil
@@ -77,6 +88,7 @@ func (o *orderedVars) UnmarshalYAML(node *yaml.Node) error {
 		if err := k.Decode(&kv.Name); err != nil {
 			return err
 		}
+		kv.Name = normalizeVarName(kv.Name)
 		// Detect string vs other scalars/collections
 		if v.Kind == yaml.ScalarNode && v.Tag == "!!str" {
 			if err := v.Decode(&kv.Value); err != nil {
@@ -111,7 +123,7 @@ func (o *orderedVars) UnmarshalJSON(data []byte) error {
 	for _, k := range keys {
 		val := m[k]
 		_, isString := val.(string)
-		out = append(out, varKV{Name: k, Value: val, IsString: isString})
+		out = append(out, varKV{Name: normalizeVarName(k), Value: val, IsString: isString})
 	}
 	*o = out
 	return nil

--- a/internal/policy/bundle_structured.go
+++ b/internal/policy/bundle_structured.go
@@ -183,9 +183,10 @@ func tryParseStructuredBundle(data []byte, path string) ([]Source, bool, error) 
 	if IsCompiledBundle(data) {
 		return nil, false, nil
 	}
-	// The decoder would resolve anchors silently, so refuse them here: loading
-	// and validating a bundle must agree on what the format accepts.
-	if err := bundleAnchorError(data, path); err != nil {
+	// The decoder would resolve anchors, and read a tagged scalar as something
+	// other than its text, without saying so; refuse both here, since loading and
+	// validating a bundle must agree on what the format accepts.
+	if err := bundleRefusalError(data, path); err != nil {
 		return nil, false, err
 	}
 	return decodeStructuredBundle(data, path)

--- a/internal/policy/bundle_structured.go
+++ b/internal/policy/bundle_structured.go
@@ -130,43 +130,63 @@ func (o *orderedVars) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// bindable splits a policy's vars into the ones it can bind, in author order,
-// and an error for every name it cannot. A name binds nothing when it is empty,
-// and a repeated name binds once: the later declaration shadows the earlier, so
-// only one of the two can survive and the surviving one is the declaration the
-// expansion would bind.
+// varBinding is what a policy can do with one of its vars: the var as authored,
+// the scope its expression is evaluated in, and the reason its name binds nothing
+// when it binds nothing.
+type varBinding struct {
+	kv    varKV       // kv is the var as the document declares it.
+	scope orderedVars // scope is the vars bound above it, the names its expression may read.
+	err   error       // err is why the name binds nothing, nil when it binds.
+}
+
+// bindings pairs every var with the scope its expression sees and with the reason
+// its name binds nothing, in author order. A name binds nothing when it is empty,
+// and a repeated name binds once: the first declaration wins, because every
+// expression below it, the repeat's own included, is written against the name
+// already in scope. Reporting the repeat rather than the declaration it repeats is
+// also how the node walk names that defect, so the two readers point at one line.
 //
-// Splitting rather than refusing at the first bad name is what lets validation
-// report every name defect and still compile the vars beneath them. A reader that
-// runs the policy must refuse it instead (see wrapVars): a var the author named
-// twice is a var Deputy cannot say which value it holds, and a dropped
-// declaration is not something to run.
-// Names are compared normalized, as CEL binds them and as the node walk reports
-// them, so " blocked " and "blocked" are the one name they read as and the walk's
-// wording of each defect is the wording reported here.
-func (o orderedVars) bindable() (orderedVars, []error) {
-	binds := make(map[string]int, len(o))
-	for i, kv := range o {
-		if name := normalizeVarName(kv.Name); name != "" {
-			binds[name] = i
-		}
-	}
-	var (
-		bound      orderedVars
-		unbindable []error
-	)
-	for i, kv := range o {
+// Names are compared normalized, as CEL binds them, so " blocked " and "blocked"
+// are the one name they read as.
+//
+// Carrying the scopes is what lets validation compile the expression of a var
+// whose name it has already refused: the expression is wrong or right on its own,
+// in the scope it would have been evaluated in, whatever the name above it says.
+// Compiling it in any other scope would invent a diagnostic, since a name the
+// document declares below cannot be read from above. A reader that runs the policy
+// refuses it at the first unbindable name instead (see wrapVars): a var the author
+// named twice is a var Deputy cannot say which value it holds.
+func (o orderedVars) bindings() []varBinding {
+	out := make([]varBinding, 0, len(o))
+	var bound orderedVars
+	seen := make(map[string]struct{}, len(o))
+	for _, kv := range o {
+		binding := varBinding{kv: kv, scope: slices.Clone(bound)}
 		name := normalizeVarName(kv.Name)
+		_, repeated := seen[name]
 		switch {
 		case name == "":
-			unbindable = append(unbindable, errors.New(emptyVarNameMessage))
-		case binds[name] != i:
-			unbindable = append(unbindable, fmt.Errorf(duplicateVarNameFormat, name))
+			binding.err = errors.New(emptyVarNameMessage)
+		case repeated:
+			binding.err = fmt.Errorf(duplicateVarNameFormat, name)
 		default:
+			seen[name] = struct{}{}
 			bound = append(bound, kv)
 		}
+		out = append(out, binding)
 	}
-	return bound, unbindable
+	return out
+}
+
+// nestVars wraps a CEL body in one comprehension per var, in reverse author order
+// so an earlier var is in scope for a later one. It does no checking: a caller
+// that runs a policy validates the names first (wrapVars), and validation uses it
+// to compile the expression of a var whose name it has already reported.
+func nestVars(vars orderedVars, body string) string {
+	for _, v := range slices.Backward(vars) {
+		body = fmt.Sprintf("([%s]).map(%s, %s)[0]", v.exprString(), v.Name, body)
+	}
+	return body
 }
 
 // Names returns the ordered variable names.
@@ -414,19 +434,18 @@ func (p structuredPolicy) toCELSource() (string, error) {
 // defect in, which the whole-policy expansion cannot do.
 //
 // A name the policy cannot bind refuses the whole policy, which is what a reader
-// that runs it must do; validation reports every one of them and compiles what is
-// left (see bindable).
+// that runs it must do; validation reports every one of them and compiles the rest
+// (see bindings).
 func (p structuredPolicy) wrapVars(body string) (string, error) {
 	if len(p.Vars) == 0 {
 		return body, nil
 	}
-	if _, unbindable := p.Vars.bindable(); len(unbindable) > 0 {
-		return "", unbindable[0]
+	for _, binding := range p.Vars.bindings() {
+		if binding.err != nil {
+			return "", binding.err
+		}
 	}
-	for _, v := range slices.Backward(p.Vars) {
-		body = fmt.Sprintf("([%s]).map(%s, %s)[0]", v.exprString(), v.Name, body)
-	}
-	return body, nil
+	return nestVars(p.Vars, body), nil
 }
 
 // toRuleExpr converts a structured rule into a CEL expression string.

--- a/internal/policy/bundle_structured.go
+++ b/internal/policy/bundle_structured.go
@@ -399,29 +399,56 @@ func (p structuredPolicy) toCELSource() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	metadata := []string{}
-	if p.Name != "" {
-		metadata = append(metadata, fmt.Sprintf("//! policy.name = \"%s\"", escapeComment(p.Name)))
+	var metadata metadataComments
+	metadata.set("name", p.Name)
+	metadata.set("description", p.Description)
+	metadata.setList("entrypoints", p.Entrypoints)
+	metadata.setList("commands", p.Commands)
+	if p.Mode != ModeEnforce {
+		metadata.set("mode", p.Mode)
 	}
-	if p.Description != "" {
-		metadata = append(metadata, fmt.Sprintf("//! policy.description = \"%s\"", escapeComment(p.Description)))
-	}
-	if len(p.Entrypoints) > 0 {
-		metadata = append(metadata, fmt.Sprintf("//! policy.entrypoints = \"%s\"", strings.Join(p.Entrypoints, ",")))
-	}
-	if len(p.Commands) > 0 {
-		metadata = append(metadata, fmt.Sprintf("//! policy.commands = \"%s\"", strings.Join(p.Commands, ",")))
-	}
-	if p.Mode != "" && p.Mode != "enforce" {
-		metadata = append(metadata, fmt.Sprintf("//! policy.mode = \"%s\"", p.Mode))
-	}
-	if len(p.Ecosystems) > 0 {
-		metadata = append(metadata, fmt.Sprintf("//! policy.ecosystems = \"%s\"", strings.Join(p.Ecosystems, ",")))
-	}
+	metadata.setList("ecosystems", p.Ecosystems)
 	if len(metadata) == 0 {
 		return body, nil
 	}
 	return strings.Join(metadata, "\n") + "\n" + body, nil
+}
+
+// metadataComments accumulates the `//! policy.<key> = "<value>"` comments a
+// generated policy carries, and is the only thing that writes one. Going through
+// it is what keeps a value the author wrote from being read back as a directive.
+//
+// Escaping per field is what let one through: name and description escaped, and
+// the four fields added beside them did not, so an ecosystems entry of
+// `npm\n//! policy.mode = advisory\n//` generated a second metadata line that
+// parsePolicyMetadata read as a mode, while the trailing `//` commented out the
+// closing quote of the line it broke out of. The bundle read as deny, loaded as
+// advisory, and linted and compiled clean. That is the same defect as an
+// interpolated ecosystem guard, the text a reviewer reads not being the policy
+// that runs, one layer over: escaped where the value becomes CEL and not where it
+// becomes metadata.
+//
+// A key is Deputy's own text and a value is the author's, so only the value is
+// escaped; passing an author-supplied key would be a different mistake, and no
+// caller has one to pass.
+type metadataComments []string
+
+// set records one metadata comment. An empty value is dropped, since a reader
+// acts on nothing it says, and the value is escaped so it can only ever be data
+// on the line it is written on.
+func (m *metadataComments) set(key, value string) {
+	if value == "" {
+		return
+	}
+	*m = append(*m, fmt.Sprintf("//! policy.%s = \"%s\"", key, escapeComment(value)))
+}
+
+// setList records one metadata comment holding a list, joined with commas as
+// parsePolicyMetadata splits them. A value containing a comma is read back as two
+// entries, which loses what the author wrote but cannot say anything they did not:
+// the escaping keeps the whole list on the one line the key introduces.
+func (m *metadataComments) setList(key string, values []string) {
+	m.set(key, strings.Join(values, ","))
 }
 
 // wrapVars binds a policy's variables around a CEL body, one comprehension per
@@ -513,9 +540,14 @@ func celStringLiteral(value string) string {
 	return strconv.Quote(value)
 }
 
-// escapeComment escapes characters in a string to make it safe for inclusion
-// in a generated CEL comment. Multi-line strings (from YAML | or >) must have
-// newlines escaped to avoid breaking the single-line comment format.
+// escapeComment escapes an authored value so it stays on the one line of the
+// generated `//!` comment that carries it. A newline would end the comment for
+// both readers of it, CEL's lexer and parsePolicyMetadata, so a value holding one
+// could open a metadata line of its own; a quote would end the value early, and a
+// backslash would make either escape ambiguous.
+//
+// It is reached only through metadataComments, which is what makes the escaping a
+// property of writing a metadata line rather than of remembering to call this.
 func escapeComment(s string) string {
 	s = strings.ReplaceAll(s, "\\", "\\\\")
 	s = strings.ReplaceAll(s, "\"", "\\\"")

--- a/internal/policy/bundle_structured.go
+++ b/internal/policy/bundle_structured.go
@@ -130,6 +130,45 @@ func (o *orderedVars) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// bindable splits a policy's vars into the ones it can bind, in author order,
+// and an error for every name it cannot. A name binds nothing when it is empty,
+// and a repeated name binds once: the later declaration shadows the earlier, so
+// only one of the two can survive and the surviving one is the declaration the
+// expansion would bind.
+//
+// Splitting rather than refusing at the first bad name is what lets validation
+// report every name defect and still compile the vars beneath them. A reader that
+// runs the policy must refuse it instead (see wrapVars): a var the author named
+// twice is a var Deputy cannot say which value it holds, and a dropped
+// declaration is not something to run.
+// Names are compared normalized, as CEL binds them and as the node walk reports
+// them, so " blocked " and "blocked" are the one name they read as and the walk's
+// wording of each defect is the wording reported here.
+func (o orderedVars) bindable() (orderedVars, []error) {
+	binds := make(map[string]int, len(o))
+	for i, kv := range o {
+		if name := normalizeVarName(kv.Name); name != "" {
+			binds[name] = i
+		}
+	}
+	var (
+		bound      orderedVars
+		unbindable []error
+	)
+	for i, kv := range o {
+		name := normalizeVarName(kv.Name)
+		switch {
+		case name == "":
+			unbindable = append(unbindable, errors.New(emptyVarNameMessage))
+		case binds[name] != i:
+			unbindable = append(unbindable, fmt.Errorf(duplicateVarNameFormat, name))
+		default:
+			bound = append(bound, kv)
+		}
+	}
+	return bound, unbindable
+}
+
 // Names returns the ordered variable names.
 func (o orderedVars) Names() []string {
 	if len(o) == 0 {
@@ -172,6 +211,15 @@ func (b *structuredBundle) normalizeNames() {
 // restatement of it; one constant is what keeps the two readers from drifting
 // into reporting one mistake twice.
 const policyNeedsRuleMessage = "policy must contain at least one rule"
+
+// Messages for a vars mapping a policy cannot bind. The node walk locates both
+// defects from the document, in its own words, and validation folds the loader's
+// restatement of them by matching the wording, so one spelling of each is what
+// keeps a single mistake from being reported twice.
+const (
+	emptyVarNameMessage    = "vars must have non-empty names"
+	duplicateVarNameFormat = "duplicate var name %q"
+)
 
 // tryParseStructuredBundle attempts to parse a byte slice as a structured YAML bundle.
 // It returns the generated CEL sources if successful, or a boolean indicating
@@ -364,19 +412,16 @@ func (p structuredPolicy) toCELSource() (string, error) {
 // wrong or right on their own: validation wraps an empty body with it to report
 // vars that do not compile in a policy whose rules the walk has already found a
 // defect in, which the whole-policy expansion cannot do.
+//
+// A name the policy cannot bind refuses the whole policy, which is what a reader
+// that runs it must do; validation reports every one of them and compiles what is
+// left (see bindable).
 func (p structuredPolicy) wrapVars(body string) (string, error) {
 	if len(p.Vars) == 0 {
 		return body, nil
 	}
-	seen := map[string]struct{}{}
-	for _, kv := range p.Vars {
-		if strings.TrimSpace(kv.Name) == "" {
-			return "", fmt.Errorf("vars must have non-empty names")
-		}
-		if _, ok := seen[kv.Name]; ok {
-			return "", fmt.Errorf("duplicate var name %q", kv.Name)
-		}
-		seen[kv.Name] = struct{}{}
+	if _, unbindable := p.Vars.bindable(); len(unbindable) > 0 {
+		return "", unbindable[0]
 	}
 	for _, v := range slices.Backward(p.Vars) {
 		body = fmt.Sprintf("([%s]).map(%s, %s)[0]", v.exprString(), v.Name, body)

--- a/internal/policy/bundle_structured.go
+++ b/internal/policy/bundle_structured.go
@@ -145,6 +145,9 @@ type structuredRule struct {
 // It returns the generated CEL sources if successful, or a boolean indicating
 // whether the input looked like a bundle but failed validation.
 func tryParseStructuredBundle(data []byte, path string) ([]Source, bool, error) {
+	if IsCompiledBundle(data) {
+		return nil, false, nil
+	}
 	var bundle structuredBundle
 	if err := yaml.Unmarshal(data, &bundle); err != nil {
 		return nil, false, nil
@@ -180,8 +183,14 @@ func tryParseStructuredBundle(data []byte, path string) ([]Source, bool, error) 
 	return sources, true, nil
 }
 
-// TryParseStructuredBundleBytes parses data into a structuredBundle and returns it plus a parsed flag.
+// TryParseStructuredBundleBytes parses data into a structuredBundle and returns
+// it plus a parsed flag. A bundle already compiled by `deputy policy bundle` is
+// reported as not parsed, because its policies hold compiled CEL rather than
+// authored rules and callers must handle it as a compiled bundle instead.
 func TryParseStructuredBundleBytes(data []byte) (*structuredBundle, bool, error) {
+	if IsCompiledBundle(data) {
+		return nil, false, nil
+	}
 	var bundle structuredBundle
 	if err := yaml.Unmarshal(data, &bundle); err != nil {
 		return nil, false, nil

--- a/internal/policy/bundle_structured.go
+++ b/internal/policy/bundle_structured.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strconv"
 	"strings"
 
 	yaml "gopkg.in/yaml.v3"
@@ -458,7 +459,7 @@ func (r structuredRule) toRuleExpr(ecosystems []string) (string, error) {
 	if len(ecosystems) > 0 {
 		quoted := make([]string, len(ecosystems))
 		for i, eco := range ecosystems {
-			quoted[i] = fmt.Sprintf("\"%s\"", eco)
+			quoted[i] = celStringLiteral(eco)
 		}
 		guard := fmt.Sprintf("(request.?ecosystem.orValue(\"\") in [%s]) || (pkg.ecosystem in [%s])", strings.Join(quoted, ","), strings.Join(quoted, ","))
 		when = fmt.Sprintf("((%s) && (%s))", guard, when)
@@ -491,6 +492,25 @@ func (r structuredRule) toRuleExpr(ecosystems []string) (string, error) {
 		return "", fmt.Errorf("marshal action: %w", err)
 	}
 	return fmt.Sprintf("((%s) ? [%s] : [])", when, string(actionJSON)), nil
+}
+
+// celStringLiteral renders an authored value as a CEL string literal, quoted and
+// escaped, so a value can only ever be data in the generated expression. It is
+// used for the ecosystem guard, which is the one place a policy's own text is
+// interpolated into CEL rather than marshaled into it.
+//
+// Interpolating the value bare let it close the literal and keep going: an
+// ecosystems entry of `npm"] || true || ["x"] == ["x` generated a guard that
+// matched every ecosystem, so a bundle that reads as scoped to npm denied a PyPI
+// package, and it compiled and linted clean. That is the same defect as an aliased
+// policy, the text a reviewer reads not being the policy that runs, reached through
+// a field instead of a YAML construct.
+//
+// Go's quoting is CEL's: both accept \\, \", \n, \r, \t, \a, \b, \f, \v, \xHH,
+// \uXXXX and \UXXXXXXXX, which is every escape strconv.Quote emits, so the literal
+// it produces parses as the value it was given.
+func celStringLiteral(value string) string {
+	return strconv.Quote(value)
 }
 
 // escapeComment escapes characters in a string to make it safe for inclusion

--- a/internal/policy/bundle_structured.go
+++ b/internal/policy/bundle_structured.go
@@ -151,6 +151,11 @@ func tryParseStructuredBundle(data []byte, path string) ([]Source, bool, error) 
 	if IsCompiledBundle(data) {
 		return nil, false, nil
 	}
+	// The decoder would resolve anchors silently, so refuse them here: loading
+	// and validating a bundle must agree on what the format accepts.
+	if err := bundleAnchorError(data, path); err != nil {
+		return nil, false, err
+	}
 	var bundle structuredBundle
 	if err := yaml.Unmarshal(data, &bundle); err != nil {
 		if LooksLikeStructuredBundle(data) {

--- a/internal/policy/bundle_structured.go
+++ b/internal/policy/bundle_structured.go
@@ -168,6 +168,21 @@ func tryParseStructuredBundle(data []byte, path string) ([]Source, bool, error) 
 	if err := bundleAnchorError(data, path); err != nil {
 		return nil, false, err
 	}
+	return decodeStructuredBundle(data, path)
+}
+
+// decodeStructuredBundle turns an authored bundle into policy sources, without
+// the refusal of YAML anchors that loading one puts in front of the decoder.
+//
+// Only validation reads a bundle this way, for its last backstop: it has already
+// located every anchor in the document itself, and the refusal stops at the
+// first one, so going through it would hide the bundle-level shapes that nothing
+// but decoding finds and cost the author a lint run. It is safe there because
+// validation skips this whenever the document holds an alias or a merge key, the
+// constructs that would make the decoder read something other than what the
+// document says. Every other caller loads a bundle to run it and must refuse
+// them, so it calls tryParseStructuredBundle.
+func decodeStructuredBundle(data []byte, path string) ([]Source, bool, error) {
 	var bundle structuredBundle
 	if err := yaml.Unmarshal(data, &bundle); err != nil {
 		if LooksLikeStructuredBundle(data) {

--- a/internal/policy/bundle_structured.go
+++ b/internal/policy/bundle_structured.go
@@ -242,9 +242,9 @@ func (p structuredPolicy) toCELSource() (string, error) {
 	}
 	p.Commands = normalizedCommands
 	if p.Mode != "" {
-		mode := strings.ToLower(strings.TrimSpace(p.Mode))
-		if mode != "advisory" && mode != "enforce" {
-			return "", fmt.Errorf("invalid mode %q (expected advisory|enforce)", p.Mode)
+		mode, err := ValidateMode(p.Mode)
+		if err != nil {
+			return "", err
 		}
 		p.Mode = mode
 	}

--- a/internal/policy/bundle_structured.go
+++ b/internal/policy/bundle_structured.go
@@ -141,6 +141,18 @@ type structuredRule struct {
 	Details     map[string]any    `yaml:"details,omitempty"`     // Details provides extra context.
 }
 
+// normalizeNames trims surrounding whitespace from every policy name, so that
+// "audit" and " audit " are the one name they read as. A name identifies a
+// policy: validation reports the second as a duplicate, and the name is what
+// ends up in a source name and in the generated policy.name metadata, so the
+// loader has to fold them together too or a bundle the linter rejects would
+// still compile.
+func (b *structuredBundle) normalizeNames() {
+	for i := range b.Policies {
+		b.Policies[i].Name = strings.TrimSpace(b.Policies[i].Name)
+	}
+}
+
 // tryParseStructuredBundle attempts to parse a byte slice as a structured YAML bundle.
 // It returns the generated CEL sources if successful, or a boolean indicating
 // whether the input looked like a bundle but failed validation. A file that has
@@ -166,6 +178,7 @@ func tryParseStructuredBundle(data []byte, path string) ([]Source, bool, error) 
 	if len(bundle.Policies) == 0 {
 		return nil, false, nil
 	}
+	bundle.normalizeNames()
 	seenNames := map[string]struct{}{}
 	var sources []Source
 	for _, pol := range bundle.Policies {
@@ -209,6 +222,7 @@ func TryParseStructuredBundleBytes(data []byte) (*structuredBundle, bool, error)
 	if len(bundle.Policies) == 0 {
 		return nil, false, nil
 	}
+	bundle.normalizeNames()
 	return &bundle, true, nil
 }
 

--- a/internal/policy/bundle_structured.go
+++ b/internal/policy/bundle_structured.go
@@ -241,10 +241,10 @@ func (p structuredPolicy) toCELSource() (string, error) {
 	}
 	var builder strings.Builder
 	builder.WriteString("[]")
-	for _, rule := range p.Rules {
+	for i, rule := range p.Rules {
 		expr, err := rule.toRuleExpr(p.Ecosystems)
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("rule[%d]: %w", i, err)
 		}
 		builder.WriteString(" + ")
 		builder.WriteString(expr)
@@ -311,7 +311,11 @@ func (r structuredRule) toRuleExpr(ecosystems []string) (string, error) {
 	if strings.TrimSpace(r.Action) == "" {
 		return "", fmt.Errorf("rule missing action")
 	}
-	action := map[string]any{"action": r.Action}
+	normalizedAction, err := ValidateActionType(r.Action)
+	if err != nil {
+		return "", err
+	}
+	action := map[string]any{"action": normalizedAction}
 	if r.Reason != "" {
 		action["reason"] = r.Reason
 	}

--- a/internal/policy/bundle_structured.go
+++ b/internal/policy/bundle_structured.go
@@ -189,11 +189,18 @@ func tryParseStructuredBundle(data []byte, path string) ([]Source, bool, error) 
 	if err := bundleRefusalError(data, path); err != nil {
 		return nil, false, err
 	}
-	return decodeStructuredBundle(data, path)
+	return decodeStructuredBundle(data, path, LooksLikeStructuredBundle(data))
 }
 
 // decodeStructuredBundle turns an authored bundle into policy sources, without
 // the refusal of YAML anchors that loading one puts in front of the decoder.
+//
+// isBundle is the caller's answer to whether the data is an authored bundle at
+// all, which decides what a decode failure means: a policy the author wrote,
+// reported so they are told which field is wrong, or a file that was never a
+// bundle, left for the caller's other formats. Taking the answer rather than
+// asking again is what keeps a caller that has already committed to the document
+// being a bundle, as validation has, from being told it is not one.
 //
 // Only validation reads a bundle this way, for its last backstop: it has already
 // located every anchor in the document itself, and the refusal stops at the
@@ -203,10 +210,10 @@ func tryParseStructuredBundle(data []byte, path string) ([]Source, bool, error) 
 // constructs that would make the decoder read something other than what the
 // document says. Every other caller loads a bundle to run it and must refuse
 // them, so it calls tryParseStructuredBundle.
-func decodeStructuredBundle(data []byte, path string) ([]Source, bool, error) {
+func decodeStructuredBundle(data []byte, path string, isBundle bool) ([]Source, bool, error) {
 	var bundle structuredBundle
 	if err := yaml.Unmarshal(data, &bundle); err != nil {
-		if LooksLikeStructuredBundle(data) {
+		if isBundle {
 			return nil, false, fmt.Errorf("%s: %w", path, err)
 		}
 		return nil, false, nil

--- a/internal/policy/bundle_structured.go
+++ b/internal/policy/bundle_structured.go
@@ -143,13 +143,19 @@ type structuredRule struct {
 
 // tryParseStructuredBundle attempts to parse a byte slice as a structured YAML bundle.
 // It returns the generated CEL sources if successful, or a boolean indicating
-// whether the input looked like a bundle but failed validation.
+// whether the input looked like a bundle but failed validation. A file that has
+// the shape of an authored bundle but does not decode reports the decode error
+// rather than being dismissed as an unknown format, since the author wrote a
+// policy and deserves to be told which field is wrong.
 func tryParseStructuredBundle(data []byte, path string) ([]Source, bool, error) {
 	if IsCompiledBundle(data) {
 		return nil, false, nil
 	}
 	var bundle structuredBundle
 	if err := yaml.Unmarshal(data, &bundle); err != nil {
+		if LooksLikeStructuredBundle(data) {
+			return nil, false, fmt.Errorf("%s: %w", path, err)
+		}
 		return nil, false, nil
 	}
 	if len(bundle.Policies) == 0 {

--- a/internal/policy/bundle_structured.go
+++ b/internal/policy/bundle_structured.go
@@ -298,24 +298,9 @@ func (p structuredPolicy) toCELSource() (string, error) {
 		builder.WriteString(" + ")
 		builder.WriteString(expr)
 	}
-	body := builder.String()
-	if len(p.Vars) > 0 {
-		seen := map[string]struct{}{}
-		for _, kv := range p.Vars {
-			if strings.TrimSpace(kv.Name) == "" {
-				return "", fmt.Errorf("vars must have non-empty names")
-			}
-			if _, ok := seen[kv.Name]; ok {
-				return "", fmt.Errorf("duplicate var name %q", kv.Name)
-			}
-			seen[kv.Name] = struct{}{}
-		}
-		// expand vars in reverse author order so earlier vars are in scope for later ones
-		for _, v := range slices.Backward(p.Vars) {
-			name := v.Name
-			expr := v.exprString()
-			body = fmt.Sprintf("([%s]).map(%s, %s)[0]", expr, name, body)
-		}
+	body, err := p.wrapVars(builder.String())
+	if err != nil {
+		return "", err
 	}
 	metadata := []string{}
 	if p.Name != "" {
@@ -340,6 +325,35 @@ func (p structuredPolicy) toCELSource() (string, error) {
 		return body, nil
 	}
 	return strings.Join(metadata, "\n") + "\n" + body, nil
+}
+
+// wrapVars binds a policy's variables around a CEL body, one comprehension per
+// variable in reverse author order so an earlier var is in scope for a later
+// one. Names have to be unique and non-empty, since a duplicate would silently
+// shadow the binding before it.
+//
+// It is separate from the rest of the expansion because a policy's vars are
+// wrong or right on their own: validation wraps an empty body with it to report
+// vars that do not compile in a policy whose rules the walk has already found a
+// defect in, which the whole-policy expansion cannot do.
+func (p structuredPolicy) wrapVars(body string) (string, error) {
+	if len(p.Vars) == 0 {
+		return body, nil
+	}
+	seen := map[string]struct{}{}
+	for _, kv := range p.Vars {
+		if strings.TrimSpace(kv.Name) == "" {
+			return "", fmt.Errorf("vars must have non-empty names")
+		}
+		if _, ok := seen[kv.Name]; ok {
+			return "", fmt.Errorf("duplicate var name %q", kv.Name)
+		}
+		seen[kv.Name] = struct{}{}
+	}
+	for _, v := range slices.Backward(p.Vars) {
+		body = fmt.Sprintf("([%s]).map(%s, %s)[0]", v.exprString(), v.Name, body)
+	}
+	return body, nil
 }
 
 // toRuleExpr converts a structured rule into a CEL expression string.

--- a/internal/policy/bundle_structured.go
+++ b/internal/policy/bundle_structured.go
@@ -2,6 +2,7 @@ package policy
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"slices"
@@ -165,6 +166,13 @@ func (b *structuredBundle) normalizeNames() {
 	}
 }
 
+// policyNeedsRuleMessage is how a reader of a bundle says that a policy has no
+// rules to run. The node walk locates the same defect from the document, in its
+// own words, so validation matches this spelling to fold the loader's
+// restatement of it; one constant is what keeps the two readers from drifting
+// into reporting one mistake twice.
+const policyNeedsRuleMessage = "policy must contain at least one rule"
+
 // tryParseStructuredBundle attempts to parse a byte slice as a structured YAML bundle.
 // It returns the generated CEL sources if successful, or a boolean indicating
 // whether the input looked like a bundle but failed validation. A file that has
@@ -210,7 +218,7 @@ func decodeStructuredBundle(data []byte, path string) ([]Source, bool, error) {
 	var sources []Source
 	for _, pol := range bundle.Policies {
 		if len(pol.Rules) == 0 {
-			return nil, false, fmt.Errorf("%s/%s: policy must contain at least one rule", path, pol.Name)
+			return nil, false, fmt.Errorf("%s/%s: %s", path, pol.Name, policyNeedsRuleMessage)
 		}
 		if pol.Name != "" {
 			if _, dup := seenNames[pol.Name]; dup {
@@ -272,7 +280,7 @@ func ParseStructuredSources(data []byte, virtualPath string) ([]Source, error) {
 // It generates the necessary metadata comments and constructs the rule evaluation logic.
 func (p structuredPolicy) toCELSource() (string, error) {
 	if len(p.Rules) == 0 {
-		return "", fmt.Errorf("policy must contain at least one rule")
+		return "", errors.New(policyNeedsRuleMessage)
 	}
 	for _, ep := range p.Entrypoints {
 		if !IsAllowedEntrypoint(ep) {

--- a/internal/policy/bundle_structured.go
+++ b/internal/policy/bundle_structured.go
@@ -43,20 +43,42 @@ type varKV struct {
 	IsString bool   // IsString indicates if the value was parsed as a string.
 }
 
-// exprString converts the variable's value into a CEL-compatible string representation.
-// Strings are returned as-is (quoted by the caller if needed), while other types
-// are JSON-marshaled.
-func (kv varKV) exprString() string {
+// exprString renders the var's value as the CEL expression the policy binds the
+// name to. A string is the author's own CEL and is returned as written; every
+// other value is marshaled to JSON, which is a subset of CEL's literal syntax.
+//
+// A value JSON has no spelling for refuses the var rather than standing in for it.
+// Substituting `null` bound a name to a value the bundle does not declare: a
+// `threshold: .nan` compiled, linted clean, and made `threshold == null` true, so
+// the policy that ran was not the policy that was reviewed. Every value the
+// decoder reads and JSON can represent is unaffected, which is every var Deputy
+// ships; what is refused is the handful YAML can write and JSON cannot, the
+// not-a-number and the infinities among them.
+func (kv varKV) exprString() (string, error) {
 	if kv.IsString {
 		if s, ok := kv.Value.(string); ok {
-			return s
+			return s, nil
 		}
 	}
 	b, err := json.Marshal(kv.Value)
 	if err != nil {
-		return "null"
+		return "", varNotRepresentableError(kv.Name, err)
 	}
-	return string(b)
+	return string(b), nil
+}
+
+// varNotRepresentableFormat is how a reader of a bundle says that a var holds a
+// value Deputy cannot write into the CEL a policy generates. The node walk locates
+// the same defect from the document, so validation matches this spelling to fold
+// the loader's restatement of it; one constant is what keeps the two readers from
+// reporting one mistake twice.
+const varNotRepresentableFormat = "var %q holds a value that cannot be represented: %w"
+
+// varNotRepresentableError renders that message for one var and the marshal
+// failure behind it. Both readers go through it rather than through the format, so
+// neither can spell the message the other has to recognize.
+func varNotRepresentableError(name string, err error) error {
+	return fmt.Errorf(varNotRepresentableFormat, name, err)
 }
 
 // normalizeVarName trims surrounding whitespace from a variable name, so that
@@ -92,7 +114,7 @@ func (o *orderedVars) UnmarshalYAML(node *yaml.Node) error {
 		}
 		kv.Name = normalizeVarName(kv.Name)
 		// Detect string vs other scalars/collections
-		if v.Kind == yaml.ScalarNode && v.Tag == "!!str" {
+		if v.Kind == yaml.ScalarNode && v.Tag == strTag {
 			if err := v.Decode(&kv.Value); err != nil {
 				return err
 			}
@@ -180,14 +202,22 @@ func (o orderedVars) bindings() []varBinding {
 }
 
 // nestVars wraps a CEL body in one comprehension per var, in reverse author order
-// so an earlier var is in scope for a later one. It does no checking: a caller
-// that runs a policy validates the names first (wrapVars), and validation uses it
-// to compile the expression of a var whose name it has already reported.
-func nestVars(vars orderedVars, body string) string {
+// so an earlier var is in scope for a later one. It checks no name: a caller that
+// runs a policy validates those first (wrapVars), and validation uses this to
+// compile the expression of a var whose name it has already reported.
+//
+// A var whose value has no CEL spelling refuses the nest, since there is no
+// expression to bind the name to and standing something else in would bind a value
+// the bundle does not declare (see exprString).
+func nestVars(vars orderedVars, body string) (string, error) {
 	for _, v := range slices.Backward(vars) {
-		body = fmt.Sprintf("([%s]).map(%s, %s)[0]", v.exprString(), v.Name, body)
+		expr, err := v.exprString()
+		if err != nil {
+			return "", err
+		}
+		body = fmt.Sprintf("([%s]).map(%s, %s)[0]", expr, v.Name, body)
 	}
-	return body
+	return body, nil
 }
 
 // Names returns the ordered variable names.
@@ -463,7 +493,8 @@ func (m *metadataComments) setList(key string, values []string) {
 //
 // A name the policy cannot bind refuses the whole policy, which is what a reader
 // that runs it must do; validation reports every one of them and compiles the rest
-// (see bindings).
+// (see bindings). A value with no CEL spelling refuses it for the same reason: the
+// name would bind something the bundle does not declare (see exprString).
 func (p structuredPolicy) wrapVars(body string) (string, error) {
 	if len(p.Vars) == 0 {
 		return body, nil
@@ -473,7 +504,7 @@ func (p structuredPolicy) wrapVars(body string) (string, error) {
 			return "", binding.err
 		}
 	}
-	return nestVars(p.Vars, body), nil
+	return nestVars(p.Vars, body)
 }
 
 // toRuleExpr converts a structured rule into a CEL expression string.

--- a/internal/policy/bundle_structured.go
+++ b/internal/policy/bundle_structured.go
@@ -274,10 +274,10 @@ func tryParseStructuredBundle(data []byte, path string) ([]Source, bool, error) 
 // located every anchor in the document itself, and the refusal stops at the
 // first one, so going through it would hide the bundle-level shapes that nothing
 // but decoding finds and cost the author a lint run. It is safe there because
-// validation skips this whenever the document holds an alias or a merge key, the
-// constructs that would make the decoder read something other than what the
-// document says. Every other caller loads a bundle to run it and must refuse
-// them, so it calls tryParseStructuredBundle.
+// validation acts on nothing the decoder resolves: it reports the shapes the
+// decode refuses, each on the line the decoder names, which for a reference is
+// where the anchor it reads is written. Every other caller loads a bundle to run
+// it and must refuse those constructs, so it calls tryParseStructuredBundle.
 func decodeStructuredBundle(data []byte, path string, isBundle bool) ([]Source, bool, error) {
 	var bundle structuredBundle
 	if err := yaml.Unmarshal(data, &bundle); err != nil {

--- a/internal/policy/bundle_structured_test.go
+++ b/internal/policy/bundle_structured_test.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -76,6 +77,85 @@ func TestOrderedVarsRejectDuplicateNames(t *testing.T) {
 	}
 	if _, err := p.toCELSource(); err == nil {
 		t.Fatalf("expected error for duplicate var names, got nil")
+	}
+}
+
+// TestStructuredPolicyValidatesActionVocabulary pins that a rule action outside
+// the allow/deny/warn vocabulary is a load-time error, and that casing and
+// surrounding whitespace are normalized rather than rejected.
+func TestStructuredPolicyValidatesActionVocabulary(t *testing.T) {
+	cases := []struct {
+		name        string
+		action      string
+		wantErr     bool
+		wantInError []string
+		wantEmitted string
+	}{
+		{name: "deny", action: "deny", wantEmitted: "deny"},
+		{name: "warn", action: "warn", wantEmitted: "warn"},
+		{name: "allow", action: "allow", wantEmitted: "allow"},
+		{name: "uppercase is normalized", action: "DENY", wantEmitted: "deny"},
+		{name: "padded is normalized", action: "  Warn\t", wantEmitted: "warn"},
+		{
+			name:        "typo is rejected",
+			action:      "dney",
+			wantErr:     true,
+			wantInError: []string{`"dney"`, "allow|deny|warn"},
+		},
+		{
+			name:        "unknown verb is rejected",
+			action:      "block",
+			wantErr:     true,
+			wantInError: []string{`"block"`, "allow|deny|warn"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := structuredPolicy{
+				Name:  "vocabulary",
+				Rules: []structuredRule{{Action: tc.action, When: "true", Reason: "because"}},
+			}
+			src, err := p.toCELSource()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for action %q, got source: %s", tc.action, src)
+				}
+				for _, want := range append(tc.wantInError, "rule[0]") {
+					if !strings.Contains(err.Error(), want) {
+						t.Fatalf("error %q missing %q", err, want)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("toCELSource: %v", err)
+			}
+			if !strings.Contains(src, fmt.Sprintf(`"action":"%s"`, tc.wantEmitted)) {
+				t.Fatalf("expected normalized action %q in source: %s", tc.wantEmitted, src)
+			}
+		})
+	}
+}
+
+// TestStructuredBundleActionErrorNamesPolicyAndFile pins that the parse error for
+// an unknown action identifies the file, policy, and rule the author must fix.
+func TestStructuredBundleActionErrorNamesPolicyAndFile(t *testing.T) {
+	data := []byte(`
+policies:
+  - name: typo-action
+    rules:
+      - when: "true"
+        action: dney
+        reason: "should deny"
+`)
+	_, err := ParseStructuredSources(data, "bundle.yaml")
+	if err == nil {
+		t.Fatal("expected error for unknown action")
+	}
+	for _, want := range []string{"bundle.yaml", "typo-action", "rule[0]", `"dney"`, "allow|deny|warn"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error %q missing %q", err, want)
+		}
 	}
 }
 

--- a/internal/policy/bundle_structured_test.go
+++ b/internal/policy/bundle_structured_test.go
@@ -80,6 +80,61 @@ func TestOrderedVarsRejectDuplicateNames(t *testing.T) {
 	}
 }
 
+// TestLoaderNormalizesVarNames pins that the loader reads a variable name the
+// way validation and CEL do, with surrounding whitespace trimmed. CEL binds
+// " blocked " and "blocked" as the one identifier, so a bundle declaring both
+// shadows one with the other; validation calls that a duplicate, and a loader
+// that compared the raw spellings would compile a bundle the linter rejects.
+func TestLoaderNormalizesVarNames(t *testing.T) {
+	cases := []struct {
+		name       string
+		vars       string
+		wantErr    string
+		wantInBody string
+	}{
+		{
+			name:       "a padded name binds the trimmed identifier",
+			vars:       "      \" blocked \": '[\"left-pad\"]'\n",
+			wantInBody: ".map(blocked,",
+		},
+		{
+			name:    "a padded name duplicating a bare one is rejected",
+			vars:    "      blocked: '[\"left-pad\"]'\n      \" blocked \": '[\"right-pad\"]'\n",
+			wantErr: `duplicate var name "blocked"`,
+		},
+		{
+			name:    "a name that is only whitespace is rejected",
+			vars:    "      \"  \": '1'\n",
+			wantErr: "vars must have non-empty names",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := "policies:\n  - name: vars\n    vars:\n" + tc.vars +
+				"    rules:\n      - when: \"true\"\n        action: deny\n        reason: r\n"
+			sources, err := ParseStructuredSources([]byte(bundle), "bundle.yaml")
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error %q, got sources %+v", tc.wantErr, sources)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error %q missing %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseStructuredSources: %v", err)
+			}
+			if len(sources) != 1 {
+				t.Fatalf("expected one source, got %d", len(sources))
+			}
+			if !strings.Contains(sources[0].Body, tc.wantInBody) {
+				t.Fatalf("body %q missing %q", sources[0].Body, tc.wantInBody)
+			}
+		})
+	}
+}
+
 // TestStructuredPolicyValidatesActionVocabulary pins that a rule action outside
 // the allow/deny/warn vocabulary is a load-time error, and that casing and
 // surrounding whitespace are normalized rather than rejected.

--- a/internal/policy/bundle_structured_test.go
+++ b/internal/policy/bundle_structured_test.go
@@ -311,3 +311,87 @@ func TestGeneratedEcosystemGuardCannotBeRewritten(t *testing.T) {
 		})
 	}
 }
+
+// TestGeneratedMetadataCannotCarryADirective pins that no value a bundle authors
+// can open a `//!` metadata line of its own in the CEL a policy generates. Those
+// comments are Deputy's own writing, read back by parsePolicyMetadata when a source
+// is loaded, so a value that breaks out of the line carrying it declares policy
+// behavior nobody authored.
+//
+// The escaping used to be applied per field, and the fields added beside name and
+// description did not apply it: an ecosystems entry holding
+// "\n//! policy.mode = advisory\n//" generated a mode line the engine obeyed, while
+// the trailing comment swallowed the closing quote of the line it broke out of, so
+// the bundle read as deny, loaded as advisory, and both linted and compiled clean.
+// That is the metadata counterpart of a rewritten ecosystem guard: the text a
+// reviewer reads not being the policy that runs.
+//
+// The whole path is checked, from the authored bundle to the actions the engine
+// returns, because every half of it looked right on its own. The count of metadata
+// lines is checked with it, so a value that stays data but still adds a line the
+// parser reads cannot pass by declaring a key Deputy does not act on yet.
+func TestGeneratedMetadataCannotCarryADirective(t *testing.T) {
+	const directive = `\n//! policy.mode = advisory\n//`
+	cases := []struct {
+		name         string
+		policyName   string
+		fields       string
+		wantMetadata int
+	}{
+		{
+			name:         "in an ecosystems entry beside a real one",
+			policyName:   "scoped",
+			fields:       "    ecosystems: [\"npm\", \"npm" + directive + "\"]\n",
+			wantMetadata: 2,
+		},
+		{
+			name:         "in the policy name",
+			policyName:   "scoped" + directive,
+			wantMetadata: 1,
+		},
+		{
+			name:         "in the description",
+			policyName:   "scoped",
+			fields:       "    description: \"d" + directive + "\"\n",
+			wantMetadata: 2,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := "policies:\n  - name: \"" + tc.policyName + "\"\n" + tc.fields +
+				"    rules:\n      - when: \"true\"\n        action: deny\n        reason: r\n"
+			sources, err := ParseStructuredSources([]byte(bundle), "b.yaml")
+			if err != nil {
+				t.Fatalf("ParseStructuredSources: %v", err)
+			}
+			body := sources[0].Body
+			lines := 0
+			for line := range strings.SplitSeq(body, "\n") {
+				if strings.HasPrefix(strings.TrimSpace(line), "//!") {
+					lines++
+				}
+			}
+			if lines != tc.wantMetadata {
+				t.Fatalf("generated %d metadata lines, want %d:\n%s", lines, tc.wantMetadata, body)
+			}
+			if mode := parsePolicyMetadata(body).Mode; mode != "" {
+				t.Fatalf("a bundle that declares no mode generated mode %q:\n%s", mode, body)
+			}
+			eng, err := NewEngine(sources)
+			if err != nil {
+				t.Fatalf("NewEngine: %v", err)
+			}
+			payload := map[string]any{
+				"pkg":     map[string]any{"name": "left-pad", "ecosystem": "npm"},
+				"request": map[string]any{"ecosystem": "npm"},
+			}
+			actions, err := eng.EvaluateAllMap(t.Context(), payload, "scan", "")
+			if err != nil {
+				t.Fatalf("EvaluateAllMap: %v", err)
+			}
+			if len(actions) != 1 || !ActionTypeIs(actions[0].Type, ActionDeny) {
+				t.Fatalf("a policy authored to deny returned %+v, want one deny:\n%s", actions, body)
+			}
+		})
+	}
+}

--- a/internal/policy/bundle_structured_test.go
+++ b/internal/policy/bundle_structured_test.go
@@ -2,6 +2,7 @@ package policy
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -229,5 +230,84 @@ func TestStructuredPolicyNormalizesCommandAliases(t *testing.T) {
 	}
 	if strings.Contains(src, "exec") {
 		t.Fatalf("compiled source retained legacy exec alias: %s", src)
+	}
+}
+
+// TestGeneratedEcosystemGuardCannotBeRewritten pins that a policy's ecosystems
+// reach the generated guard as string literals and nothing else. The guard is CEL
+// source built by interpolating each value, so a value carrying a quote used to
+// close the list and continue the expression: the bundle below reads as scoped to
+// npm, and before this it compiled, linted clean, and denied a PyPI package. The
+// text a reviewer reads has to be the policy that runs, which is the same reason
+// the format refuses aliases.
+//
+// The plain cases are here too, so escaping cannot pass by scoping nothing.
+func TestGeneratedEcosystemGuardCannotBeRewritten(t *testing.T) {
+	cases := []struct {
+		name       string
+		ecosystems string
+		ecosystem  string
+		wantDeny   bool
+	}{
+		{
+			name:       "a value crafted to close the list and always match",
+			ecosystems: `['npm"] || true || ["x"] == ["x']`,
+			ecosystem:  "PyPI",
+		},
+		{
+			name:       "a value carrying a bare quote",
+			ecosystems: `['npm"']`,
+			ecosystem:  "npm",
+		},
+		{
+			name:       "a value carrying a backslash",
+			ecosystems: `['npm\']`,
+			ecosystem:  "npm",
+		},
+		{
+			name:       "the declared ecosystem matches",
+			ecosystems: `['npm']`,
+			ecosystem:  "npm",
+			wantDeny:   true,
+		},
+		{
+			name:       "another ecosystem does not match",
+			ecosystems: `['npm']`,
+			ecosystem:  "PyPI",
+		},
+		{
+			name:       "one of several declared ecosystems matches",
+			ecosystems: `['npm', 'PyPI']`,
+			ecosystem:  "PyPI",
+			wantDeny:   true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := "policies:\n  - name: scoped\n    ecosystems: " + tc.ecosystems +
+				"\n    rules:\n      - when: \"pkg.name == 'left-pad'\"\n        action: deny\n        reason: r\n"
+			sources, err := ParseStructuredSources([]byte(bundle), "b.yaml")
+			if err != nil {
+				t.Fatalf("ParseStructuredSources: %v", err)
+			}
+			eng, err := NewEngine(sources)
+			if err != nil {
+				t.Fatalf("NewEngine: %v", err)
+			}
+			// request is supplied because the generated guard reads it before
+			// pkg, and an absent one errors before the ecosystem is compared.
+			payload := map[string]any{
+				"pkg":     map[string]any{"name": "left-pad", "ecosystem": tc.ecosystem},
+				"request": map[string]any{"ecosystem": "unrelated"},
+			}
+			actions, err := eng.EvaluateAllMap(t.Context(), payload, "scan", "")
+			if err != nil {
+				t.Fatalf("EvaluateAllMap: %v", err)
+			}
+			denied := slices.ContainsFunc(actions, func(a Action) bool { return ActionTypeIs(a.Type, ActionDeny) })
+			if denied != tc.wantDeny {
+				t.Fatalf("denied a %s package = %v, want %v (actions %+v)", tc.ecosystem, denied, tc.wantDeny, actions)
+			}
+		})
 	}
 }

--- a/internal/policy/bundle_structured_test.go
+++ b/internal/policy/bundle_structured_test.go
@@ -395,3 +395,79 @@ func TestGeneratedMetadataCannotCarryADirective(t *testing.T) {
 		})
 	}
 }
+
+// TestVarValueWithoutACELSpellingRefusesThePolicy pins that a var Deputy cannot
+// write into the CEL a policy generates refuses the policy rather than binding
+// something else. A non-string var value is marshaled to JSON, which is a subset of
+// CEL's literal syntax, and YAML writes values JSON has no spelling for.
+//
+// Substituting `null` for the marshal failure bound a name to a value the bundle
+// does not declare: `threshold: .nan` compiled, validated clean, and made
+// `threshold == null` true, so the policy that ran was not the policy that was
+// reviewed. The refusal is only correct if it cannot fire for a value the author is
+// entitled to write, so the values a bundle can legitimately hold are pinned here
+// beside the ones it cannot, each checked for the literal it binds.
+func TestVarValueWithoutACELSpellingRefusesThePolicy(t *testing.T) {
+	refused := []struct {
+		name  string
+		value string
+	}{
+		{name: "a not-a-number", value: ".nan"},
+		{name: "a positive infinity", value: ".inf"},
+		{name: "a negative infinity", value: "-.inf"},
+		{name: "a not-a-number written in capitals", value: ".NaN"},
+		{name: "an infinity inside a list", value: "[1, .inf]"},
+		{name: "a not-a-number inside a nested mapping", value: "{a: {b: .nan}}"},
+		// A CEL map may be keyed by an integer, but JSON has no spelling for
+		// one, so this used to bind null as well. Refusing it says so, and the
+		// author can write the map as a CEL expression instead.
+		{name: "a mapping keyed by something other than a string", value: "{1: a}"},
+	}
+	for _, tc := range refused {
+		t.Run("refuses "+tc.name, func(t *testing.T) {
+			_, err := ParseStructuredSources([]byte(varBundle(tc.value)), "b.yaml")
+			if err == nil {
+				t.Fatalf("a var holding %s was accepted", tc.value)
+			}
+			if !strings.Contains(err.Error(), `var "threshold" holds a value that cannot be represented`) {
+				t.Fatalf("error %q should name the var and what is wrong with it", err)
+			}
+		})
+	}
+	accepted := []struct {
+		name    string
+		value   string
+		literal string
+	}{
+		{name: "an integer", value: "5", literal: "([5])"},
+		{name: "a float", value: "5.5", literal: "([5.5])"},
+		{name: "the largest float64", value: "1.7976931348623157e308", literal: "([1.7976931348623157e+308])"},
+		{name: "a boolean", value: "true", literal: "([true])"},
+		{name: "an explicit null", value: "null", literal: "([null])"},
+		{name: "a list", value: "[1, 2, 3]", literal: "([[1,2,3]])"},
+		{name: "an empty list", value: "[]", literal: "([[]])"},
+		{name: "a nested mapping", value: "{a: 1, b: [x, y]}", literal: `([{"a":1,"b":["x","y"]}])`},
+		{name: "a string, which is the author's own CEL", value: "'1 + 1'", literal: "([1 + 1])"},
+	}
+	for _, tc := range accepted {
+		t.Run("accepts "+tc.name, func(t *testing.T) {
+			sources, err := ParseStructuredSources([]byte(varBundle(tc.value)), "b.yaml")
+			if err != nil {
+				t.Fatalf("a var holding %s was refused: %v", tc.value, err)
+			}
+			if !strings.Contains(sources[0].Body, tc.literal) {
+				t.Fatalf("a var holding %s should bind %s, got:\n%s", tc.value, tc.literal, sources[0].Body)
+			}
+			if _, err := NewEngine(sources); err != nil {
+				t.Fatalf("NewEngine: %v", err)
+			}
+		})
+	}
+}
+
+// varBundle writes the smallest bundle that binds one var, for the cases that ask
+// only what a var value expands to.
+func varBundle(value string) string {
+	return "policies:\n  - name: thresholded\n    vars:\n      threshold: " + value +
+		"\n    rules:\n      - when: \"true\"\n        action: deny\n        reason: r\n"
+}

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -36,7 +36,7 @@ type compiledPolicy struct {
 	program     celProgram              // program is the compiled CEL executable.
 	entrypoints collections.Set[string] // entrypoints is the set of entrypoints this policy applies to.
 	commands    collections.Set[string] // commands is the set of commands this policy applies to.
-	mode        string                  // mode defines the execution mode (e.g., "enforce", "audit").
+	mode        string                  // mode is the canonical execution mode (see Modes), or empty for the enforce default.
 }
 
 // celProgram is the minimal interface we need from cel.Program for testing/abstraction.
@@ -61,16 +61,44 @@ func NewEngine(sources []Source) (*Engine, error) {
 		if err := validateEntrypoints(meta.Entrypoints, src.Name); err != nil {
 			return nil, err
 		}
+		mode, err := declaredMode(meta.Mode, src.Name)
+		if err != nil {
+			return nil, err
+		}
 
 		compiled = append(compiled, compiledPolicy{
 			source:      src,
 			program:     prog,
 			entrypoints: collections.NewSetFunc(meta.Entrypoints, strings.TrimSpace),
 			commands:    collections.NewSetFunc(meta.Commands, NormalizeCommand),
-			mode:        meta.Mode,
+			mode:        mode,
 		})
 	}
 	return &Engine{compiled: compiled}, nil
+}
+
+// declaredMode returns the canonical form of the mode a policy source declares,
+// refusing one Deputy does not recognize. Evaluation asks whether a policy's mode
+// is advisory and enforces when it is not, so an unrecognized spelling would turn
+// a policy the author meant to observe with into one that blocks, which is both
+// the opposite of what they asked for and silent. It is the load-time counterpart
+// of validateEntrypoints, and of the check the structured bundle format runs while
+// expanding a policy, so a mode is refused the same way whether it arrives as a
+// bundle field or as a comment on a raw CEL source.
+//
+// Canonicalizing here is what lets every reader of the mode compare it without
+// repeating the normalization: an authored " ADVISORY " is stored as advisory. An
+// empty mode is absent rather than unknown and means enforce, the default, so it
+// loads.
+func declaredMode(mode, policyName string) (string, error) {
+	if NormalizeMode(mode) == "" {
+		return "", nil
+	}
+	canonical, err := ValidateMode(mode)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w", policyName, err)
+	}
+	return canonical, nil
 }
 
 // validateEntrypoints checks that all entrypoints are known canonical values.
@@ -176,7 +204,7 @@ func (e *Engine) EvaluateAll(ctx context.Context, input proto.Message, command, 
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", pol.source.Name, err)
 		}
-		if strings.EqualFold(pol.mode, "advisory") {
+		if strings.EqualFold(pol.mode, ModeAdvisory) {
 			normalized = downgradeAdvisory(normalized)
 		}
 		// Record individual policy result as span event
@@ -282,7 +310,7 @@ func (e *Engine) EvaluateAllMap(ctx context.Context, payload map[string]any, com
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", pol.source.Name, err)
 		}
-		if strings.EqualFold(pol.mode, "advisory") {
+		if strings.EqualFold(pol.mode, ModeAdvisory) {
 			normalized = downgradeAdvisory(normalized)
 		}
 		// Record individual policy result as span event

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -95,13 +95,15 @@ func sourceMetadata(src Source) (policyMetadata, error) {
 // engine refuses when it loads the source, naming the policy and the offending
 // value. A source it accepts is one NewEngine will not reject over its metadata.
 //
-// It exists for a reader that checks a source without running it, which is lint. A
-// compiled bundle carries its policies as compiled CEL with their metadata in `//!`
-// comments, so compiling the CEL is the only question lint used to ask of one: a
-// bundle declaring `advsiory` linted OK and then failed to load in production,
-// which is the mistake lint exists to catch first. Both readers go through
-// sourceMetadata rather than each reading the metadata, so lint cannot come to
-// certify an artifact the engine refuses.
+// It exists for a reader that has a source but is not about to run it: the loader,
+// which refuses a compiled bundle carrying metadata the engine will not load (see
+// LoadSourcesFromBytes), and lint, for the raw source it reads off stdin without a
+// loader. A compiled policy carries its metadata as `//!` comments, so compiling the
+// CEL was the only question either of them asked of one, and a bundle declaring
+// `advsiory` linted OK, repackaged, and then failed to load in production.
+//
+// Every reader goes through sourceMetadata rather than reading the metadata itself,
+// so a check added at the engine boundary is a check they all make.
 func ValidateSourceMetadata(src Source) error {
 	_, err := sourceMetadata(src)
 	return err

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -55,26 +55,56 @@ func NewEngine(sources []Source) (*Engine, error) {
 		if err != nil {
 			return nil, err
 		}
-		meta := parsePolicyMetadata(src.Body)
-
-		// Validate entrypoints at load time - reject unknown entrypoints
-		if err := validateEntrypoints(meta.Entrypoints, src.Name); err != nil {
-			return nil, err
-		}
-		mode, err := declaredMode(meta.Mode, src.Name)
+		meta, err := sourceMetadata(src)
 		if err != nil {
 			return nil, err
 		}
-
 		compiled = append(compiled, compiledPolicy{
 			source:      src,
 			program:     prog,
 			entrypoints: collections.NewSetFunc(meta.Entrypoints, strings.TrimSpace),
 			commands:    collections.NewSetFunc(meta.Commands, NormalizeCommand),
-			mode:        mode,
+			mode:        meta.Mode,
 		})
 	}
 	return &Engine{compiled: compiled}, nil
+}
+
+// sourceMetadata reads the `//!` metadata a policy source declares and refuses the
+// closed vocabularies it gets wrong. It is the load-time boundary of the engine:
+// evaluation reads the mode to decide whether to downgrade a denial and the
+// entrypoints to decide whether to run the policy at all, so a spelling Deputy does
+// not recognize would silently change what the policy does rather than fail.
+//
+// The mode it returns is canonical, so every later reader compares it without
+// repeating the normalization.
+func sourceMetadata(src Source) (policyMetadata, error) {
+	meta := parsePolicyMetadata(src.Body)
+	if err := validateEntrypoints(meta.Entrypoints, src.Name); err != nil {
+		return policyMetadata{}, err
+	}
+	mode, err := declaredMode(meta.Mode, src.Name)
+	if err != nil {
+		return policyMetadata{}, err
+	}
+	meta.Mode = mode
+	return meta, nil
+}
+
+// ValidateSourceMetadata reports the metadata a policy source declares that the
+// engine refuses when it loads the source, naming the policy and the offending
+// value. A source it accepts is one NewEngine will not reject over its metadata.
+//
+// It exists for a reader that checks a source without running it, which is lint. A
+// compiled bundle carries its policies as compiled CEL with their metadata in `//!`
+// comments, so compiling the CEL is the only question lint used to ask of one: a
+// bundle declaring `advsiory` linted OK and then failed to load in production,
+// which is the mistake lint exists to catch first. Both readers go through
+// sourceMetadata rather than each reading the metadata, so lint cannot come to
+// certify an artifact the engine refuses.
+func ValidateSourceMetadata(src Source) error {
+	_, err := sourceMetadata(src)
+	return err
 }
 
 // declaredMode returns the canonical form of the mode a policy source declares,

--- a/internal/policy/engine_advisory_test.go
+++ b/internal/policy/engine_advisory_test.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 )
@@ -197,6 +198,80 @@ func TestValidateSourceMetadataAgreesWithNewEngine(t *testing.T) {
 			}
 			if !strings.Contains(validateErr.Error(), src.Name) {
 				t.Fatalf("error %q should name the policy it refuses", validateErr)
+			}
+		})
+	}
+}
+
+// TestLoadSourcesRefusesMetadataInEitherFormat pins that loading a bundle means the
+// same thing in both formats it can be written in. An authored policy's mode and
+// entrypoints are fields, refused while the policy expands; a compiled policy's are
+// `//!` comments, and nothing read them, so the loader accepted a compiled bundle
+// that NewEngine then refused to load.
+//
+// That asymmetry is what let three readers wave the same artifact through: lint
+// certified it, `policy bundle` repackaged it, and only the engine said no. The
+// check belongs on the loader because that is where every reader of a compiled
+// bundle passes.
+func TestLoadSourcesRefusesMetadataInEitherFormat(t *testing.T) {
+	compiled := func(source string) string {
+		body, err := json.Marshal(source)
+		if err != nil {
+			t.Fatalf("marshal source: %v", err)
+		}
+		return `{"schemaVersion":"policy.deputy.sh/v1alpha1","policies":[{"name":"p","source":` + string(body) + `}]}`
+	}
+	cases := []struct {
+		name     string
+		document string
+		wantErr  string
+	}{
+		{
+			name:     "an authored bundle whose mode is misspelled",
+			document: "policies:\n  - name: p\n    mode: advsiory\n    rules:\n      - when: \"true\"\n        action: deny\n        reason: r\n",
+			wantErr:  `invalid mode "advsiory"`,
+		},
+		{
+			name:     "a compiled bundle whose mode is misspelled",
+			document: compiled("//! policy.mode = advsiory\n[]"),
+			wantErr:  `invalid mode "advsiory"`,
+		},
+		{
+			name:     "an authored bundle whose entrypoint is misspelled",
+			document: "policies:\n  - name: p\n    entrypoints: [\"scan_vulnerabilities\"]\n    rules:\n      - when: \"true\"\n        action: deny\n        reason: r\n",
+			wantErr:  `invalid entrypoint "scan_vulnerabilities"`,
+		},
+		{
+			name:     "a compiled bundle whose entrypoint is misspelled",
+			document: compiled(`//! policy.entrypoints = "scan_vulnerabilities"` + "\n[]"),
+			wantErr:  `invalid entrypoint "scan_vulnerabilities"`,
+		},
+		{
+			name:     "an authored bundle whose metadata is right",
+			document: "policies:\n  - name: p\n    mode: advisory\n    entrypoints: [\"scan_vulnerability\"]\n    rules:\n      - when: \"true\"\n        action: deny\n        reason: r\n",
+		},
+		{
+			name:     "a compiled bundle whose metadata is right",
+			document: compiled(`//! policy.mode = "advisory"` + "\n" + `//! policy.entrypoints = "scan_vulnerability"` + "\n[]"),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sources, err := LoadSourcesFromBytes([]byte(tc.document), "b")
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("loading a bundle Deputy accepts failed: %v", err)
+				}
+				if _, err := NewEngine(sources); err != nil {
+					t.Fatalf("a loaded bundle has to build an engine: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("the loader accepted a bundle the engine refuses, got %d sources", len(sources))
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("error %q should name the offending value as %q", err, tc.wantErr)
 			}
 		})
 	}

--- a/internal/policy/engine_advisory_test.go
+++ b/internal/policy/engine_advisory_test.go
@@ -130,3 +130,74 @@ func TestStructuredPolicyModeAdvisory(t *testing.T) {
 		t.Fatalf("expected warn, got %+v", acts)
 	}
 }
+
+// TestValidateSourceMetadataAgreesWithNewEngine pins the equivalence a reader that
+// checks a source without running it depends on: ValidateSourceMetadata accepts a
+// source exactly when NewEngine will not reject it over its metadata, with the same
+// wording.
+//
+// Lint is that reader. A compiled bundle carries its policies as compiled CEL with
+// their metadata in `//!` comments, so compiling the CEL used to be the only question
+// lint asked of one, and a bundle declaring `advsiory` reported OK and then failed to
+// load in production. Both readers now go through one function, and this is what
+// keeps a check added to the engine boundary from being a check lint does not make.
+func TestValidateSourceMetadataAgreesWithNewEngine(t *testing.T) {
+	// Every body compiles, so the only thing either reader can object to is the
+	// metadata above it.
+	cases := []struct {
+		name    string
+		body    string
+		wantErr string
+	}{
+		{
+			name:    "a misspelled mode",
+			body:    "//! policy.mode = advsiory\n[]",
+			wantErr: `invalid mode "advsiory"`,
+		},
+		{
+			name:    "a mode outside the vocabulary",
+			body:    "//! policy.mode = \"audit\"\n[]",
+			wantErr: `invalid mode "audit"`,
+		},
+		{
+			name:    "a misspelled entrypoint",
+			body:    "//! policy.entrypoints = \"scan_vulnerabilities\"\n[]",
+			wantErr: `invalid entrypoint "scan_vulnerabilities"`,
+		},
+		{name: "no metadata at all", body: "[]"},
+		{name: "an advisory mode", body: "//! policy.mode = \"advisory\"\n[]"},
+		{name: "an enforce mode", body: "//! policy.mode = \"enforce\"\n[]"},
+		{name: "a known entrypoint", body: "//! policy.entrypoints = \"scan_vulnerability\"\n[]"},
+		{name: "a name and a description only", body: "//! policy.name = \"p\"\n//! policy.description = \"d\"\n[]"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := Source{Name: "b.json::p", Body: tc.body}
+			// The body compiling is what makes this a question about metadata: a
+			// reader that stopped at the CEL would agree by accident otherwise.
+			if err := Compile(src.Body, nil); err != nil {
+				t.Fatalf("the body should compile, so the metadata is the only thing left to refuse: %v", err)
+			}
+			validateErr := ValidateSourceMetadata(src)
+			_, engineErr := NewEngine([]Source{src})
+			if (validateErr == nil) != (engineErr == nil) {
+				t.Fatalf("the two readers disagree: ValidateSourceMetadata=%v, NewEngine=%v", validateErr, engineErr)
+			}
+			if tc.wantErr == "" {
+				if validateErr != nil {
+					t.Fatalf("expected the source to be accepted, got %v", validateErr)
+				}
+				return
+			}
+			if !strings.Contains(validateErr.Error(), tc.wantErr) {
+				t.Fatalf("error %q should name the offending value as %q", validateErr, tc.wantErr)
+			}
+			if validateErr.Error() != engineErr.Error() {
+				t.Fatalf("the two readers word one refusal differently: %q and %q", validateErr, engineErr)
+			}
+			if !strings.Contains(validateErr.Error(), src.Name) {
+				t.Fatalf("error %q should name the policy it refuses", validateErr)
+			}
+		})
+	}
+}

--- a/internal/policy/engine_advisory_test.go
+++ b/internal/policy/engine_advisory_test.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -30,6 +31,77 @@ true ? [{"action":"deny","reason":"block it"}] : []`,
 	}
 	if actions[0].Reason == "" {
 		t.Fatalf("expected reason to be preserved")
+	}
+}
+
+// TestEngineRefusesAnUnknownMode pins that a policy declaring a mode Deputy does
+// not recognize is refused when it is loaded, on every path a mode can arrive by.
+// Evaluation asks whether the mode is advisory and enforces when it is not, so a
+// misspelled "advsiory" turns a policy the author meant to observe with into one
+// that blocks: the opposite of what they asked for, and silent. The engine already
+// refuses an unknown entrypoint at this boundary, and a mode is the same kind of
+// closed vocabulary.
+//
+// An absent mode is not an unknown one. It means enforce, which is the default, so
+// it has to keep loading.
+func TestEngineRefusesAnUnknownMode(t *testing.T) {
+	const rule = "\ntrue ? [{\"action\":\"deny\",\"reason\":\"block it\"}] : []"
+	cases := []struct {
+		name     string
+		metadata string
+		wantErr  string
+		wantType string
+	}{
+		{
+			name:     "a misspelled mode",
+			metadata: "//! policy.mode = \"advsiory\"",
+			wantErr:  `invalid mode "advsiory"`,
+		},
+		{
+			name:     "a mode that is not in the vocabulary at all",
+			metadata: "//! policy.mode = \"audit\"",
+			wantErr:  `invalid mode "audit"`,
+		},
+		{
+			name:     "no mode at all",
+			metadata: "//! policy.name = \"plain\"",
+			wantType: ActionDeny,
+		},
+		{
+			name:     "an advisory mode written with padding and capitals",
+			metadata: "//! policy.mode = \"  ADVISORY  \"",
+			wantType: ActionWarn,
+		},
+		{
+			name:     "an enforce mode",
+			metadata: "//! policy.mode = \"enforce\"",
+			wantType: ActionDeny,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := Source{Name: "mode", Body: tc.metadata + rule}
+			eng, err := NewEngine([]Source{src})
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected the mode to be refused, got engine %v", eng)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error %q should name the offending mode as %q", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewEngine: %v", err)
+			}
+			actions, err := eng.EvaluateAll(t.Context(), nil, "proxy", "")
+			if err != nil {
+				t.Fatalf("EvaluateAll: %v", err)
+			}
+			if len(actions) != 1 || actions[0].Type != tc.wantType {
+				t.Fatalf("expected one %s action, got %+v", tc.wantType, actions)
+			}
+		})
 	}
 }
 

--- a/internal/policy/helper_catalog.go
+++ b/internal/policy/helper_catalog.go
@@ -96,7 +96,7 @@ var helperFunctions = []HelperFunction{
 	// Both global function and method syntax are supported:
 	//   severityAtLeast(vulnerability, "HIGH")  // global function
 	//   vulnerability.severityAtLeast("HIGH")   // method syntax
-	{Name: "severityAtLeast", Signature: "severityAtLeast(v, level) / v.severityAtLeast(level)", Doc: "Check if severity >= level. Both syntaxes supported. Order: CRITICAL > HIGH > MEDIUM > LOW."},
+	{Name: "severityAtLeast", Signature: "severityAtLeast(v, level) / v.severityAtLeast(level)", Doc: "Check if severity >= level. Both syntaxes supported. Order: CRITICAL > HIGH > MEDIUM > LOW > UNSPECIFIED. An unknown level fails evaluation."},
 	{Name: "isCritical", Signature: "isCritical(v) / v.isCritical()", Doc: "Check if CRITICAL severity. Both global and method syntax supported."},
 	{Name: "isHighOrAbove", Signature: "isHighOrAbove(v) / v.isHighOrAbove()", Doc: "Check if HIGH or CRITICAL severity. Both global and method syntax supported."},
 

--- a/internal/policy/helpers_runtime.go
+++ b/internal/policy/helpers_runtime.go
@@ -3,6 +3,7 @@ package policy
 import (
 	"context"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -581,6 +582,8 @@ func customHelperFunctions() []cel.EnvOption {
 		// Works with proto Finding messages and map-based vulnerability objects.
 		//
 		// Severity order (highest to lowest): CRITICAL > HIGH > MEDIUM > LOW > UNSPECIFIED
+		// A level outside that vocabulary fails evaluation with an error instead of
+		// silently matching every finding.
 		//
 		// Example usage in CEL (both syntaxes supported):
 		//   severityAtLeast(vulnerability, "HIGH")       // global function syntax
@@ -723,41 +726,67 @@ func customHelperFunctions() []cel.EnvOption {
 	}
 }
 
-// severityAtLeastBinding is the CEL binding for severityAtLeast function.
+// Severity ranks order severity levels for comparison. Higher is more severe,
+// and the value of each constant is its index in severityLevelNames.
+const (
+	severityRankUnspecified = iota
+	severityRankLow
+	severityRankMedium
+	severityRankHigh
+	severityRankCritical
+)
+
+// severityLevelNames is the severity vocabulary, ordered least to most severe so
+// that a name's index is its rank. It doubles as the list quoted back to policy
+// authors when they pass a level Deputy does not know.
+var severityLevelNames = []string{"UNSPECIFIED", "LOW", "MEDIUM", "HIGH", "CRITICAL"}
+
+// severityAtLeastBinding is the CEL binding for the severityAtLeast function.
+// The threshold is authored, not observed, so an unrecognized level is a
+// programming mistake in the policy: it returns a CEL error naming the valid
+// levels rather than ranking the typo below everything, which would have made
+// the comparison true for every finding.
 func severityAtLeastBinding(vulnVal, levelVal ref.Val) ref.Val {
-	threshold := strings.ToUpper(toString(levelVal))
-	actual := extractSeverityString(vulnVal)
-	return types.Bool(severityRank(actual) >= severityRank(threshold))
+	level := toString(levelVal)
+	threshold, ok := severityRank(level)
+	if !ok {
+		return types.NewErr("severityAtLeast: unknown severity level %q (expected %s)", level, strings.Join(severityLevelNames, "|"))
+	}
+	return types.Bool(findingSeverityRank(vulnVal) >= threshold)
 }
 
 // isCriticalBinding is the CEL binding for isCritical function.
 func isCriticalBinding(val ref.Val) ref.Val {
-	actual := extractSeverityString(val)
-	return types.Bool(severityRank(actual) == 4) // CRITICAL = 4
+	return types.Bool(findingSeverityRank(val) == severityRankCritical)
 }
 
 // isHighOrAboveBinding is the CEL binding for isHighOrAbove function.
 func isHighOrAboveBinding(val ref.Val) ref.Val {
-	actual := extractSeverityString(val)
-	rank := severityRank(actual)
-	return types.Bool(rank >= 3) // HIGH = 3, CRITICAL = 4
+	return types.Bool(findingSeverityRank(val) >= severityRankHigh)
 }
 
-// severityRank returns a numeric rank for severity ordering.
-// Higher rank = more severe. CRITICAL=4, HIGH=3, MEDIUM=2, LOW=1, UNSPECIFIED=0.
-func severityRank(s string) int {
-	switch strings.ToUpper(s) {
-	case "CRITICAL":
-		return 4
-	case "HIGH":
-		return 3
-	case "MEDIUM":
-		return 2
-	case "LOW":
-		return 1
-	default:
-		return 0
+// severityRank returns the ordered rank of a severity level name and whether the
+// name belongs to the known vocabulary. Matching ignores case and surrounding
+// whitespace. Callers must not collapse the false result into rank zero for
+// author-supplied levels: zero sorts below LOW, so an unknown level would
+// compare "at least" true for every finding.
+func severityRank(name string) (int, bool) {
+	idx := slices.Index(severityLevelNames, strings.ToUpper(strings.TrimSpace(name)))
+	if idx < 0 {
+		return severityRankUnspecified, false
 	}
+	return idx, true
+}
+
+// findingSeverityRank ranks the severity carried by a finding. Unlike an authored
+// threshold, observed data can legitimately be missing or carry a level Deputy
+// does not model, so it ranks as unspecified instead of failing evaluation.
+func findingSeverityRank(val ref.Val) int {
+	rank, ok := severityRank(extractSeverityString(val))
+	if !ok {
+		return severityRankUnspecified
+	}
+	return rank
 }
 
 // extractSeverityString extracts the severity level as a string from a proto Finding or map.

--- a/internal/policy/helpers_runtime.go
+++ b/internal/policy/helpers_runtime.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"cmp"
 	"context"
 	"reflect"
 	"slices"
@@ -15,6 +16,7 @@ import (
 	"github.com/temporalio/deputy/internal/purlx"
 	"github.com/temporalio/deputy/internal/vulnerability/ssvc"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 // levenshteinMaxInputLen is the maximum string length accepted by the levenshtein
@@ -726,20 +728,64 @@ func customHelperFunctions() []cel.EnvOption {
 	}
 }
 
-// Severity ranks order severity levels for comparison. Higher is more severe,
-// and the value of each constant is its index in severityLevelNames.
+// Severity ranks order severity levels for comparison. Higher is more severe.
+// They are the enum numbers of deputy.vulnerability.v1.SeverityLevel, which the
+// proto declares in ascending severity order, so ranking never needs a
+// hand-maintained copy of the level list.
 const (
-	severityRankUnspecified = iota
-	severityRankLow
-	severityRankMedium
-	severityRankHigh
-	severityRankCritical
+	severityRankUnspecified = int(vulnerabilityv1.SeverityLevel_SEVERITY_LEVEL_UNSPECIFIED)
+	severityRankHigh        = int(vulnerabilityv1.SeverityLevel_SEVERITY_LEVEL_HIGH)
+	severityRankCritical    = int(vulnerabilityv1.SeverityLevel_SEVERITY_LEVEL_CRITICAL)
 )
 
-// severityLevelNames is the severity vocabulary, ordered least to most severe so
-// that a name's index is its rank. It doubles as the list quoted back to policy
-// authors when they pass a level Deputy does not know.
-var severityLevelNames = []string{"UNSPECIFIED", "LOW", "MEDIUM", "HIGH", "CRITICAL"}
+// severityLevelPrefix is the generated enum's value prefix. Policies write the
+// bare level ("CRITICAL"), not the proto spelling.
+const severityLevelPrefix = "SEVERITY_LEVEL_"
+
+// severityLevels is the severity vocabulary derived from the generated
+// SeverityLevel descriptor.
+var severityLevels = newSeverityVocabulary()
+
+// severityVocabulary is the set of severity level names Deputy accepts, together
+// with their rank. It is built from the proto descriptor rather than written out
+// by hand so that a new or renamed enum value cannot drift away from what
+// severityAtLeast accepts or from the error message it prints.
+type severityVocabulary struct {
+	ranks map[string]int // ranks maps a bare level name to its enum number.
+	names []string       // names lists the bare level names ordered least to most severe.
+}
+
+// newSeverityVocabulary reads the SeverityLevel enum descriptor once at startup,
+// strips the generated prefix from each value, and orders the names by enum
+// number so messages read least to most severe.
+func newSeverityVocabulary() severityVocabulary {
+	values := vulnerabilityv1.SeverityLevel(0).Descriptor().Values()
+	vocab := severityVocabulary{ranks: make(map[string]int, values.Len())}
+	byRank := make([]protoreflect.EnumValueDescriptor, 0, values.Len())
+	for i := range values.Len() {
+		byRank = append(byRank, values.Get(i))
+	}
+	slices.SortFunc(byRank, func(a, b protoreflect.EnumValueDescriptor) int {
+		return cmp.Compare(a.Number(), b.Number())
+	})
+	for _, value := range byRank {
+		name := strings.TrimPrefix(string(value.Name()), severityLevelPrefix)
+		vocab.ranks[name] = int(value.Number())
+		vocab.names = append(vocab.names, name)
+	}
+	return vocab
+}
+
+// nameFor returns the bare level name for a rank, and whether the rank is one
+// the enum defines.
+func (v severityVocabulary) nameFor(rank int) (string, bool) {
+	for name, known := range v.ranks {
+		if known == rank {
+			return name, true
+		}
+	}
+	return "", false
+}
 
 // severityAtLeastBinding is the CEL binding for the severityAtLeast function.
 // The threshold is authored, not observed, so an unrecognized level is a
@@ -750,7 +796,7 @@ func severityAtLeastBinding(vulnVal, levelVal ref.Val) ref.Val {
 	level := toString(levelVal)
 	threshold, ok := severityRank(level)
 	if !ok {
-		return types.NewErr("severityAtLeast: unknown severity level %q (expected %s)", level, strings.Join(severityLevelNames, "|"))
+		return types.NewErr("severityAtLeast: unknown severity level %q (expected %s)", level, strings.Join(severityLevels.names, "|"))
 	}
 	return types.Bool(findingSeverityRank(vulnVal) >= threshold)
 }
@@ -771,11 +817,11 @@ func isHighOrAboveBinding(val ref.Val) ref.Val {
 // author-supplied levels: zero sorts below LOW, so an unknown level would
 // compare "at least" true for every finding.
 func severityRank(name string) (int, bool) {
-	idx := slices.Index(severityLevelNames, strings.ToUpper(strings.TrimSpace(name)))
-	if idx < 0 {
+	rank, ok := severityLevels.ranks[strings.ToUpper(strings.TrimSpace(name))]
+	if !ok {
 		return severityRankUnspecified, false
 	}
-	return idx, true
+	return rank, true
 }
 
 // findingSeverityRank ranks the severity carried by a finding. Unlike an authored
@@ -1214,38 +1260,22 @@ func severityLevelToString(level any) string {
 	}
 }
 
-// severityIntToString converts a severity level int to a string.
+// severityIntToString converts a severity level int to a string, reporting
+// "UNKNOWN" for a number the SeverityLevel enum does not define.
 func severityIntToString(level int32) string {
-	switch level {
-	case 0:
-		return "UNSPECIFIED"
-	case 1:
-		return "LOW"
-	case 2:
-		return "MEDIUM"
-	case 3:
-		return "HIGH"
-	case 4:
-		return "CRITICAL"
-	default:
-		return "UNKNOWN"
+	if name, ok := severityLevels.nameFor(int(level)); ok {
+		return name
 	}
+	return "UNKNOWN"
 }
 
-// severityLevelProtoToString converts a proto SeverityLevel enum to a string.
+// severityLevelProtoToString converts a proto SeverityLevel enum to its bare
+// name, falling back to UNSPECIFIED for a value this build does not know.
 func severityLevelProtoToString(level vulnerabilityv1.SeverityLevel) string {
-	switch level {
-	case vulnerabilityv1.SeverityLevel_SEVERITY_LEVEL_CRITICAL:
-		return "CRITICAL"
-	case vulnerabilityv1.SeverityLevel_SEVERITY_LEVEL_HIGH:
-		return "HIGH"
-	case vulnerabilityv1.SeverityLevel_SEVERITY_LEVEL_MEDIUM:
-		return "MEDIUM"
-	case vulnerabilityv1.SeverityLevel_SEVERITY_LEVEL_LOW:
-		return "LOW"
-	default:
-		return "UNSPECIFIED"
+	if name, ok := severityLevels.nameFor(int(level)); ok {
+		return name
 	}
+	return "UNSPECIFIED"
 }
 
 // extractImportStatus extracts the import_status field from a node.

--- a/internal/policy/helpers_severity_test.go
+++ b/internal/policy/helpers_severity_test.go
@@ -1,0 +1,114 @@
+package policy
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	vulnerabilityv1 "github.com/temporalio/deputy/gen/deputy/vulnerability/v1"
+)
+
+// findingRegistry adapts Finding protos into CEL values the way the policy
+// environment does; the default adapter cannot adapt unregistered messages.
+var findingRegistry = func() *types.Registry {
+	reg, err := types.NewRegistry(&vulnerabilityv1.Finding{})
+	if err != nil {
+		panic(err)
+	}
+	return reg
+}()
+
+// findingWithSeverity builds a CEL value for a Finding carrying the given
+// severity level, matching what policies receive at evaluation time.
+func findingWithSeverity(level vulnerabilityv1.SeverityLevel) ref.Val {
+	return findingRegistry.NativeToValue(&vulnerabilityv1.Finding{
+		Advisory: &vulnerabilityv1.Advisory{
+			Severity: &vulnerabilityv1.Severity{Level: level},
+		},
+	})
+}
+
+// TestSeverityAtLeastRejectsUnknownLevel pins that an unrecognized threshold is a
+// loud CEL error instead of a rank-zero threshold that matches every finding.
+func TestSeverityAtLeastRejectsUnknownLevel(t *testing.T) {
+	cases := []struct {
+		name    string
+		level   string
+		finding vulnerabilityv1.SeverityLevel
+		wantErr bool
+		want    bool
+	}{
+		{name: "critical threshold not met by low", level: "CRITICAL", finding: vulnerabilityv1.SeverityLevel_SEVERITY_LEVEL_LOW},
+		{name: "critical threshold met by critical", level: "CRITICAL", finding: vulnerabilityv1.SeverityLevel_SEVERITY_LEVEL_CRITICAL, want: true},
+		{name: "lowercase threshold accepted", level: "high", finding: vulnerabilityv1.SeverityLevel_SEVERITY_LEVEL_CRITICAL, want: true},
+		{name: "unspecified threshold matches anything", level: "UNSPECIFIED", finding: vulnerabilityv1.SeverityLevel_SEVERITY_LEVEL_LOW, want: true},
+		{name: "transposed letters", level: "CRITCAL", finding: vulnerabilityv1.SeverityLevel_SEVERITY_LEVEL_LOW, wantErr: true},
+		{name: "unmodeled synonym", level: "MODERATE", finding: vulnerabilityv1.SeverityLevel_SEVERITY_LEVEL_LOW, wantErr: true},
+		{name: "empty level", level: "", finding: vulnerabilityv1.SeverityLevel_SEVERITY_LEVEL_CRITICAL, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := severityAtLeastBinding(findingWithSeverity(tc.finding), types.String(tc.level))
+			if tc.wantErr {
+				err, ok := got.(*types.Err)
+				if !ok {
+					t.Fatalf("expected CEL error for level %q, got %v", tc.level, got)
+				}
+				msg := err.String()
+				for _, want := range []string{tc.level, "UNSPECIFIED|LOW|MEDIUM|HIGH|CRITICAL"} {
+					if !strings.Contains(msg, want) {
+						t.Fatalf("error %q missing %q", msg, want)
+					}
+				}
+				return
+			}
+			if got.Value() != tc.want {
+				t.Fatalf("severityAtLeast(%s, %q) = %v, want %v", tc.finding, tc.level, got.Value(), tc.want)
+			}
+		})
+	}
+}
+
+// TestSeverityAtLeastErrorSurfacesFromEvaluation pins that the CEL error reaches
+// the caller as a failed evaluation rather than being swallowed into a result.
+func TestSeverityAtLeastErrorSurfacesFromEvaluation(t *testing.T) {
+	src := `severityAtLeast(vulnerability, "CRITCAL") ? [{"action": "deny", "reason": "critical"}] : []`
+	input := map[string]any{
+		"vulnerability": &vulnerabilityv1.Finding{
+			Advisory: &vulnerabilityv1.Advisory{
+				Severity: &vulnerabilityv1.Severity{Level: vulnerabilityv1.SeverityLevel_SEVERITY_LEVEL_LOW},
+			},
+		},
+	}
+	got, err := Evaluate(t.Context(), src, input)
+	if err == nil {
+		t.Fatalf("expected evaluation error, got result %#v", got)
+	}
+	if !strings.Contains(err.Error(), "CRITCAL") {
+		t.Fatalf("error %q should name the offending level", err)
+	}
+}
+
+// TestFindingSeverityRankToleratesUnknownData pins the asymmetry: observed data
+// that lacks a severity ranks as unspecified rather than failing evaluation.
+func TestFindingSeverityRankToleratesUnknownData(t *testing.T) {
+	cases := []struct {
+		name  string
+		value ref.Val
+		want  int
+	}{
+		{name: "missing advisory", value: findingRegistry.NativeToValue(&vulnerabilityv1.Finding{}), want: severityRankUnspecified},
+		{name: "critical", value: findingWithSeverity(vulnerabilityv1.SeverityLevel_SEVERITY_LEVEL_CRITICAL), want: severityRankCritical},
+		{name: "unmodeled map level", value: types.DefaultTypeAdapter.NativeToValue(map[string]any{
+			"advisory": map[string]any{"severity": map[string]any{"level": "MODERATE"}},
+		}), want: severityRankUnspecified},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := findingSeverityRank(tc.value); got != tc.want {
+				t.Fatalf("findingSeverityRank = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/policy/helpers_severity_test.go
+++ b/internal/policy/helpers_severity_test.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -27,6 +28,53 @@ func findingWithSeverity(level vulnerabilityv1.SeverityLevel) ref.Val {
 			Severity: &vulnerabilityv1.Severity{Level: level},
 		},
 	})
+}
+
+// TestSeverityVocabularyMatchesProtoDescriptor pins that the levels
+// severityAtLeast accepts, the ranks it compares with, and the levels it names
+// in its error message all come from deputy.vulnerability.v1.SeverityLevel. A
+// level added to or renamed in the proto must not need a matching edit here.
+func TestSeverityVocabularyMatchesProtoDescriptor(t *testing.T) {
+	values := vulnerabilityv1.SeverityLevel(0).Descriptor().Values()
+	if values.Len() == 0 {
+		t.Fatal("SeverityLevel descriptor has no values")
+	}
+	if len(severityLevels.ranks) != values.Len() {
+		t.Fatalf("vocabulary has %d levels, descriptor has %d", len(severityLevels.ranks), values.Len())
+	}
+	lowFinding := findingWithSeverity(vulnerabilityv1.SeverityLevel_SEVERITY_LEVEL_LOW)
+	for i := range values.Len() {
+		value := values.Get(i)
+		name := strings.TrimPrefix(string(value.Name()), severityLevelPrefix)
+		t.Run(name, func(t *testing.T) {
+			rank, ok := severityRank(name)
+			if !ok {
+				t.Fatalf("severityRank rejects declared level %q", name)
+			}
+			if want := int(value.Number()); rank != want {
+				t.Fatalf("rank of %q = %d, want the enum number %d", name, rank, want)
+			}
+			if got := severityAtLeastBinding(lowFinding, types.String(name)); types.IsError(got) {
+				t.Fatalf("severityAtLeast rejected declared level %q: %v", name, got)
+			}
+			// The error message must quote the whole vocabulary back.
+			err := severityAtLeastBinding(lowFinding, types.String("NOT_A_LEVEL"))
+			if !strings.Contains(err.(*types.Err).String(), name) {
+				t.Fatalf("error message omits declared level %q: %v", name, err)
+			}
+		})
+	}
+}
+
+// TestSeverityRanksAreAscending pins the invariant the ranking relies on: the
+// enum declares levels from least to most severe, so its numbers order them. A
+// value inserted out of order would silently mis-rank comparisons, so it must
+// fail here instead.
+func TestSeverityRanksAreAscending(t *testing.T) {
+	want := []string{"UNSPECIFIED", "LOW", "MEDIUM", "HIGH", "CRITICAL"}
+	if !slices.Equal(severityLevels.names, want) {
+		t.Fatalf("severity levels in enum-number order = %v, want %v (a level added out of severity order breaks ordered comparisons)", severityLevels.names, want)
+	}
 }
 
 // TestSeverityAtLeastRejectsUnknownLevel pins that an unrecognized threshold is a

--- a/internal/policy/lsp/completions.go
+++ b/internal/policy/lsp/completions.go
@@ -12,9 +12,14 @@ import (
 var (
 	yamlTopKeys = []string{"policies", "metadata"}
 	policyKeys  = []string{"name", "description", "ecosystems", "entrypoints", "commands", "mode", "vars", "rules"}
-	actions     = []string{"allow", "deny", "warn"}
 	modes       = []string{"enforce", "advisory"}
 )
+
+// actions is the vocabulary offered for a rule's action field. It comes from the
+// deputy.policy.v1.ActionType descriptor by way of policy.ActionTypes, the same
+// list validation enforces, so an action added to the proto is suggested by the
+// editor as soon as it is accepted by the linter.
+var actions = policy.ActionTypes()
 
 // celVariables are the common identifiers injected into CEL environments.
 var celVariables = append([]string{}, policy.DefaultVariableNames()...)

--- a/internal/policy/lsp/completions.go
+++ b/internal/policy/lsp/completions.go
@@ -12,7 +12,6 @@ import (
 var (
 	yamlTopKeys = []string{"policies", "metadata"}
 	policyKeys  = []string{"name", "description", "ecosystems", "entrypoints", "commands", "mode", "vars", "rules"}
-	modes       = []string{"enforce", "advisory"}
 )
 
 // actions is the vocabulary offered for a rule's action field. It comes from the
@@ -20,6 +19,13 @@ var (
 // list validation enforces, so an action added to the proto is suggested by the
 // editor as soon as it is accepted by the linter.
 var actions = policy.ActionTypes()
+
+// modes is the vocabulary offered for a policy's mode field. It comes from
+// policy.Modes, the list ValidateMode accepts, so a mode Deputy gains is
+// suggested by the editor as soon as it is accepted by the linter. A copy kept
+// here drifts the moment one is added, and the editor is where an author looks to
+// find out what they may write.
+var modes = policy.Modes()
 
 // celVariables are the common identifiers injected into CEL environments.
 var celVariables = append([]string{}, policy.DefaultVariableNames()...)

--- a/internal/policy/lsp/completions_vocabulary_test.go
+++ b/internal/policy/lsp/completions_vocabulary_test.go
@@ -13,7 +13,9 @@ import (
 // derived from the deputy.policy.v1.ActionType descriptor, so a hand-kept copy
 // here would let a new proto action lint clean while the editor never offered
 // it, which is exactly the cross-surface drift the descriptor is meant to
-// prevent.
+// prevent. A policy's execution modes are the same shape of vocabulary: the
+// modes ValidateMode accepts are the modes the editor must offer, so a mode
+// added beside them fails here rather than being suggested by nothing.
 func TestCompletionVocabulariesComeFromTheValidator(t *testing.T) {
 	cases := []struct {
 		name string
@@ -29,6 +31,16 @@ func TestCompletionVocabulariesComeFromTheValidator(t *testing.T) {
 			name: "actions inside a rule item",
 			line: "  - action: ",
 			want: policy.ActionTypes(),
+		},
+		{
+			name: "modes",
+			line: "mode: ",
+			want: policy.Modes(),
+		},
+		{
+			name: "modes inside a policy item",
+			line: "    mode: ",
+			want: policy.Modes(),
 		},
 	}
 	for _, tc := range cases {

--- a/internal/policy/lsp/completions_vocabulary_test.go
+++ b/internal/policy/lsp/completions_vocabulary_test.go
@@ -1,0 +1,49 @@
+package lsp
+
+import (
+	"slices"
+	"testing"
+
+	protocol "github.com/sourcegraph/go-lsp"
+	"github.com/temporalio/deputy/internal/policy"
+)
+
+// TestCompletionVocabulariesComeFromTheValidator pins the editor's closed-set
+// suggestions to the vocabularies validation enforces. The action list is
+// derived from the deputy.policy.v1.ActionType descriptor, so a hand-kept copy
+// here would let a new proto action lint clean while the editor never offered
+// it, which is exactly the cross-surface drift the descriptor is meant to
+// prevent.
+func TestCompletionVocabulariesComeFromTheValidator(t *testing.T) {
+	cases := []struct {
+		name string
+		line string
+		want []string
+	}{
+		{
+			name: "actions",
+			line: "action: ",
+			want: policy.ActionTypes(),
+		},
+		{
+			name: "actions inside a rule item",
+			line: "  - action: ",
+			want: policy.ActionTypes(),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			items := completionItems(tc.line, len(tc.line))
+			labels := make([]string, 0, len(items))
+			for _, item := range items {
+				labels = append(labels, item.Label)
+				if item.Kind != protocol.CIKEnum {
+					t.Fatalf("completion %q kind = %v, want enum", item.Label, item.Kind)
+				}
+			}
+			if !slices.Equal(labels, tc.want) {
+				t.Fatalf("completions = %v, want %v", labels, tc.want)
+			}
+		})
+	}
+}

--- a/internal/policy/lsp/diagnostics.go
+++ b/internal/policy/lsp/diagnostics.go
@@ -30,125 +30,50 @@ type diagnosticEngine struct{}
 // newDiagnosticEngine creates a new instance of the diagnostic engine.
 func newDiagnosticEngine() *diagnosticEngine { return &diagnosticEngine{} }
 
-// analyze runs YAML parsing, structural checks, and CEL compilation.
+// analyze runs the shared policy bundle validation and renders its issues as LSP
+// diagnostics, supplying the editor's richer CEL error formatting. The checks
+// themselves live in the policy package so `deputy policy lint` and the editor
+// agree on what a valid policy is.
 func (d *diagnosticEngine) analyze(uri protocol.DocumentURI, text string) ([]protocol.Diagnostic, error) {
-	root := &yaml.Node{}
-	if err := yaml.Unmarshal([]byte(text), root); err != nil {
+	issues, err := policy.ValidateBundle(text, policy.ValidateOptions{
+		Source: string(uri),
+		CheckWhen: func(when policy.RuleWhen) []policy.Issue {
+			compileErr := policy.Compile(when.Expr, when.DeclaredVars)
+			if compileErr == nil {
+				return nil
+			}
+			knownNames := append(policy.DefaultVariableNames(), when.DeclaredVars...)
+			return []policy.Issue{celErrorIssue(when, compileErr, knownNames)}
+		},
+	})
+	if err != nil {
 		return []protocol.Diagnostic{yamlErrorToDiagnostic(uri, err)}, nil
 	}
-	diag := make([]protocol.Diagnostic, 0)
-
-	// Navigate to mapping under document.
-	if len(root.Content) == 0 {
-		return diag, nil
-	}
-	doc := root.Content[0]
-	if doc.Kind != yaml.MappingNode {
-		diag = append(diag, makeDiagnostic(uri, doc.Line, doc.Column, "root must be a mapping", protocol.Error))
-		return diag, nil
-	}
-	policiesNode := findMapValue(doc, "policies")
-	if policiesNode == nil {
-		diag = append(diag, makeDiagnostic(uri, doc.Line, doc.Column, "missing required 'policies' list", protocol.Error))
-		return diag, nil
-	}
-	if policiesNode.Kind != yaml.SequenceNode {
-		diag = append(diag, makeDiagnostic(uri, policiesNode.Line, policiesNode.Column, "'policies' must be a list", protocol.Error))
-		return diag, nil
-	}
-	seenNames := map[string]struct{}{}
-	for _, item := range policiesNode.Content {
-		if item.Kind != yaml.MappingNode {
-			diag = append(diag, makeDiagnostic(uri, item.Line, item.Column, "policy must be a mapping", protocol.Error))
-			continue
-		}
-		// name
-		nameNode := findMapValue(item, "name")
-		if nameNode != nil && nameNode.Kind == yaml.ScalarNode {
-			name := strings.TrimSpace(nameNode.Value)
-			if name != "" {
-				if _, dup := seenNames[name]; dup {
-					diag = append(diag, makeDiagnostic(uri, nameNode.Line, nameNode.Column, fmt.Sprintf("duplicate policy name %q", name), protocol.Error))
-				}
-				seenNames[name] = struct{}{}
-			}
-		}
-		// entrypoints / commands enums
-		checkListEnum := func(key string, validator func(string) bool) {
-			node := findMapValue(item, key)
-			if node == nil {
-				return
-			}
-			if node.Kind != yaml.SequenceNode {
-				diag = append(diag, makeDiagnostic(uri, node.Line, node.Column, fmt.Sprintf("'%s' must be a list", key), protocol.Error))
-				return
-			}
-			for _, v := range node.Content {
-				if v.Kind != yaml.ScalarNode {
-					diag = append(diag, makeDiagnostic(uri, v.Line, v.Column, fmt.Sprintf("'%s' items must be strings", key), protocol.Error))
-					continue
-				}
-				if !validator(v.Value) {
-					diag = append(diag, makeDiagnostic(uri, v.Line, v.Column, fmt.Sprintf("invalid %s %q", key[:len(key)-1], v.Value), protocol.Warning))
-				}
-			}
-		}
-		checkListEnum("entrypoints", policy.IsAllowedEntrypoint)
-		checkListEnum("commands", policy.IsAllowedCommand)
-
-		declaredVars := collectDeclaredVars(item)
-		knownNames := append(policy.DefaultVariableNames(), declaredVars...)
-
-		// rules
-		diag = append(diag, validateRulesNode(uri, item, declaredVars, knownNames)...)
-	}
-
-	// Compile the whole policy to ensure bundled vars/metadata are valid.
-	if _, err := policy.ParseStructuredSources([]byte(text), string(uri)); err != nil {
-		diag = append(diag, makeDiagnostic(uri, 0, 0, err.Error(), protocol.Warning))
+	diag := make([]protocol.Diagnostic, 0, len(issues))
+	for _, issue := range issues {
+		diag = append(diag, issueToDiagnostic(uri, issue))
 	}
 	return diag, nil
 }
 
-// validateRulesNode validates the rules list for a policy item and returns diagnostics.
-// It checks for the presence of a rules list, validates each rule's structure,
-// compiles CEL expressions, and checks for missing required fields.
-func validateRulesNode(uri protocol.DocumentURI, item *yaml.Node, declaredVars, knownNames []string) []protocol.Diagnostic {
-	var diag []protocol.Diagnostic
-	rulesNode := findMapValue(item, "rules")
-	if rulesNode == nil {
-		return []protocol.Diagnostic{makeDiagnostic(uri, item.Line, item.Column, "policy missing 'rules'", protocol.Error)}
+// issueToDiagnostic renders a shared validation issue as an LSP diagnostic,
+// preserving its position, width, and quick-fix code.
+func issueToDiagnostic(uri protocol.DocumentURI, issue policy.Issue) protocol.Diagnostic {
+	severity := protocol.Error
+	switch issue.Severity {
+	case policy.IssueWarning:
+		severity = protocol.Warning
+	case policy.IssueHint:
+		severity = protocol.Hint
 	}
-	if rulesNode.Kind != yaml.SequenceNode {
-		return []protocol.Diagnostic{makeDiagnostic(uri, rulesNode.Line, rulesNode.Column, "'rules' must be a list", protocol.Error)}
+	if issue.Length > 0 {
+		return diagWithRangeAndCode(uri, issue.Line, issue.Column, issue.Length, issue.Message, severity, issue.Code)
 	}
-	for _, rule := range rulesNode.Content {
-		if rule.Kind != yaml.MappingNode {
-			diag = append(diag, makeDiagnostic(uri, rule.Line, rule.Column, "rule must be a mapping", protocol.Error))
-			continue
-		}
-		whenNode := findMapValue(rule, "when")
-		if whenNode == nil || whenNode.Kind != yaml.ScalarNode {
-			diag = append(diag, diagWithCode(uri, rule.Line, rule.Column, "rule missing 'when' expression", protocol.Error, "missing-when"))
-			continue
-		}
-		// CEL compile of the when expression with location mapping.
-		if err := policy.Compile(whenNode.Value, declaredVars); err != nil {
-			diag = append(diag, celErrorDiagnostic(uri, whenNode, err, knownNames))
-		}
-		actionNode := findMapValue(rule, "action")
-		if actionNode == nil || actionNode.Kind != yaml.ScalarNode {
-			diag = append(diag, diagWithCode(uri, rule.Line, rule.Column, "rule missing 'action'", protocol.Error, "missing-action"))
-		} else {
-			if actionNode.Value == "deny" || actionNode.Value == "warn" {
-				reasonNode := findMapValue(rule, "reason")
-				if reasonNode == nil || strings.TrimSpace(reasonNode.Value) == "" {
-					diag = append(diag, diagWithRangeAndCode(uri, actionNode.Line, actionNode.Column, len(actionNode.Value), "missing 'reason' for warn/deny", protocol.Hint, "missing-reason"))
-				}
-			}
-		}
+	d := makeDiagnostic(uri, issue.Line, issue.Column, issue.Message, severity)
+	if issue.Code != "" {
+		d.Code = issue.Code
 	}
-	return diag
+	return d
 }
 
 // yamlErrorToDiagnostic converts a YAML parsing error into an LSP diagnostic.
@@ -195,14 +120,6 @@ func makeDiagnostic(_ protocol.DocumentURI, line, col int, msg string, sev proto
 	}
 }
 
-// diagWithCode creates a diagnostic with an associated error code.
-// This code is used by the code action handler to provide quick fixes.
-func diagWithCode(uri protocol.DocumentURI, line, col int, msg string, sev protocol.DiagnosticSeverity, code string) protocol.Diagnostic {
-	d := makeDiagnostic(uri, line, col, msg, sev)
-	d.Code = code
-	return d
-}
-
 // diagWithRangeAndCode creates a diagnostic with a specific length and error code.
 // It is useful for highlighting specific tokens or ranges.
 func diagWithRangeAndCode(uri protocol.DocumentURI, line, col, length int, msg string, sev protocol.DiagnosticSeverity, code string) protocol.Diagnostic {
@@ -212,9 +129,11 @@ func diagWithRangeAndCode(uri protocol.DocumentURI, line, col, length int, msg s
 	return d
 }
 
-// celErrorDiagnostic converts a CEL compilation error into an LSP diagnostic.
-// It attempts to map the error location to the specific AST node in the YAML.
-func celErrorDiagnostic(uri protocol.DocumentURI, node *yaml.Node, err error, knownNames []string) protocol.Diagnostic {
+// celErrorIssue converts a CEL compilation error into a validation issue placed
+// on the offending token. It maps the compiler's line and column back onto the
+// YAML document, widens the range to the smallest covering AST node, and adds a
+// name suggestion and source snippet the plain compiler message lacks.
+func celErrorIssue(when policy.RuleWhen, err error, knownNames []string) policy.Issue {
 	msg := err.Error()
 	lineOffset, colOffset := 0, 0
 	var parsedLine, parsedCol int
@@ -222,28 +141,28 @@ func celErrorDiagnostic(uri protocol.DocumentURI, node *yaml.Node, err error, kn
 		lineOffset = parsedLine - 1
 		colOffset = parsedCol - 1
 	}
-	line := node.Line + lineOffset
-	col := node.Column + colOffset
+	line := when.Line + lineOffset
+	col := when.Column + colOffset
 	length := 1
 	// Try to map to AST offset to widen the range (ident, select chain, call target/args)
-	if rngLen, adjustedCol := widenWithAST(node.Value, node.Column, lineOffset, colOffset); rngLen > 0 {
+	if rngLen, adjustedCol := widenWithAST(when.Expr, when.Column, lineOffset, colOffset); rngLen > 0 {
 		col = adjustedCol
 		length = rngLen
 	}
 	// Fallback to undeclared name widen
 	if length <= 1 {
 		if name := extractUndeclaredName(msg); name != "" {
-			if idx := strings.Index(node.Value, name); idx >= 0 {
-				col = node.Column + idx
+			if idx := strings.Index(when.Expr, name); idx >= 0 {
+				col = when.Column + idx
 				length = len(name)
 			}
 		}
 	}
 	// Final fallback: extend token until whitespace
 	if length <= 1 {
-		if offset := offsetFromLineCol(node.Value, lineOffset, colOffset); offset >= 0 && offset < len(node.Value) {
+		if offset := offsetFromLineCol(when.Expr, lineOffset, colOffset); offset >= 0 && offset < len(when.Expr) {
 			end := offset
-			for end < len(node.Value) && !isSpaceOrPunct(rune(node.Value[end])) {
+			for end < len(when.Expr) && !isSpaceOrPunct(rune(when.Expr[end])) {
 				end++
 			}
 			length = end - offset
@@ -255,14 +174,23 @@ func celErrorDiagnostic(uri protocol.DocumentURI, node *yaml.Node, err error, kn
 			display = fmt.Sprintf("%s (did you mean '%s'?)", display, suggestion)
 		}
 	}
-	if snippet := snippetFromCelError(node.Value, parsedLine, parsedCol, extractUndeclaredName(msg)); snippet.code != "" {
+	if snippet := snippetFromCelError(when.Expr, parsedLine, parsedCol, extractUndeclaredName(msg)); snippet.code != "" {
 		display = fmt.Sprintf("%s\n  %s\n  %s", display, snippet.code, snippet.caret)
 	}
-	d := diagWithRangeAndCode(uri, line, col, length, display, protocol.Error, "cel-error")
+	code := "cel-error"
 	if strings.Contains(msg, "undeclared reference to '") {
-		d.Code = "undeclared"
+		code = "undeclared"
 	}
-	return d
+	return policy.Issue{
+		Policy:    when.Policy,
+		RuleIndex: when.RuleIndex,
+		Line:      line,
+		Column:    col,
+		Length:    length,
+		Severity:  policy.IssueError,
+		Code:      code,
+		Message:   display,
+	}
 }
 
 // widenWithAST attempts to find the smallest AST node (ident/select/call target/arg) containing the offset and returns its length and adjusted column.
@@ -416,32 +344,9 @@ func snippetFromCelError(expr string, line, col int, hint string) snippetInfo {
 	}
 }
 
-// collectDeclaredVars returns the set of variable names declared under vars: for a policy mapping node.
-func collectDeclaredVars(policyNode *yaml.Node) []string {
-	var names []string
-	varsNode := findMapValue(policyNode, "vars")
-	if varsNode == nil || varsNode.Kind != yaml.MappingNode {
-		return names
-	}
-	for i := 0; i+1 < len(varsNode.Content); i += 2 {
-		k := varsNode.Content[i]
-		if k.Kind == yaml.ScalarNode && strings.TrimSpace(k.Value) != "" {
-			names = append(names, k.Value)
-		}
-	}
-	return names
-}
-
 // findMapValue returns the value node for the given key inside a mapping node.
+// The policy package owns the bundle's YAML shape, so this delegates rather than
+// keeping a second copy of the lookup.
 func findMapValue(mapNode *yaml.Node, key string) *yaml.Node {
-	if mapNode.Kind != yaml.MappingNode {
-		return nil
-	}
-	for i := 0; i+1 < len(mapNode.Content); i += 2 {
-		k := mapNode.Content[i]
-		if k.Kind == yaml.ScalarNode && k.Value == key {
-			return mapNode.Content[i+1]
-		}
-	}
-	return nil
+	return policy.MappingValue(mapNode, key)
 }

--- a/internal/policy/metadata.go
+++ b/internal/policy/metadata.go
@@ -1,6 +1,46 @@
 package policy
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
+
+// Mode constants are the execution modes a policy may declare.
+const (
+	// ModeEnforce lets deny actions deny. It is the default when mode is unset.
+	ModeEnforce = "enforce"
+
+	// ModeAdvisory downgrades the policy's deny actions to warnings.
+	ModeAdvisory = "advisory"
+)
+
+// Modes returns the execution modes a policy may declare, in the order used by
+// error messages. The slice is freshly allocated so callers cannot mutate the
+// vocabulary.
+func Modes() []string {
+	return []string{ModeAdvisory, ModeEnforce}
+}
+
+// NormalizeMode folds an authored mode into its canonical form by trimming and
+// lowercasing, matching the case-insensitive comparison the engine does when it
+// decides whether to downgrade denials.
+func NormalizeMode(mode string) string {
+	return strings.ToLower(strings.TrimSpace(mode))
+}
+
+// ValidateMode returns the canonical form of an authored mode, or an error
+// naming the offending value and the valid vocabulary. An unrecognized mode is
+// rejected rather than treated as enforce, because "advsiory" silently
+// enforcing is the opposite of what the author asked for.
+func ValidateMode(mode string) (string, error) {
+	normalized := NormalizeMode(mode)
+	switch normalized {
+	case ModeAdvisory, ModeEnforce:
+		return normalized, nil
+	default:
+		return "", fmt.Errorf("invalid mode %q (expected %s)", mode, strings.Join(Modes(), "|"))
+	}
+}
 
 type policyMetadata struct {
 	Name        string   // Name is the policy name extracted from metadata.

--- a/internal/policy/metadata.go
+++ b/internal/policy/metadata.go
@@ -47,7 +47,7 @@ type policyMetadata struct {
 	Entrypoints []string // Entrypoints lists the entrypoints this policy applies to.
 	Commands    []string // Commands lists the commands this policy applies to.
 	Ecosystems  []string // Ecosystems lists the ecosystems this policy applies to.
-	Mode        string   // Mode defines the execution mode (e.g., "enforce", "audit").
+	Mode        string   // Mode is the execution mode the source declares, validated when it is loaded (see declaredMode).
 }
 
 // parsePolicyMetadata reads leading `//! key = value` comments from a CEL source body.

--- a/internal/policy/source.go
+++ b/internal/policy/source.go
@@ -112,6 +112,16 @@ func BuildBundle(paths []string) (*Bundle, error) {
 	}, nil
 }
 
+// IsCompiledBundle reports whether data is a bundle produced by
+// `deputy policy bundle`. JSON is valid YAML, and a compiled bundle also has a
+// non-empty "policies" array, so callers that probe for a structured bundle must
+// rule this shape out first: its entries carry compiled CEL under "source"
+// rather than the rules an authored policy has.
+func IsCompiledBundle(data []byte) bool {
+	_, ok := tryParseBundle(data)
+	return ok
+}
+
 func tryParseBundle(data []byte) (*Bundle, bool) {
 	var b Bundle
 	if err := json.Unmarshal(data, &b); err != nil {

--- a/internal/policy/source.go
+++ b/internal/policy/source.go
@@ -82,10 +82,24 @@ func LoadSourcesFromBytes(data []byte, path string) ([]Source, error) {
 			if name == "" {
 				name = filepath.Base(path)
 			}
-			sources = append(sources, Source{
+			src := Source{
 				Name: fmt.Sprintf("%s::%s", path, name),
 				Body: p.Source,
-			})
+			}
+			// A compiled policy carries its mode and entrypoints as `//!` comments,
+			// and the authored branch below refuses a value outside either vocabulary
+			// while it expands the policy, so refusing one here is what makes loading
+			// a bundle mean the same thing in both of the formats this reads.
+			//
+			// This is the one place every reader of a compiled bundle passes through,
+			// which is why the check belongs here: each caller compiled the CEL and
+			// stopped, so `policy lint` certified a bundle declaring `advsiory` and
+			// `policy bundle` repackaged it, both of them producing an artifact
+			// NewEngine refuses to load.
+			if err := ValidateSourceMetadata(src); err != nil {
+				return nil, err
+			}
+			sources = append(sources, src)
 		}
 		return sources, nil
 	}

--- a/internal/policy/source.go
+++ b/internal/policy/source.go
@@ -53,33 +53,52 @@ func LoadSources(paths []string) ([]Source, error) {
 		if err != nil {
 			return nil, fmt.Errorf("read policy %q: %w", path, err)
 		}
-		// Try JSON bundle format first (compiled bundles)
-		if bundle, ok := tryParseBundle(data); ok {
-			for _, p := range bundle.Policies {
-				name := p.Name
-				if name == "" {
-					name = filepath.Base(path)
-				}
-				sources = append(sources, Source{
-					Name: fmt.Sprintf("%s::%s", path, name),
-					Body: p.Source,
-				})
-			}
-			continue
-		}
-		// Try structured YAML format (human-authored policies)
-		s, ok, err := tryParseStructuredBundle(data, path)
+		s, err := LoadSourcesFromBytes(data, path)
 		if err != nil {
 			return nil, err
 		}
-		if ok {
-			sources = append(sources, s...)
-			continue
-		}
-		// Neither format matched - provide helpful error
-		return nil, fmt.Errorf("%s: unrecognized policy format; expected YAML with 'policies:' key or JSON bundle with 'schemaVersion' field", path)
+		sources = append(sources, s...)
 	}
 	return sources, nil
+}
+
+// LoadSourcesFromBytes returns the policy sources data holds, trying the
+// compiled bundle format first and the authored one second, exactly as
+// LoadSources does; it is the implementation LoadSources reads files for.
+//
+// It exists for a caller that already has the bytes and no file to reread, such
+// as lint reading stdin. Sharing it is what keeps a policy supplied on stdin
+// loading the same way as the identical file, rather than each caller deciding
+// the format for itself.
+//
+// path names the source in errors and in generated source names; a caller
+// without a file may pass any label.
+func LoadSourcesFromBytes(data []byte, path string) ([]Source, error) {
+	// Try JSON bundle format first (compiled bundles)
+	if bundle, ok := tryParseBundle(data); ok {
+		sources := make([]Source, 0, len(bundle.Policies))
+		for _, p := range bundle.Policies {
+			name := p.Name
+			if name == "" {
+				name = filepath.Base(path)
+			}
+			sources = append(sources, Source{
+				Name: fmt.Sprintf("%s::%s", path, name),
+				Body: p.Source,
+			})
+		}
+		return sources, nil
+	}
+	// Try structured YAML format (human-authored policies)
+	sources, ok, err := tryParseStructuredBundle(data, path)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		return sources, nil
+	}
+	// Neither format matched - provide helpful error
+	return nil, fmt.Errorf("%s: unrecognized policy format; expected YAML with 'policies:' key or JSON bundle with 'schemaVersion' field", path)
 }
 
 // BuildBundle compiles all provided policy sources and returns a bundle structure.

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -290,10 +290,14 @@ func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 		}
 		located := validatePolicyNode(item, seenNames, opts)
 		issues = append(issues, located...)
-		// A policy the walk already located an error in is not expanded: its
+		// A policy the walk already located an error in is not expanded whole: its
 		// expansion is expected to fail too, and restating that failure in
 		// generated CEL the author never wrote would only obscure the real defect.
+		// Its vars are still compiled, since they are a defect of their own and
+		// expansion stops at the first failure, which would leave them unreported
+		// until the located one is fixed and lint rerun.
 		if slices.ContainsFunc(located, func(is Issue) bool { return is.Severity == IssueError }) {
+			issues = append(issues, varExpansionIssues(item, opts.ExtraVars)...)
 			continue
 		}
 		issues = append(issues, expandedPolicyIssues(item, source, opts.ExtraVars, located)...)
@@ -345,6 +349,36 @@ func expandedPolicyIssues(item *yaml.Node, source string, extraVars []string, lo
 	if err := Compile(body, extraVars); err != nil {
 		issue := issueAt(item, IssueError, "cel-error", err.Error())
 		issue.Policy = pol.Name
+		return []Issue{issue}
+	}
+	return nil
+}
+
+// varExpansionIssues reports the vars of one policy that do not compile. It
+// exists for the policy the walk already found an error in, which is not
+// expanded whole: expansion stops at its first failure, so a rule the walk has
+// already reported would hide an uncompilable var behind it and hand the author
+// the var only after the rule is fixed. Wrapping an empty body in the policy's
+// vars asks the one question the located issue leaves open.
+//
+// It reports only what nothing else owns. A policy that does not decode, and a
+// var name that is empty or duplicated, are already reported by the walk, so
+// neither is restated here.
+func varExpansionIssues(item *yaml.Node, extraVars []string) []Issue {
+	var pol structuredPolicy
+	if err := item.Decode(&pol); err != nil {
+		return nil
+	}
+	if len(pol.Vars) == 0 {
+		return nil
+	}
+	body, err := pol.wrapVars("[]")
+	if err != nil {
+		return nil
+	}
+	if err := Compile(body, extraVars); err != nil {
+		issue := issueAt(item, IssueError, "cel-error", err.Error())
+		issue.Policy = strings.TrimSpace(pol.Name)
 		return []Issue{issue}
 	}
 	return nil

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -575,10 +575,10 @@ func DeclaredVarNames(policyNode *yaml.Node) []string {
 }
 
 // MappingValue returns the value node for a key inside a YAML mapping node, or
-// nil when the node is not a mapping or the key is absent. It reads only what
-// the document says: anchors, aliases, and merge keys are rejected (see
-// anchorIssues) and the nodes carrying them are skipped, so no reader has to
-// resolve them.
+// nil when the node is not a mapping, the key is absent, or the key is present
+// with an explicitly null value. It reads only what the document says: anchors,
+// aliases, and merge keys are rejected (see anchorIssues) and the nodes carrying
+// them are skipped, so no reader has to resolve them.
 func MappingValue(mapNode *yaml.Node, key string) *yaml.Node {
 	if mapNode == nil || mapNode.Kind != yaml.MappingNode {
 		return nil
@@ -586,10 +586,25 @@ func MappingValue(mapNode *yaml.Node, key string) *yaml.Node {
 	for i := 0; i+1 < len(mapNode.Content); i += 2 {
 		k := mapNode.Content[i]
 		if k.Kind == yaml.ScalarNode && k.Value == key {
+			if isNullNode(mapNode.Content[i+1]) {
+				return nil
+			}
 			return mapNode.Content[i+1]
 		}
 	}
 	return nil
+}
+
+// isNullNode reports whether a value node is YAML's null: `key: null`, `key: ~`,
+// and a key written with no value at all all resolve to the !!null tag. The
+// decoder leaves the corresponding Go field at its zero value, which for every
+// optional field of a policy is indistinguishable from the field being absent,
+// so the node walk has to read a null the same way. Without this it reports
+// `mode: null` as an invalid mode and `entrypoints: null` as a malformed list
+// for a bundle the loader accepts, and treats the literal text "null" as a
+// policy name two such policies would then collide on.
+func isNullNode(node *yaml.Node) bool {
+	return node != nil && node.Kind == yaml.ScalarNode && node.Tag == "!!null"
 }
 
 // isMergeKey reports whether a mapping key is YAML's merge key, the "<<" that

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -157,7 +157,18 @@ const bundlePoliciesKey = "policies"
 // of a document, in raw text. It is deliberately a last resort: YAML that parses
 // is always probed by walking its nodes, and this runs only for a document the
 // parser rejected outright, where no structure is available to walk.
-var unparsedBundleKey = regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(bundlePoliciesKey) + `[ \t]*:`)
+var unparsedBundleKey = regexp.MustCompile(`(?m)^` + yamlKeyPattern(bundlePoliciesKey) + `[ \t]*:`)
+
+// yamlKeyPattern returns a regexp fragment matching a YAML mapping key in each
+// of the three ways a document can spell it: bare, single-quoted, and
+// double-quoted. All three name the same key, so raw text that recognized only
+// the bare form would dismiss a quoted bundle as an unknown format instead of
+// reporting the syntax error the author needs pointed at a line. The key is
+// escaped, so it is matched literally.
+func yamlKeyPattern(key string) string {
+	quoted := regexp.QuoteMeta(key)
+	return `(?:` + quoted + `|'` + quoted + `'|"` + quoted + `")`
+}
 
 // writesBundleKey reports whether raw text writes the bundle's policies key at
 // the top level, which is how a document the YAML parser rejected is still

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	yaml "gopkg.in/yaml.v3"
@@ -108,16 +109,35 @@ type ValidateOptions struct {
 	CheckWhen func(RuleWhen) []Issue
 }
 
+// LooksLikeStructuredBundle reports whether data has the shape of an authored
+// policy bundle: a mapping carrying a non-empty "policies" list. It deliberately
+// does not require the bundle to decode into Deputy's types, so a policy with a
+// mistyped field is still recognized as a policy and can be reported with
+// located, specific errors instead of being dismissed as an unknown format.
+// Compiled bundles are ruled out first: their JSON has a "policies" array too.
+func LooksLikeStructuredBundle(data []byte) bool {
+	if IsCompiledBundle(data) {
+		return false
+	}
+	root := &yaml.Node{}
+	if err := yaml.Unmarshal(data, root); err != nil || len(root.Content) == 0 {
+		return false
+	}
+	policies := MappingValue(root.Content[0], "policies")
+	return policies != nil && policies.Kind == yaml.SequenceNode && len(policies.Content) > 0
+}
+
 // ValidateBundle reports every structural problem in a structured policy bundle:
 // unknown entrypoints, commands and actions, duplicate policy names, malformed
 // rules, and conditions that do not compile. It is the one implementation behind
 // both `deputy policy lint` and the editor's diagnostics, so a policy that lints
 // clean is a policy the editor considers clean.
 //
-// It returns an error only when the text is not YAML at all; every other problem
-// comes back as an Issue so callers can report them all at once. Loading the
-// bundle is the last resort check, reported only when nothing more precise was
-// found, because a load failure repeats what the located issues already say.
+// It returns an error only when the text is not YAML at all, or is a compiled
+// bundle rather than an authored one; every other problem comes back as an Issue
+// so callers can report them all at once. A bundle that does not decode into
+// Deputy's types is still validated: the node walk reports what it can locate
+// and the decode failure is added on top.
 func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 	if IsCompiledBundle([]byte(text)) {
 		return nil, errors.New("compiled policy bundle: validate the authored policies it was built from")
@@ -151,12 +171,19 @@ func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 	}
 	// Load the whole bundle as a backstop for shapes the node walk does not model,
 	// such as a rule field of the wrong type. The loader stops at its first
-	// failure and cannot point at a line, so its message is dropped when a located
-	// issue already reports the same thing.
+	// failure, so its message is dropped when a located issue already reports the
+	// same thing, and is anchored on the line it names when it names one.
 	source := cmp.Or(opts.Source, "policy")
 	if _, err := ParseStructuredSources([]byte(text), source); err != nil {
 		if message, duplicate := loaderMessage(err, source, issues); !duplicate {
-			issues = append(issues, Issue{RuleIndex: NoRule, Severity: IssueWarning, Code: "bundle-error", Message: message})
+			issues = append(issues, Issue{
+				RuleIndex: NoRule,
+				Line:      lineFromYAMLError(message),
+				Column:    1,
+				Severity:  IssueWarning,
+				Code:      "bundle-error",
+				Message:   message,
+			})
 		}
 	}
 	return issues, nil
@@ -386,6 +413,26 @@ func loaderMessage(err error, source string, located []Issue) (string, bool) {
 		}
 	}
 	return message, false
+}
+
+// lineFromYAMLError returns the 1-based line a YAML decode error names, or zero
+// when it names none. The decoder reports type mismatches as "line N: cannot
+// unmarshal ...", which is the only position information available for a field
+// the node walk does not model.
+func lineFromYAMLError(message string) int {
+	_, after, ok := strings.Cut(message, "line ")
+	if !ok {
+		return 0
+	}
+	digits := after
+	if idx := strings.IndexFunc(after, func(r rune) bool { return r < '0' || r > '9' }); idx >= 0 {
+		digits = after[:idx]
+	}
+	line, err := strconv.Atoi(digits)
+	if err != nil || line < 1 {
+		return 0
+	}
+	return line
 }
 
 // issueAt builds an issue anchored at a YAML node.

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -1,0 +1,344 @@
+package policy
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+	"strings"
+
+	yaml "gopkg.in/yaml.v3"
+)
+
+// IssueSeverity says how loudly a validation issue should be reported. It maps
+// onto LSP diagnostic severities and onto lint's pass/fail decision: errors and
+// warnings fail a lint run, hints are advice.
+type IssueSeverity int
+
+const (
+	// IssueError marks a bundle that cannot be loaded or a rule that cannot do
+	// what it says.
+	IssueError IssueSeverity = iota
+
+	// IssueWarning marks a value Deputy does not recognize, so the surrounding
+	// policy will not behave as written.
+	IssueWarning
+
+	// IssueHint marks authoring advice that does not change behavior.
+	IssueHint
+)
+
+// String returns the lowercase label used in lint output.
+func (s IssueSeverity) String() string {
+	switch s {
+	case IssueError:
+		return "error"
+	case IssueWarning:
+		return "warning"
+	case IssueHint:
+		return "hint"
+	default:
+		return "unknown"
+	}
+}
+
+// NoRule is the RuleIndex of an issue that is not scoped to a single rule.
+const NoRule = -1
+
+// Issue is one problem found while validating a policy bundle. Positions are
+// 1-based as YAML reports them, and are zero when the issue cannot be tied to a
+// specific node. Code is a stable identifier editors use to offer quick fixes.
+type Issue struct {
+	Policy    string        // Policy is the name of the offending policy, empty when unnamed or bundle-wide.
+	RuleIndex int           // RuleIndex is the 0-based rule position, or NoRule.
+	Line      int           // Line is the 1-based line of the offending node.
+	Column    int           // Column is the 1-based column of the offending node.
+	Length    int           // Length is the width of the offending token, 0 when unknown.
+	Severity  IssueSeverity // Severity says how loudly to report the issue.
+	Code      string        // Code is a stable machine-readable identifier.
+	Message   string        // Message is the human-readable description.
+}
+
+// String renders the issue as "line:col: severity: policy rule: message" for
+// command-line output. Callers prefix it with the file being linted. The
+// location comes first so the line stays greppable and the message last so
+// multi-line compiler output (a snippet with a caret) still reads correctly.
+func (i Issue) String() string {
+	var b strings.Builder
+	if i.Line > 0 {
+		fmt.Fprintf(&b, "%d:%d: ", i.Line, i.Column)
+	}
+	fmt.Fprintf(&b, "%s: ", i.Severity)
+	switch {
+	case i.Policy != "" && i.RuleIndex >= 0:
+		fmt.Fprintf(&b, "policy %q rule[%d]: ", i.Policy, i.RuleIndex)
+	case i.Policy != "":
+		fmt.Fprintf(&b, "policy %q: ", i.Policy)
+	case i.RuleIndex >= 0:
+		fmt.Fprintf(&b, "rule[%d]: ", i.RuleIndex)
+	}
+	b.WriteString(i.Message)
+	return b.String()
+}
+
+// RuleWhen describes a rule's `when` expression and the names in scope for it,
+// so a caller can compile the expression with its own error rendering.
+type RuleWhen struct {
+	Policy       string   // Policy is the name of the policy that owns the rule.
+	RuleIndex    int      // RuleIndex is the 0-based rule position.
+	Expr         string   // Expr is the CEL source of the condition.
+	Line         int      // Line is the 1-based line where the expression starts.
+	Column       int      // Column is the 1-based column where the expression starts.
+	DeclaredVars []string // DeclaredVars are the policy vars plus any caller-supplied extras.
+}
+
+// ValidateOptions tunes bundle validation for a particular surface.
+type ValidateOptions struct {
+	// Source names the bundle in messages that come from loading it, such as a
+	// file path or a document URI. It defaults to "policy".
+	Source string
+
+	// ExtraVars are variable names the caller declares out of band, such as
+	// lint's --var flag.
+	ExtraVars []string
+
+	// CheckWhen validates a rule condition. It is called in document order so
+	// issues stay sorted by position. When nil, conditions are compiled with
+	// Compile and reported with the raw compiler message; surfaces with richer
+	// error rendering (the editor, the linter) supply their own.
+	CheckWhen func(RuleWhen) []Issue
+}
+
+// ValidateBundle reports every structural problem in a structured policy bundle:
+// unknown entrypoints, commands and actions, duplicate policy names, malformed
+// rules, and conditions that do not compile. It is the one implementation behind
+// both `deputy policy lint` and the editor's diagnostics, so a policy that lints
+// clean is a policy the editor considers clean.
+//
+// It returns an error only when the text is not YAML at all; every other problem
+// comes back as an Issue so callers can report them all at once. Loading the
+// bundle is the last resort check, reported only when nothing more precise was
+// found, because a load failure repeats what the located issues already say.
+func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
+	root := &yaml.Node{}
+	if err := yaml.Unmarshal([]byte(text), root); err != nil {
+		return nil, fmt.Errorf("parse policy YAML: %w", err)
+	}
+	issues := make([]Issue, 0)
+	if len(root.Content) == 0 {
+		return issues, nil
+	}
+	doc := root.Content[0]
+	if doc.Kind != yaml.MappingNode {
+		return append(issues, issueAt(doc, IssueError, "root-not-mapping", "root must be a mapping")), nil
+	}
+	policiesNode := MappingValue(doc, "policies")
+	if policiesNode == nil {
+		return append(issues, issueAt(doc, IssueError, "missing-policies", "missing required 'policies' list")), nil
+	}
+	if policiesNode.Kind != yaml.SequenceNode {
+		return append(issues, issueAt(policiesNode, IssueError, "policies-not-list", "'policies' must be a list")), nil
+	}
+	seenNames := map[string]struct{}{}
+	for _, item := range policiesNode.Content {
+		if item.Kind != yaml.MappingNode {
+			issues = append(issues, issueAt(item, IssueError, "policy-not-mapping", "policy must be a mapping"))
+			continue
+		}
+		issues = append(issues, validatePolicyNode(item, seenNames, opts)...)
+	}
+	// Load the whole bundle so problems the node walk does not model (mode, vars,
+	// empty rule lists) are still reported, but only when nothing located said it
+	// first: the loader stops at the first failure and cannot point at a line.
+	if slices.ContainsFunc(issues, func(i Issue) bool { return i.Severity != IssueHint }) {
+		return issues, nil
+	}
+	source := cmp.Or(opts.Source, "policy")
+	if _, err := ParseStructuredSources([]byte(text), source); err != nil {
+		issues = append(issues, Issue{RuleIndex: NoRule, Severity: IssueWarning, Code: "bundle-error", Message: err.Error()})
+	}
+	return issues, nil
+}
+
+// validatePolicyNode checks one policy mapping: its name uniqueness, its
+// entrypoint and command vocabularies, and its rules. seenNames accumulates
+// across the bundle so duplicates are reported on the second occurrence.
+func validatePolicyNode(item *yaml.Node, seenNames map[string]struct{}, opts ValidateOptions) []Issue {
+	var issues []Issue
+	name := ""
+	nameNode := MappingValue(item, "name")
+	if nameNode != nil && nameNode.Kind == yaml.ScalarNode {
+		name = strings.TrimSpace(nameNode.Value)
+		if name != "" {
+			if _, dup := seenNames[name]; dup {
+				issues = append(issues, issueAt(nameNode, IssueError, "duplicate-policy", fmt.Sprintf("duplicate policy name %q", name)))
+			}
+			seenNames[name] = struct{}{}
+		}
+	}
+	issues = append(issues, validateListEnum(item, "entrypoints", IsAllowedEntrypoint)...)
+	issues = append(issues, validateListEnum(item, "commands", IsAllowedCommand)...)
+
+	declaredVars := DeclaredVarNames(item)
+	issues = append(issues, validateRules(item, name, append(declaredVars, opts.ExtraVars...), opts.CheckWhen)...)
+	for i := range issues {
+		if issues[i].Policy == "" {
+			issues[i].Policy = name
+		}
+	}
+	return issues
+}
+
+// validateListEnum checks that every entry of a string-list field belongs to a
+// closed vocabulary. An unknown entry is a warning rather than an error because
+// the bundle still loads: the policy just never matches what the author meant.
+func validateListEnum(item *yaml.Node, key string, allowed func(string) bool) []Issue {
+	node := MappingValue(item, key)
+	if node == nil {
+		return nil
+	}
+	if node.Kind != yaml.SequenceNode {
+		return []Issue{issueAt(node, IssueError, key+"-not-list", fmt.Sprintf("'%s' must be a list", key))}
+	}
+	singular := strings.TrimSuffix(key, "s")
+	var issues []Issue
+	for _, v := range node.Content {
+		if v.Kind != yaml.ScalarNode {
+			issues = append(issues, issueAt(v, IssueError, key+"-not-strings", fmt.Sprintf("'%s' items must be strings", key)))
+			continue
+		}
+		if !allowed(v.Value) {
+			issues = append(issues, issueAt(v, IssueWarning, "invalid-"+singular, fmt.Sprintf("invalid %s %q", singular, v.Value)))
+		}
+	}
+	return issues
+}
+
+// validateRules checks the rules list of a policy: every rule needs a condition
+// that compiles and an action from the known vocabulary, and a rule that denies
+// or warns should say why.
+func validateRules(item *yaml.Node, policyName string, declaredVars []string, checkWhen func(RuleWhen) []Issue) []Issue {
+	rulesNode := MappingValue(item, "rules")
+	if rulesNode == nil {
+		return []Issue{issueAt(item, IssueError, "missing-rules", "policy missing 'rules'")}
+	}
+	if rulesNode.Kind != yaml.SequenceNode {
+		return []Issue{issueAt(rulesNode, IssueError, "rules-not-list", "'rules' must be a list")}
+	}
+	var issues []Issue
+	for idx, rule := range rulesNode.Content {
+		if rule.Kind != yaml.MappingNode {
+			issues = append(issues, ruleIssue(idx, issueAt(rule, IssueError, "rule-not-mapping", "rule must be a mapping")))
+			continue
+		}
+		whenNode := MappingValue(rule, "when")
+		if whenNode == nil || whenNode.Kind != yaml.ScalarNode {
+			issues = append(issues, ruleIssue(idx, issueAt(rule, IssueError, "missing-when", "rule missing 'when' expression")))
+			continue
+		}
+		for _, issue := range checkRuleWhen(checkWhen, RuleWhen{
+			Policy:       policyName,
+			RuleIndex:    idx,
+			Expr:         whenNode.Value,
+			Line:         whenNode.Line,
+			Column:       whenNode.Column,
+			DeclaredVars: declaredVars,
+		}) {
+			issues = append(issues, ruleIssue(idx, issue))
+		}
+		issues = append(issues, validateRuleAction(rule, idx)...)
+	}
+	return issues
+}
+
+// validateRuleAction checks a rule's action against the allow/deny/warn
+// vocabulary and nudges deny/warn rules to carry a reason.
+func validateRuleAction(rule *yaml.Node, idx int) []Issue {
+	actionNode := MappingValue(rule, "action")
+	if actionNode == nil || actionNode.Kind != yaml.ScalarNode {
+		return []Issue{ruleIssue(idx, issueAt(rule, IssueError, "missing-action", "rule missing 'action'"))}
+	}
+	action, err := ValidateActionType(actionNode.Value)
+	if err != nil {
+		issue := issueAt(actionNode, IssueError, "invalid-action", err.Error())
+		issue.Length = len(actionNode.Value)
+		return []Issue{ruleIssue(idx, issue)}
+	}
+	if action != ActionDeny && action != ActionWarn {
+		return nil
+	}
+	reasonNode := MappingValue(rule, "reason")
+	if reasonNode != nil && strings.TrimSpace(reasonNode.Value) != "" {
+		return nil
+	}
+	issue := issueAt(actionNode, IssueHint, "missing-reason", "missing 'reason' for warn/deny")
+	issue.Length = len(actionNode.Value)
+	return []Issue{ruleIssue(idx, issue)}
+}
+
+// checkRuleWhen runs the caller's condition check, falling back to a plain
+// Compile so every surface validates conditions even without custom rendering.
+func checkRuleWhen(checkWhen func(RuleWhen) []Issue, when RuleWhen) []Issue {
+	if checkWhen != nil {
+		return checkWhen(when)
+	}
+	if err := Compile(when.Expr, when.DeclaredVars); err != nil {
+		return []Issue{{
+			RuleIndex: when.RuleIndex,
+			Line:      when.Line,
+			Column:    when.Column,
+			Severity:  IssueError,
+			Code:      "cel-error",
+			Message:   err.Error(),
+		}}
+	}
+	return nil
+}
+
+// issueAt builds an issue anchored at a YAML node.
+func issueAt(node *yaml.Node, severity IssueSeverity, code, message string) Issue {
+	issue := Issue{RuleIndex: NoRule, Severity: severity, Code: code, Message: message}
+	if node != nil {
+		issue.Line = node.Line
+		issue.Column = node.Column
+	}
+	return issue
+}
+
+// ruleIssue tags an issue with the rule it came from.
+func ruleIssue(idx int, issue Issue) Issue {
+	issue.RuleIndex = idx
+	return issue
+}
+
+// DeclaredVarNames returns the variable names declared under a policy node's
+// vars mapping, in author order. Callers use it to declare those names before
+// compiling the policy's conditions.
+func DeclaredVarNames(policyNode *yaml.Node) []string {
+	var names []string
+	varsNode := MappingValue(policyNode, "vars")
+	if varsNode == nil || varsNode.Kind != yaml.MappingNode {
+		return names
+	}
+	for i := 0; i+1 < len(varsNode.Content); i += 2 {
+		k := varsNode.Content[i]
+		if k.Kind == yaml.ScalarNode && strings.TrimSpace(k.Value) != "" {
+			names = append(names, k.Value)
+		}
+	}
+	return names
+}
+
+// MappingValue returns the value node for a key inside a YAML mapping node, or
+// nil when the node is not a mapping or the key is absent.
+func MappingValue(mapNode *yaml.Node, key string) *yaml.Node {
+	if mapNode == nil || mapNode.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(mapNode.Content); i += 2 {
+		k := mapNode.Content[i]
+		if k.Kind == yaml.ScalarNode && k.Value == key {
+			return mapNode.Content[i+1]
+		}
+	}
+	return nil
+}

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -2,6 +2,7 @@ package policy
 
 import (
 	"cmp"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -119,6 +120,9 @@ type ValidateOptions struct {
 // bundle is the last resort check, reported only when nothing more precise was
 // found, because a load failure repeats what the located issues already say.
 func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
+	if IsCompiledBundle([]byte(text)) {
+		return nil, errors.New("compiled policy bundle: validate the authored policies it was built from")
+	}
 	root := &yaml.Node{}
 	if err := yaml.Unmarshal([]byte(text), root); err != nil {
 		return nil, fmt.Errorf("parse policy YAML: %w", err)

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -425,20 +425,35 @@ func expandedPolicyIssues(item *yaml.Node, source string, extraVars []string, lo
 // failure outright is not the same thing. It withheld any var-shape defect the
 // walk does not model, and left the one it does to a bundle-wide backstop that an
 // unrelated located error stops before it runs.
+//
+// A name the policy cannot bind is reported and then set aside, so the vars
+// beneath it are still compiled. It is the defect of one var, and stopping at it
+// asked about the vars only in a policy whose every name is already right, which
+// cost the author a lint run per mistyped name. Setting one aside is not
+// forgiving it: the name is reported here, the walk locates it as an error of its
+// own, and every reader that runs the policy refuses it outright.
 func varCompileIssues(pol structuredPolicy, item *yaml.Node, source string, extraVars []string, located []Issue) []Issue {
 	if len(pol.Vars) == 0 {
 		return nil
 	}
+	bound, unbindable := pol.Vars.bindable()
+	var issues []Issue
+	for _, err := range unbindable {
+		issues = append(issues, backstopIssue(fmt.Errorf("%s/%s: %w", source, pol.Name, err), source, item, located)...)
+	}
+	// pol is a copy, so narrowing its vars to the ones the policy can bind asks
+	// the compiler about exactly the names the expansion would put in scope.
+	pol.Vars = bound
 	body, err := pol.wrapVars("[]")
 	if err != nil {
-		return backstopIssue(fmt.Errorf("%s/%s: %w", source, pol.Name, err), source, item, located)
+		return append(issues, backstopIssue(fmt.Errorf("%s/%s: %w", source, pol.Name, err), source, item, located)...)
 	}
 	if err := Compile(body, extraVars); err != nil {
 		issue := issueAt(item, IssueError, "cel-error", err.Error())
 		issue.Policy = strings.TrimSpace(pol.Name)
-		return []Issue{issue}
+		issues = append(issues, issue)
 	}
-	return nil
+	return issues
 }
 
 // backstopIssue renders a load failure as an issue, or nothing when a located
@@ -551,11 +566,11 @@ func validateVars(item *yaml.Node) []Issue {
 		key := node.Content[i]
 		name := varKeyName(key)
 		if name == "" {
-			issues = append(issues, issueAt(key, IssueError, "empty-var-name", "vars must have non-empty names"))
+			issues = append(issues, issueAt(key, IssueError, "empty-var-name", emptyVarNameMessage))
 			continue
 		}
 		if _, dup := seen[name]; dup {
-			issues = append(issues, issueAt(key, IssueError, "duplicate-var", fmt.Sprintf("duplicate var name %q", name)))
+			issues = append(issues, issueAt(key, IssueError, "duplicate-var", fmt.Sprintf(duplicateVarNameFormat, name)))
 		}
 		seen[name] = struct{}{}
 	}

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -432,28 +432,44 @@ func expandedPolicyIssues(item *yaml.Node, source string, extraVars []string, lo
 // cost the author a lint run per mistyped name. Setting one aside is not
 // forgiving it: the name is reported here, the walk locates it as an error of its
 // own, and every reader that runs the policy refuses it outright.
+//
+// The expression such a var holds is still asked about too, in the scope it would
+// have been evaluated in, which is the vars bound above it. A name that binds
+// nothing says nothing about the expression beside it, and withholding it made the
+// author fix the name to be told the value was wrong as well.
 func varCompileIssues(pol structuredPolicy, item *yaml.Node, source string, extraVars []string, located []Issue) []Issue {
 	if len(pol.Vars) == 0 {
 		return nil
 	}
-	bound, unbindable := pol.Vars.bindable()
-	var issues []Issue
-	for _, err := range unbindable {
-		issues = append(issues, backstopIssue(fmt.Errorf("%s/%s: %w", source, pol.Name, err), source, item, located)...)
+	var (
+		issues []Issue
+		bound  orderedVars
+	)
+	for _, binding := range pol.Vars.bindings() {
+		if binding.err == nil {
+			bound = append(bound, binding.kv)
+			continue
+		}
+		issues = append(issues, backstopIssue(fmt.Errorf("%s/%s: %w", source, pol.Name, binding.err), source, item, located)...)
+		issues = append(issues, celIssues(nestVars(binding.scope, binding.kv.exprString()), extraVars, item, pol.Name)...)
 	}
-	// pol is a copy, so narrowing its vars to the ones the policy can bind asks
-	// the compiler about exactly the names the expansion would put in scope.
-	pol.Vars = bound
-	body, err := pol.wrapVars("[]")
-	if err != nil {
-		return append(issues, backstopIssue(fmt.Errorf("%s/%s: %w", source, pol.Name, err), source, item, located)...)
+	// The vars that do bind are compiled as one nest, since each is in scope for
+	// the next, and wrapping an empty body asks about them and nothing else.
+	return append(issues, celIssues(nestVars(bound, "[]"), extraVars, item, pol.Name)...)
+}
+
+// celIssues reports generated CEL that does not compile as an issue anchored on the
+// policy node. It is the one place validation renders a compiler failure over CEL
+// the author did not write, so the vars a policy binds and the expression of one it
+// cannot bind are reported the same way.
+func celIssues(body string, extraVars []string, item *yaml.Node, policyName string) []Issue {
+	err := Compile(body, extraVars)
+	if err == nil {
+		return nil
 	}
-	if err := Compile(body, extraVars); err != nil {
-		issue := issueAt(item, IssueError, "cel-error", err.Error())
-		issue.Policy = strings.TrimSpace(pol.Name)
-		issues = append(issues, issue)
-	}
-	return issues
+	issue := issueAt(item, IssueError, "cel-error", err.Error())
+	issue.Policy = policyName
+	return []Issue{issue}
 }
 
 // backstopIssue renders a load failure as an issue, or nothing when a located

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -296,12 +296,17 @@ func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 	// on its own and adds only what is not already reported. It is the decode
 	// alone: routing it through the loader would stop at the loader's refusal of
 	// an anchor this run has already located and named a line for, and hide the
-	// bundle-level shape behind it. A document that says part of itself elsewhere
-	// is skipped, since the decoder would resolve what no reader of a bundle may.
-	if !resolvesElsewhere(root) {
-		if _, _, err := decodeStructuredBundle([]byte(text), source, true); err != nil {
-			issues = append(issues, backstopIssue(err, source, doc, issues)...)
-		}
+	// bundle-level shape behind it.
+	//
+	// A document that says part of itself elsewhere is decoded too, references and
+	// all. The decoder resolves what no reader of a bundle may, which is why
+	// nothing here acts on the resolved value, but it is still the only reader that
+	// can find these shapes, and an anchor is defined in the document it is used
+	// in, so every line it names is a line the author wrote. Skipping it let one
+	// alias withhold every bundle-level shape in the file until the alias was
+	// removed and lint rerun.
+	if _, _, err := decodeStructuredBundle([]byte(text), source, true); err != nil {
+		issues = append(issues, backstopIssue(err, source, doc, issues)...)
 	}
 	return issues, nil
 }

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -270,11 +270,12 @@ func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 	seenNames := map[string]struct{}{}
 	source := cmp.Or(opts.Source, "policy")
 	for _, item := range policiesNode.Content {
-		// Skip a policy that carries an anchor, an alias, or a merge key anywhere
-		// beneath it: it is already reported, and every further message the walk
-		// could produce would describe the alias node rather than the policy the
-		// author meant. Plain policies alongside it are still checked.
-		if len(anchorIssues(item)) > 0 {
+		// Skip a policy the walk cannot read: an alias or a merge key beneath it
+		// puts part of the policy somewhere else, so every further message would
+		// describe the reference rather than the policy the author meant. Both are
+		// already reported. An anchor definition is not a reference, so a policy
+		// carrying one says what it says and is checked like any other.
+		if resolvesElsewhere(item) {
 			continue
 		}
 		if item.Kind != yaml.MappingNode {
@@ -322,8 +323,9 @@ func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 // restates one of those is dropped and a single mistake stays a single issue.
 func expandedPolicyIssues(item *yaml.Node, source string, extraVars []string, located []Issue) []Issue {
 	var pol structuredPolicy
-	// Decoding resolves aliases, which the format refuses; that is safe here
-	// because a policy carrying one anywhere beneath it never reaches this point.
+	// Decoding resolves aliases and merge keys, which the format refuses; that is
+	// safe here because a policy carrying one anywhere beneath it never reaches
+	// this point, so the decoder reads only what the policy itself writes.
 	if err := item.Decode(&pol); err != nil {
 		return backstopIssue(fmt.Errorf("%s: %w", source, err), source, item, located)
 	}
@@ -730,6 +732,36 @@ func anchorIssues(node *yaml.Node) []Issue {
 		issues = append(issues, anchorIssues(child)...)
 	}
 	return issues
+}
+
+// resolvesElsewhere reports whether a node says part of what it means somewhere
+// other than where it is written: a YAML alias, whose value lives at the anchor
+// it names, or a merge key, which pulls another mapping's entries in. Deputy
+// refuses both (see anchorIssues), so no reader resolves them, and a walk that
+// cannot follow them can only describe the reference rather than the value.
+// Nodes carrying one are therefore skipped by the checks that read a document's
+// values.
+//
+// An anchor definition is not a reference: `description: &text foo` says foo
+// right where a reader looks for it. It is still refused, but every other check
+// around it reads what the author wrote and reports in the same pass, so the
+// refusal costs no extra lint run.
+func resolvesElsewhere(node *yaml.Node) bool {
+	if node == nil {
+		return false
+	}
+	if node.Kind == yaml.AliasNode {
+		return true
+	}
+	for i, child := range node.Content {
+		if node.Kind == yaml.MappingNode && i%2 == 0 && isMergeKey(child) {
+			return true
+		}
+		if resolvesElsewhere(child) {
+			return true
+		}
+	}
+	return false
 }
 
 // bundleAnchorError reports the first anchor, alias, or merge key in data as an

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -389,7 +389,7 @@ func expandedPolicyIssues(item *yaml.Node, source string, extraVars []string, lo
 	// still worth asking about.
 	decodeErr := item.Decode(&pol)
 	pol.Name = strings.TrimSpace(pol.Name)
-	issues := varCompileIssues(pol, item, extraVars)
+	issues := varCompileIssues(pol, item, source, extraVars, located)
 	if decodeErr != nil {
 		return append(issues, backstopIssue(fmt.Errorf("%s: %w", source, decodeErr), source, item, located)...)
 	}
@@ -418,15 +418,19 @@ func expandedPolicyIssues(item *yaml.Node, source string, extraVars []string, lo
 // the walk has already reported, an entrypoint it does not recognize, or a field
 // the decoder refuses would each hide an uncompilable var behind them.
 //
-// It reports only what nothing else owns. A var name that is empty or
-// duplicated is already reported by the walk, so neither is restated here.
-func varCompileIssues(pol structuredPolicy, item *yaml.Node, extraVars []string) []Issue {
+// It reports only what nothing else owns, which is what located is for: a var
+// name that is empty or duplicated is located by the walk, so the wrapping
+// failure that restates it is folded rather than printed twice. Discarding that
+// failure outright is not the same thing. It withheld any var-shape defect the
+// walk does not model, and left the one it does to a bundle-wide backstop that an
+// unrelated located error stops before it runs.
+func varCompileIssues(pol structuredPolicy, item *yaml.Node, source string, extraVars []string, located []Issue) []Issue {
 	if len(pol.Vars) == 0 {
 		return nil
 	}
 	body, err := pol.wrapVars("[]")
 	if err != nil {
-		return nil
+		return backstopIssue(fmt.Errorf("%s/%s: %w", source, pol.Name, err), source, item, located)
 	}
 	if err := Compile(body, extraVars); err != nil {
 		issue := issueAt(item, IssueError, "cel-error", err.Error())
@@ -512,6 +516,23 @@ func validateMode(item *yaml.Node) []Issue {
 	return nil
 }
 
+// varKeyName returns the name a vars key binds, read the way the decoder reads
+// it, or the empty string when it binds none. A null key is the case the two
+// readers would otherwise disagree about: the decoder leaves the name at its zero
+// value, which every reader of a bundle refuses, while `null` and `~` are text a
+// walk over the document would take for a name.
+//
+// It is the key-position counterpart of MappingValue reading a null value as
+// unset, and it is what lets rewritesItsText go on exempting null: the exemption
+// holds only because both readers model null the same way, which in key position
+// they now do.
+func varKeyName(key *yaml.Node) string {
+	if key == nil || key.Kind != yaml.ScalarNode || isNullNode(key) {
+		return ""
+	}
+	return normalizeVarName(key.Value)
+}
+
 // validateVars checks the vars mapping: it must be a mapping, and every variable
 // needs a unique non-empty name, since duplicates silently shadow each other
 // when the policy is expanded.
@@ -527,8 +548,8 @@ func validateVars(item *yaml.Node) []Issue {
 	seen := map[string]struct{}{}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		key := node.Content[i]
-		name := normalizeVarName(key.Value)
-		if key.Kind != yaml.ScalarNode || name == "" {
+		name := varKeyName(key)
+		if name == "" {
 			issues = append(issues, issueAt(key, IssueError, "empty-var-name", "vars must have non-empty names"))
 			continue
 		}
@@ -812,10 +833,13 @@ func DeclaredVarNames(policyNode *yaml.Node) []string {
 	}
 	for i := 0; i+1 < len(varsNode.Content); i += 2 {
 		k := varsNode.Content[i]
-		if k.Kind == yaml.ScalarNode && !isMergeKey(k) && normalizeVarName(k.Value) != "" {
-			// The name is normalized because the expansion binds the normalized
-			// spelling, and a condition is compiled against the names it can use.
-			names = append(names, normalizeVarName(k.Value))
+		// varKeyName normalizes, because the expansion binds the normalized
+		// spelling and a condition is compiled against the names it can use, and
+		// reads a null key as binding nothing, as the decoder does. Declaring the
+		// text of a null key would put a name in scope that the expanded policy
+		// never binds.
+		if name := varKeyName(k); name != "" && !isMergeKey(k) {
+			names = append(names, name)
 		}
 	}
 	return names

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -288,20 +288,23 @@ func validateRules(item *yaml.Node, policyName string, declaredVars []string, ch
 			issues = append(issues, ruleIssue(idx, issueAt(rule, IssueError, "rule-not-mapping", "rule must be a mapping")))
 			continue
 		}
+		// A rule's condition and its action are independent fields, so a missing
+		// condition must not hide a bad action: only the compile step is skipped,
+		// since there is nothing to compile.
 		whenNode := MappingValue(rule, "when")
 		if whenNode == nil || whenNode.Kind != yaml.ScalarNode {
 			issues = append(issues, ruleIssue(idx, issueAt(rule, IssueError, "missing-when", "rule missing 'when' expression")))
-			continue
-		}
-		for _, issue := range checkRuleWhen(checkWhen, RuleWhen{
-			Policy:       policyName,
-			RuleIndex:    idx,
-			Expr:         whenNode.Value,
-			Line:         whenNode.Line,
-			Column:       whenNode.Column,
-			DeclaredVars: declaredVars,
-		}) {
-			issues = append(issues, ruleIssue(idx, issue))
+		} else {
+			for _, issue := range checkRuleWhen(checkWhen, RuleWhen{
+				Policy:       policyName,
+				RuleIndex:    idx,
+				Expr:         whenNode.Value,
+				Line:         whenNode.Line,
+				Column:       whenNode.Column,
+				DeclaredVars: declaredVars,
+			}) {
+				issues = append(issues, ruleIssue(idx, issue))
+			}
 		}
 		issues = append(issues, validateRuleAction(rule, idx)...)
 	}

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -119,10 +119,14 @@ type ValidateOptions struct {
 // instead of being dismissed as an unknown format. Compiled bundles are ruled
 // out first: their JSON has a "policies" array too.
 //
-// A document whose "policies" key is not written directly still counts when the
-// decoder finds one anyway, which a top-level merge key does. Without that
-// fallback a bundle could inherit its whole policy list from an anchor and slip
-// past the checks that key off this probe, the anchor refusal among them.
+// A document whose "policies" key is not written directly still counts when a
+// reader that resolves references finds one anyway, which a top-level merge key
+// does. Without that fallback a bundle could inherit its whole policy list from
+// an anchor and slip past the checks that key off this probe, the anchor refusal
+// among them. The fallback asks the same question of the resolved document that
+// the node walk asks of the written one, whether the key is there, so an
+// inherited list that is empty or malformed is as much a bundle as an inherited
+// list that is well formed.
 //
 // A document that does not parse as YAML has no nodes to probe, so the raw text
 // is checked for the key instead. A syntax error is the mistake an author is
@@ -145,7 +149,7 @@ func LooksLikeStructuredBundle(data []byte) bool {
 	if hasMappingKey(root.Content[0], bundlePoliciesKey) {
 		return true
 	}
-	return decodesWithPolicies(data)
+	return resolvesToBundleKey(data)
 }
 
 // bundlePoliciesKey is the mapping key that marks a document as an authored
@@ -216,17 +220,25 @@ func hasMappingKey(mapNode *yaml.Node, key string) bool {
 	return false
 }
 
-// decodesWithPolicies reports whether data decodes into a bundle carrying at
-// least one policy. It is how the shape probe sees a policies key the node walk
-// cannot: the decoder resolves the aliases and merge keys the walk refuses to
-// follow, so this answers "would a reader that resolves them find policies here"
-// without any reader having to act on the resolved value.
-func decodesWithPolicies(data []byte) bool {
-	var bundle structuredBundle
-	if err := yaml.Unmarshal(data, &bundle); err != nil {
+// resolvesToBundleKey reports whether data carries the bundle key once the
+// references the node walk refuses to follow are resolved. It is how the shape
+// probe sees a policies key the walk cannot: the decoder resolves the aliases and
+// merge keys, so this answers "would a reader that resolves them find the key
+// here" without any reader having to act on the resolved value.
+//
+// It decodes into a plain mapping rather than into Deputy's bundle types, and
+// asks only whether the key is present, so the answer does not depend on the
+// inherited value being a well-formed, non-empty policy list. Requiring that
+// dismissed a bundle whose inherited list was empty or malformed as an unknown
+// format, which withheld the refusal of the construct that supplied it and left
+// the linter describing a different mistake than the editor.
+func resolvesToBundleKey(data []byte) bool {
+	var doc map[string]any
+	if err := yaml.Unmarshal(data, &doc); err != nil {
 		return false
 	}
-	return len(bundle.Policies) > 0
+	_, ok := doc[bundlePoliciesKey]
+	return ok
 }
 
 // ValidateBundle reports every structural problem in a structured policy bundle:

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -931,8 +931,21 @@ func hasMergeKey(mapNode *yaml.Node) bool {
 
 // isMergeKey reports whether a mapping key is YAML's merge key, the "<<" that
 // pulls another mapping's entries into this one.
+//
+// The question is the tag YAML resolves, not the text the key is spelled with. A
+// quoted "<<" is an ordinary string key that merges nothing, and a bundle may
+// legitimately carry it wherever it accepts arbitrary keys, in its metadata and in
+// a rule's details. Reading the text instead named a merge the author did not
+// write and, worse, made every check that reads the document's values skip the
+// policy carrying it (see resolvesElsewhere).
+//
+// Tightening this cannot let a merge through unreported: yaml.v3 merges a key when
+// it is a scalar whose value is "<<" and whose tag resolves to !!merge, which is
+// what ShortTag answers, so every spelling the decoder acts on is refused here,
+// including a tag written verbatim as its URI. A key the author explicitly tagged
+// !!merge is refused whatever its name, which is the safe direction to err in.
 func isMergeKey(key *yaml.Node) bool {
-	return key.Tag == "!!merge" || key.Value == "<<"
+	return key != nil && key.Kind == yaml.ScalarNode && key.ShortTag() == mergeTag
 }
 
 // Messages for the YAML constructs a policy bundle does not accept. Each names
@@ -949,6 +962,9 @@ const (
 
 // nullTag is YAML's resolved tag for every spelling of null.
 const nullTag = "!!null"
+
+// mergeTag is YAML's resolved tag for the merge key, in every spelling of it.
+const mergeTag = "!!merge"
 
 // rewritesItsText reports whether a scalar's value is not the text the document
 // writes for it. A YAML tag can arrange exactly that: `action: !!binary ZGVueQ==`

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -162,9 +162,13 @@ func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 		return append(issues, issueAt(policiesNode, IssueError, "policies-not-list", "'policies' must be a list")), nil
 	}
 	seenNames := map[string]struct{}{}
-	for _, item := range policiesNode.Content {
-		if item.Kind != yaml.MappingNode {
-			issues = append(issues, issueAt(item, IssueError, "policy-not-mapping", "policy must be a mapping"))
+	for _, entry := range policiesNode.Content {
+		// A policy may be written as an alias to an anchor defined elsewhere in
+		// the document. Report against the alias, which is where the author can
+		// see the problem, but validate what it points at.
+		item := ResolveAlias(entry)
+		if item == nil || item.Kind != yaml.MappingNode {
+			issues = append(issues, issueAt(entry, IssueError, "policy-not-mapping", "policy must be a mapping"))
 			continue
 		}
 		issues = append(issues, validatePolicyNode(item, seenNames, opts)...)
@@ -462,24 +466,83 @@ func DeclaredVarNames(policyNode *yaml.Node) []string {
 	}
 	for i := 0; i+1 < len(varsNode.Content); i += 2 {
 		k := varsNode.Content[i]
-		if k.Kind == yaml.ScalarNode && strings.TrimSpace(k.Value) != "" {
+		if k.Kind == yaml.ScalarNode && !isMergeKey(k) && strings.TrimSpace(k.Value) != "" {
 			names = append(names, k.Value)
 		}
 	}
 	return names
 }
 
+// aliasDepthLimit bounds how far alias and merge-key resolution will follow
+// references. YAML anchors can be nested, but a document deep enough to exceed
+// this is either generated or malicious, and refusing to follow it keeps
+// validation from looping on a self-referential anchor.
+const aliasDepthLimit = 32
+
+// ResolveAlias follows a YAML alias to the node its anchor defines, so callers
+// can treat `- *policy` exactly as the typed decoder does. A node that is not an
+// alias is returned unchanged.
+func ResolveAlias(node *yaml.Node) *yaml.Node {
+	for depth := 0; node != nil && node.Kind == yaml.AliasNode; depth++ {
+		if depth >= aliasDepthLimit {
+			return nil
+		}
+		node = node.Alias
+	}
+	return node
+}
+
 // MappingValue returns the value node for a key inside a YAML mapping node, or
-// nil when the node is not a mapping or the key is absent.
+// nil when the node is not a mapping or the key is absent. Aliases are followed
+// on both the mapping and the value, and merge keys are searched after the
+// mapping's own keys, matching how the decoder resolves inherited fields: a key
+// written directly on a policy overrides one it merges in.
 func MappingValue(mapNode *yaml.Node, key string) *yaml.Node {
-	if mapNode == nil || mapNode.Kind != yaml.MappingNode {
+	return mappingValue(mapNode, key, 0)
+}
+
+// mappingValue is MappingValue with the recursion depth that merge keys need,
+// since a merged mapping may itself merge from another.
+func mappingValue(mapNode *yaml.Node, key string, depth int) *yaml.Node {
+	node := ResolveAlias(mapNode)
+	if node == nil || node.Kind != yaml.MappingNode || depth >= aliasDepthLimit {
 		return nil
 	}
-	for i := 0; i+1 < len(mapNode.Content); i += 2 {
-		k := mapNode.Content[i]
-		if k.Kind == yaml.ScalarNode && k.Value == key {
-			return mapNode.Content[i+1]
+	var merges []*yaml.Node
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		k := node.Content[i]
+		if k.Kind != yaml.ScalarNode {
+			continue
+		}
+		if k.Value == key {
+			return ResolveAlias(node.Content[i+1])
+		}
+		if isMergeKey(k) {
+			merges = append(merges, node.Content[i+1])
+		}
+	}
+	for _, merge := range merges {
+		merged := ResolveAlias(merge)
+		if merged == nil {
+			continue
+		}
+		if merged.Kind == yaml.SequenceNode {
+			for _, item := range merged.Content {
+				if value := mappingValue(item, key, depth+1); value != nil {
+					return value
+				}
+			}
+			continue
+		}
+		if value := mappingValue(merged, key, depth+1); value != nil {
+			return value
 		}
 	}
 	return nil
+}
+
+// isMergeKey reports whether a mapping key is YAML's merge key, the "<<" that
+// pulls another mapping's entries into this one.
+func isMergeKey(key *yaml.Node) bool {
+	return key.Tag == "!!merge" || key.Value == "<<"
 }

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -290,16 +290,6 @@ func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 		}
 		located := validatePolicyNode(item, seenNames, opts)
 		issues = append(issues, located...)
-		// A policy the walk already located an error in is not expanded whole: its
-		// expansion is expected to fail too, and restating that failure in
-		// generated CEL the author never wrote would only obscure the real defect.
-		// Its vars are still compiled, since they are a defect of their own and
-		// expansion stops at the first failure, which would leave them unreported
-		// until the located one is fixed and lint rerun.
-		if slices.ContainsFunc(located, func(is Issue) bool { return is.Severity == IssueError }) {
-			issues = append(issues, varExpansionIssues(item, opts.ExtraVars)...)
-			continue
-		}
 		issues = append(issues, expandedPolicyIssues(item, source, opts.ExtraVars, located)...)
 	}
 	// Decoding the whole bundle is the last backstop, for the shapes that belong
@@ -331,17 +321,34 @@ func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 // written anywhere in the document, used to withhold the diagnostics for every
 // other policy and cost the author a lint run per defect.
 //
+// Within one policy the same rule holds, which is why the vars are compiled
+// first and on their own: every step after them stops at its first failure, so
+// asking about them last is asking only about the policies nothing else is wrong
+// with. Whatever the vars answer is independent of the field the decoder refuses
+// and of the entrypoint the walk does not recognize, and an author who has to
+// fix one before being told about the other pays a lint run per defect.
+//
 // located is what the walk already reported for this policy, so a failure that
 // restates one of those is dropped and a single mistake stays a single issue.
 func expandedPolicyIssues(item *yaml.Node, source string, extraVars []string, located []Issue) []Issue {
 	var pol structuredPolicy
 	// Decoding resolves aliases and merge keys, which the format refuses; that is
 	// safe here because a policy carrying one anywhere beneath it never reaches
-	// this point, so the decoder reads only what the policy itself writes.
-	if err := item.Decode(&pol); err != nil {
-		return backstopIssue(fmt.Errorf("%s: %w", source, err), source, item, located)
-	}
+	// this point, so the decoder reads only what the policy itself writes. A field
+	// the decoder refuses leaves the rest of the policy decoded, so the vars are
+	// still worth asking about.
+	decodeErr := item.Decode(&pol)
 	pol.Name = strings.TrimSpace(pol.Name)
+	issues := varCompileIssues(pol, item, extraVars)
+	if decodeErr != nil {
+		return append(issues, backstopIssue(fmt.Errorf("%s: %w", source, decodeErr), source, item, located)...)
+	}
+	// Expanding the policy whole would stop at, or restate in generated CEL the
+	// author never wrote, a defect that is already reported: an uncompilable var
+	// wraps every condition, and a located error is the mistake itself.
+	if len(issues) > 0 || slices.ContainsFunc(located, func(is Issue) bool { return is.Severity == IssueError }) {
+		return issues
+	}
 	body, err := pol.toCELSource()
 	if err != nil {
 		return backstopIssue(fmt.Errorf("%s/%s: %w", source, pol.Name, err), source, item, located)
@@ -354,21 +361,16 @@ func expandedPolicyIssues(item *yaml.Node, source string, extraVars []string, lo
 	return nil
 }
 
-// varExpansionIssues reports the vars of one policy that do not compile. It
-// exists for the policy the walk already found an error in, which is not
-// expanded whole: expansion stops at its first failure, so a rule the walk has
-// already reported would hide an uncompilable var behind it and hand the author
-// the var only after the rule is fixed. Wrapping an empty body in the policy's
-// vars asks the one question the located issue leaves open.
+// varCompileIssues reports the vars of one policy that do not compile. Wrapping
+// an empty body in them asks about the vars and nothing else, which is the one
+// question every other step of the expansion can stop short of: it compiles the
+// generated CEL only once the whole policy has decoded and expanded, so a rule
+// the walk has already reported, an entrypoint it does not recognize, or a field
+// the decoder refuses would each hide an uncompilable var behind them.
 //
-// It reports only what nothing else owns. A policy that does not decode, and a
-// var name that is empty or duplicated, are already reported by the walk, so
-// neither is restated here.
-func varExpansionIssues(item *yaml.Node, extraVars []string) []Issue {
-	var pol structuredPolicy
-	if err := item.Decode(&pol); err != nil {
-		return nil
-	}
+// It reports only what nothing else owns. A var name that is empty or
+// duplicated is already reported by the walk, so neither is restated here.
+func varCompileIssues(pol structuredPolicy, item *yaml.Node, extraVars []string) []Issue {
 	if len(pol.Vars) == 0 {
 		return nil
 	}

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -153,11 +153,11 @@ func LooksLikeStructuredBundle(data []byte) bool {
 // reads, so the probe and the loader cannot drift apart.
 const bundlePoliciesKey = "policies"
 
-// unparsedBundleKey matches the bundle's policies key written at the top level
-// of a document, in raw text. It is deliberately a last resort: YAML that parses
-// is always probed by walking its nodes, and this runs only for a document the
-// parser rejected outright, where no structure is available to walk.
-var unparsedBundleKey = regexp.MustCompile(`(?m)^` + yamlKeyPattern(bundlePoliciesKey) + `[ \t]*:`)
+// unparsedBundleKey matches the bundle's policies key at the start of a line, in
+// raw text. It is deliberately a last resort: YAML that parses is always probed
+// by walking its nodes, and this runs only for a document the parser rejected
+// outright, where no structure is available to walk.
+var unparsedBundleKey = regexp.MustCompile(`^` + yamlKeyPattern(bundlePoliciesKey) + `[ \t]*:`)
 
 // yamlKeyPattern returns a regexp fragment matching a YAML mapping key in each
 // of the three ways a document can spell it: bare, single-quoted, and
@@ -173,8 +173,30 @@ func yamlKeyPattern(key string) string {
 // writesBundleKey reports whether raw text writes the bundle's policies key at
 // the top level, which is how a document the YAML parser rejected is still
 // recognized as an authored bundle with a syntax error in it.
+//
+// A root key may be indented, as long as the whole document is: YAML fixes a
+// mapping's indentation at its first key, so nothing above a root key is less
+// indented than it. That is what tells an indented bundle apart from a nested
+// policies key, and from the raw CEL where the same spelling is a map literal
+// keyed inside an expression that started further left.
 func writesBundleKey(data []byte) bool {
-	return unparsedBundleKey.Match(data)
+	rootIndent := -1
+	for line := range strings.Lines(string(data)) {
+		body := strings.TrimLeft(line, " \t")
+		// A blank line carries no indentation, and a comment may sit at any, so
+		// neither says where the document's keys begin.
+		if strings.TrimSpace(body) == "" || strings.HasPrefix(body, "#") {
+			continue
+		}
+		indent := len(line) - len(body)
+		if rootIndent < 0 || indent < rootIndent {
+			rootIndent = indent
+		}
+		if indent == rootIndent && unparsedBundleKey.MatchString(body) {
+			return true
+		}
+	}
+	return false
 }
 
 // hasMappingKey reports whether a YAML mapping node carries a key, whatever its

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -207,6 +207,11 @@ func decodesWithPolicies(data []byte) bool {
 // so callers can report them all at once. A bundle that does not decode into
 // Deputy's types is still validated: the node walk reports what it can locate
 // and the decode failure is added on top.
+//
+// One run reports every independent defect, so an author fixes a file once
+// rather than peeling errors one lint at a time. That is why each policy is
+// walked and expanded on its own: nothing about one policy, and nothing the
+// document does elsewhere, withholds the diagnostics for the rest.
 func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 	if IsCompiledBundle([]byte(text)) {
 		return nil, errors.New("compiled policy bundle: validate the authored policies it was built from")
@@ -227,8 +232,8 @@ func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 	// of validation, and every other reader of a bundle, sees only plain nodes.
 	// The scan comes before the policies lookup because a root merge key can
 	// supply the whole list, which would otherwise read as a missing key. It does
-	// not stop the walk: a refused anchor must not hide an unrelated typo and
-	// cost the author a second lint run.
+	// not stop the checks that follow: a refused anchor must not hide an unrelated
+	// typo, or an uncompilable var, and cost the author a second lint run.
 	anchors := anchorIssues(root)
 	issues = append(issues, anchors...)
 	policiesNode := MappingValue(doc, bundlePoliciesKey)
@@ -252,93 +257,99 @@ func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 		return append(issues, issueAt(policiesNode, IssueError, "empty-policies", "'policies' must contain at least one policy")), nil
 	}
 	seenNames := map[string]struct{}{}
-	// Policy positions the walk already reported an error for. Their generated
-	// CEL is expected to fail too, so it is not compiled again; every other
-	// policy still is.
-	reported := map[int]bool{}
-	for i, item := range policiesNode.Content {
+	source := cmp.Or(opts.Source, "policy")
+	for _, item := range policiesNode.Content {
 		// Skip a policy that carries an anchor, an alias, or a merge key anywhere
 		// beneath it: it is already reported, and every further message the walk
 		// could produce would describe the alias node rather than the policy the
 		// author meant. Plain policies alongside it are still checked.
 		if len(anchorIssues(item)) > 0 {
-			reported[i] = true
 			continue
 		}
 		if item.Kind != yaml.MappingNode {
 			issues = append(issues, issueAt(item, IssueError, "policy-not-mapping", "policy must be a mapping"))
-			reported[i] = true
 			continue
 		}
-		policyIssues := validatePolicyNode(item, seenNames, opts)
-		if slices.ContainsFunc(policyIssues, func(is Issue) bool { return is.Severity == IssueError }) {
-			reported[i] = true
+		located := validatePolicyNode(item, seenNames, opts)
+		issues = append(issues, located...)
+		// A policy the walk already located an error in is not expanded: its
+		// expansion is expected to fail too, and restating that failure in
+		// generated CEL the author never wrote would only obscure the real defect.
+		if slices.ContainsFunc(located, func(is Issue) bool { return is.Severity == IssueError }) {
+			continue
 		}
-		issues = append(issues, policyIssues...)
+		issues = append(issues, expandedPolicyIssues(item, source, opts.ExtraVars, located)...)
 	}
-	// The loader stops at the first anchor it finds, so it has nothing to add to
-	// what the scan above already located.
-	if len(anchors) > 0 {
-		return issues, nil
-	}
-	// Load the whole bundle as a backstop for shapes the node walk does not model,
-	// such as a rule field of the wrong type. The loader stops at its first
-	// failure, so its message is dropped when a located issue already reports the
-	// same thing, and is anchored on the line it names when it names one.
-	source := cmp.Or(opts.Source, "policy")
-	sources, err := ParseStructuredSources([]byte(text), source)
-	if err != nil {
-		if message, duplicate := loaderMessage(err, source, issues); !duplicate {
-			issues = append(issues, Issue{
-				RuleIndex: NoRule,
-				Line:      lineFromYAMLError(message),
-				Column:    1,
-				Severity:  IssueWarning,
-				Code:      "bundle-error",
-				Message:   message,
-			})
+	// Loading the whole bundle is the last backstop, for the shapes that belong to
+	// no single policy, such as bundle metadata of the wrong type. It stops at its
+	// first failure, which is why it runs after every policy has been expanded on
+	// its own and adds only what is not already reported. A document carrying an
+	// anchor skips it outright: the loader stops at the first one, which the scan
+	// above already located.
+	if len(anchors) == 0 {
+		if _, err := ParseStructuredSources([]byte(text), source); err != nil {
+			issues = append(issues, backstopIssue(err, source, doc, issues)...)
 		}
-		return issues, nil
 	}
-	return append(issues, generatedSourceIssues(sources, policiesNode, opts.ExtraVars, reported)...), nil
+	return issues, nil
 }
 
-// generatedSourceIssues compiles the CEL each policy expands into, so a bundle
-// that lints clean is a bundle `deputy policy bundle` can compile. Loading a
-// bundle only generates that CEL; nothing before this compiles it. A rule's
-// condition is checked on its own, while a policy's vars wrap every condition in
-// a comprehension, so a var whose value or name is not valid CEL breaks the
-// generated body alone and no per-rule check can see it.
+// expandedPolicyIssues reports what only expanding one policy can find. Two
+// defects hide from the node walk: a field whose type the walk does not model,
+// such as a rule status written as a string, and the CEL a policy generates,
+// since a policy's vars wrap every condition in a comprehension that no per-rule
+// check compiles. Expanding here is what makes a bundle that lints clean a
+// bundle `deputy policy bundle` can compile.
 //
-// A policy the walk already located an error in is skipped, because its
-// generated body is then expected to fail too and restating that failure in
-// expanded CEL the author never wrote would only obscure the real defect. The
-// skip is per policy rather than bundle-wide: one policy with a bad condition
-// must not hide an unrelated bad var in the next one and cost the author a
-// second lint run. The loader returns one source per policy in document order,
-// which is how reported positions and failures alike are matched to the policy
-// they belong to.
-func generatedSourceIssues(sources []Source, policiesNode *yaml.Node, extraVars []string, reported map[int]bool) []Issue {
-	var issues []Issue
-	for i, src := range sources {
-		if reported[i] {
-			continue
-		}
-		err := Compile(src.Body, extraVars)
-		if err == nil {
-			continue
-		}
-		var node *yaml.Node
-		if i < len(policiesNode.Content) {
-			node = policiesNode.Content[i]
-		}
-		issue := issueAt(node, IssueError, "cel-error", err.Error())
-		if nameNode := MappingValue(node, "name"); nameNode != nil && nameNode.Kind == yaml.ScalarNode {
-			issue.Policy = strings.TrimSpace(nameNode.Value)
-		}
-		issues = append(issues, issue)
+// It works from the policy's own node rather than from a load of the whole
+// bundle, which is what lets one pass report every policy. A bundle-wide load
+// stops at its first failure, so one policy's mistyped field, or an anchor
+// written anywhere in the document, used to withhold the diagnostics for every
+// other policy and cost the author a lint run per defect.
+//
+// located is what the walk already reported for this policy, so a failure that
+// restates one of those is dropped and a single mistake stays a single issue.
+func expandedPolicyIssues(item *yaml.Node, source string, extraVars []string, located []Issue) []Issue {
+	var pol structuredPolicy
+	// Decoding resolves aliases, which the format refuses; that is safe here
+	// because a policy carrying one anywhere beneath it never reaches this point.
+	if err := item.Decode(&pol); err != nil {
+		return backstopIssue(fmt.Errorf("%s: %w", source, err), source, item, located)
 	}
-	return issues
+	pol.Name = strings.TrimSpace(pol.Name)
+	body, err := pol.toCELSource()
+	if err != nil {
+		return backstopIssue(fmt.Errorf("%s/%s: %w", source, pol.Name, err), source, item, located)
+	}
+	if err := Compile(body, extraVars); err != nil {
+		issue := issueAt(item, IssueError, "cel-error", err.Error())
+		issue.Policy = pol.Name
+		return []Issue{issue}
+	}
+	return nil
+}
+
+// backstopIssue renders a load failure as an issue, or nothing when a located
+// issue already describes the same defect. It is anchored on the line the
+// failure names, since the decoder names one for a field the walk does not
+// model, and otherwise on the node the failure came from.
+func backstopIssue(err error, source string, node *yaml.Node, located []Issue) []Issue {
+	message, duplicate := loaderMessage(err, source, located)
+	if duplicate {
+		return nil
+	}
+	issue := Issue{
+		RuleIndex: NoRule,
+		Line:      lineFromYAMLError(message),
+		Column:    1,
+		Severity:  IssueWarning,
+		Code:      "bundle-error",
+		Message:   message,
+	}
+	if issue.Line == 0 && node != nil {
+		issue.Line, issue.Column = node.Line, node.Column
+	}
+	return []Issue{issue}
 }
 
 // validatePolicyNode checks one policy mapping: its name uniqueness, its

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -450,6 +450,10 @@ func varCompileIssues(pol structuredPolicy, item *yaml.Node, source string, extr
 	var (
 		issues []Issue
 		bound  orderedVars
+		// unwritable holds the names whose value has no CEL spelling, in author
+		// order. They are dropped from every nest and declared to the compiler as
+		// unknowns instead, which is what they are.
+		unwritable []string
 	)
 	// backstop renders a failure of the expansion as an issue folded against what
 	// the walk already located, which is where a var holding a value with no CEL
@@ -457,30 +461,55 @@ func varCompileIssues(pol structuredPolicy, item *yaml.Node, source string, extr
 	backstop := func(err error) []Issue {
 		return backstopIssue(fmt.Errorf("%s/%s: %w", source, pol.Name, err), source, item, located)
 	}
-	// nested asks what wrapping a body in vars finds: a var Deputy cannot write into
-	// the generated CEL at all, or generated CEL that does not compile.
+	// nested asks what wrapping a body in vars finds, which is generated CEL that
+	// does not compile.
+	//
+	// A var already set aside is left out of the nest, since there is no expression
+	// to bind its name to, and its name is declared as an unknown alongside the
+	// caller's extra names. Leaving the name undeclared made the compiler report an
+	// undeclared reference against every expression that reads it, which is a second
+	// error the author did not make: the name is written right there. Declaring it
+	// without a type is the honest form of what Deputy knows, that the var exists and
+	// its value cannot be written, and it is what keeps one mistake to one issue
+	// while the expressions around it are still asked about.
 	nested := func(vars orderedVars, body string) []Issue {
-		expr, err := nestVars(vars, body)
+		writable := make(orderedVars, 0, len(vars))
+		for _, v := range vars {
+			if slices.Contains(unwritable, v.Name) {
+				continue
+			}
+			writable = append(writable, v)
+		}
+		expr, err := nestVars(writable, body)
 		if err != nil {
 			return backstop(err)
 		}
-		return celIssues(expr, extraVars, item, pol.Name)
+		return celIssues(expr, slices.Concat(extraVars, unwritable), item, pol.Name)
 	}
 	for _, binding := range pol.Vars.bindings() {
-		if binding.err == nil {
-			bound = append(bound, binding.kv)
+		// A var whose value Deputy cannot write into CEL is set aside like a name
+		// that binds nothing: there is no expression to nest, and stopping at it
+		// would withhold every var beside it. The walk names it on its own line, so
+		// the restatement folds to nothing and the defect is still reported once.
+		expr, exprErr := binding.kv.exprString()
+		if binding.err != nil {
+			issues = append(issues, backstop(binding.err)...)
+		}
+		if exprErr != nil {
+			issues = append(issues, backstop(exprErr)...)
+			unwritable = append(unwritable, binding.kv.Name)
 			continue
 		}
-		issues = append(issues, backstop(binding.err)...)
-		expr, err := binding.kv.exprString()
-		if err != nil {
-			issues = append(issues, backstop(err)...)
+		if binding.err == nil {
+			bound = append(bound, binding.kv)
 			continue
 		}
 		issues = append(issues, nested(binding.scope, expr)...)
 	}
 	// The vars that do bind are compiled as one nest, since each is in scope for
-	// the next, and wrapping an empty body asks about them and nothing else.
+	// the next, and wrapping an empty body asks about them and nothing else. Every
+	// var set aside above is absent from it, so the nest holds only expressions
+	// that exist and the compiler answers about the vars that are left.
 	return append(issues, nested(bound, "[]")...)
 }
 

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -549,7 +549,7 @@ func validateRules(item *yaml.Node, policyName string, declaredVars []string, ch
 		return []Issue{issueAt(rulesNode, IssueError, "rules-not-list", "'rules' must be a list")}
 	}
 	if len(rulesNode.Content) == 0 {
-		return []Issue{issueAt(rulesNode, IssueError, "empty-rules", "policy must contain at least one rule")}
+		return []Issue{issueAt(rulesNode, IssueError, "empty-rules", policyNeedsRuleMessage)}
 	}
 	var issues []Issue
 	for idx, rule := range rulesNode.Content {
@@ -631,8 +631,15 @@ func checkRuleWhen(checkWhen func(RuleWhen) []Issue, when RuleWhen) []Issue {
 // message contain one another: the two describe the same defect in slightly
 // different words. Anything else is a shape the node walk does not model and is
 // reported as is.
+//
+// Containment alone is not enough for the defects the two readers name in
+// different vocabularies, so a rule shape the walk located also covers the
+// loader's refusal of a policy with no rules to run.
 func loaderMessage(err error, source string, located []Issue) (string, bool) {
-	message := err.Error()
+	message, ok := unlocatedDecodeMessage(err, located)
+	if !ok {
+		return "", true
+	}
 	detail := strings.TrimPrefix(message, source+"/")
 	if _, rest, ok := strings.Cut(detail, ": "); ok {
 		detail = rest
@@ -653,8 +660,70 @@ func loaderMessage(err error, source string, located []Issue) (string, bool) {
 		if strings.Contains(issue.Message, detail) || strings.Contains(detail, issue.Message) {
 			return message, true
 		}
+		if detail == policyNeedsRuleMessage && slices.Contains(ruleShapeCodes, issue.Code) {
+			return message, true
+		}
 	}
 	return message, false
+}
+
+// ruleShapeCodes are the codes the node walk reports for a policy whose rules it
+// cannot read as a list of rules: absent, not a list, or empty. Every reader of
+// a bundle refuses such a policy, so each of these codes means the loader is
+// about to say the same thing in its own words, either as its refusal of a
+// policy with no rules to run or as the decoder's complaint about the value's
+// type. Neither wording contains the walk's, so the codes are what lets the
+// backstop recognize the restatement and leave one mistake as one issue.
+var ruleShapeCodes = []string{"missing-rules", "rules-not-list", "empty-rules"}
+
+// unlocatedDecodeMessage returns the loader's failure with the decoder
+// complaints a located issue already reports removed, and false when that leaves
+// nothing to report. The decoder gathers every field it refuses into one error,
+// so a restatement has to be dropped one complaint at a time: dropping the whole
+// error would take the fields only the decoder finds down with it, and hide them
+// until the located defect is fixed and lint rerun. An error that is not the
+// decoder's is passed through for the comparison the caller makes on the whole
+// message.
+func unlocatedDecodeMessage(err error, located []Issue) (string, bool) {
+	var typeErr *yaml.TypeError
+	if !errors.As(err, &typeErr) {
+		return err.Error(), true
+	}
+	kept := make([]string, 0, len(typeErr.Errors))
+	for _, complaint := range typeErr.Errors {
+		if slices.ContainsFunc(located, func(issue Issue) bool { return coversComplaint(issue, complaint) }) {
+			continue
+		}
+		kept = append(kept, complaint)
+	}
+	if len(kept) == 0 {
+		return "", false
+	}
+	if len(kept) == len(typeErr.Errors) {
+		return err.Error(), true
+	}
+	// The decode error is wrapped in the source and policy it came from, so the
+	// remaining complaints replace the original ones in place rather than losing
+	// that prefix.
+	return strings.Replace(err.Error(), typeErr.Error(), (&yaml.TypeError{Errors: kept}).Error(), 1), true
+}
+
+// coversComplaint reports whether a located issue already reports what one of
+// the decoder's complaints says. A complaint quoted verbatim is one this run has
+// already reported, which is how the per-policy expansion keeps the bundle-wide
+// decode from restating what it found. Otherwise only a rule shape is folded: a
+// rules value the walk calls "not a list" is a value the decoder cannot
+// unmarshal into its rule slice, one mistake in two vocabularies, and the line
+// the decoder names is the line the walk located it on.
+func coversComplaint(issue Issue, complaint string) bool {
+	if issue.Severity == IssueHint {
+		return false
+	}
+	if strings.Contains(issue.Message, complaint) {
+		return true
+	}
+	line := lineFromYAMLError(complaint)
+	return line > 0 && line == issue.Line && slices.Contains(ruleShapeCodes, issue.Code)
 }
 
 // lineFromYAMLError returns the 1-based line a YAML decode error names, or zero

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -451,17 +451,37 @@ func varCompileIssues(pol structuredPolicy, item *yaml.Node, source string, extr
 		issues []Issue
 		bound  orderedVars
 	)
+	// backstop renders a failure of the expansion as an issue folded against what
+	// the walk already located, which is where a var holding a value with no CEL
+	// spelling is named on its own line (see validateVars).
+	backstop := func(err error) []Issue {
+		return backstopIssue(fmt.Errorf("%s/%s: %w", source, pol.Name, err), source, item, located)
+	}
+	// nested asks what wrapping a body in vars finds: a var Deputy cannot write into
+	// the generated CEL at all, or generated CEL that does not compile.
+	nested := func(vars orderedVars, body string) []Issue {
+		expr, err := nestVars(vars, body)
+		if err != nil {
+			return backstop(err)
+		}
+		return celIssues(expr, extraVars, item, pol.Name)
+	}
 	for _, binding := range pol.Vars.bindings() {
 		if binding.err == nil {
 			bound = append(bound, binding.kv)
 			continue
 		}
-		issues = append(issues, backstopIssue(fmt.Errorf("%s/%s: %w", source, pol.Name, binding.err), source, item, located)...)
-		issues = append(issues, celIssues(nestVars(binding.scope, binding.kv.exprString()), extraVars, item, pol.Name)...)
+		issues = append(issues, backstop(binding.err)...)
+		expr, err := binding.kv.exprString()
+		if err != nil {
+			issues = append(issues, backstop(err)...)
+			continue
+		}
+		issues = append(issues, nested(binding.scope, expr)...)
 	}
 	// The vars that do bind are compiled as one nest, since each is in scope for
 	// the next, and wrapping an empty body asks about them and nothing else.
-	return append(issues, celIssues(nestVars(bound, "[]"), extraVars, item, pol.Name)...)
+	return append(issues, nested(bound, "[]")...)
 }
 
 // celIssues reports generated CEL that does not compile as an issue anchored on the
@@ -571,9 +591,9 @@ func varKeyName(key *yaml.Node) string {
 	return normalizeVarName(key.Value)
 }
 
-// validateVars checks the vars mapping: it must be a mapping, and every variable
+// validateVars checks the vars mapping: it must be a mapping, every variable
 // needs a unique non-empty name, since duplicates silently shadow each other
-// when the policy is expanded.
+// when the policy is expanded, and every value has to have a CEL spelling.
 func validateVars(item *yaml.Node) []Issue {
 	node := MappingValue(item, "vars")
 	if node == nil {
@@ -587,16 +607,52 @@ func validateVars(item *yaml.Node) []Issue {
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		key := node.Content[i]
 		name := varKeyName(key)
-		if name == "" {
+		switch {
+		case name == "":
 			issues = append(issues, issueAt(key, IssueError, "empty-var-name", emptyVarNameMessage))
-			continue
+		default:
+			if _, dup := seen[name]; dup {
+				issues = append(issues, issueAt(key, IssueError, "duplicate-var", fmt.Sprintf(duplicateVarNameFormat, name)))
+			}
+			seen[name] = struct{}{}
 		}
-		if _, dup := seen[name]; dup {
-			issues = append(issues, issueAt(key, IssueError, "duplicate-var", fmt.Sprintf(duplicateVarNameFormat, name)))
-		}
-		seen[name] = struct{}{}
+		// The value is asked about whatever the name above it says, since a name
+		// that binds nothing says nothing about the value beside it. Stopping at
+		// the name reported the value as the expansion's unlocated backstop
+		// instead, so one mistake changed severity and line depending on an
+		// unrelated one.
+		issues = append(issues, varValueIssues(name, node.Content[i+1])...)
 	}
 	return issues
+}
+
+// varValueIssues reports a var holding a value Deputy cannot write into the CEL a
+// policy generates. A non-string value is marshaled to JSON when the policy is
+// expanded, and YAML writes values JSON has no spelling for, a not-a-number and
+// the infinities among them, so a var holding one cannot be expanded at all.
+//
+// It asks encoding/json rather than judging the value itself, and it reads string
+// against non-string the way the decoder does, so it recognizes exactly what the
+// expansion recognizes: a string is the author's own CEL and goes in as written,
+// which is why it is not asked about here.
+//
+// Locating it here is what reports it on the line it is written on and beside the
+// policy's other defects. The expansion stops at the first var it cannot write, so
+// on its own it named one value per lint run and anchored it on the policy.
+func varValueIssues(name string, value *yaml.Node) []Issue {
+	if value == nil || (value.Kind == yaml.ScalarNode && value.Tag == strTag) {
+		return nil
+	}
+	var decoded any
+	// A value the decoder cannot read at all is the decoder's to report, on the
+	// line it names; this asks only about the values it can read.
+	if err := value.Decode(&decoded); err != nil {
+		return nil
+	}
+	if _, err := json.Marshal(decoded); err != nil {
+		return []Issue{issueAt(value, IssueError, "var-not-representable", varNotRepresentableError(name, err).Error())}
+	}
+	return nil
 }
 
 // validateListEnum checks that every entry of a string-list field belongs to a
@@ -1016,6 +1072,11 @@ const nullTag = "!!null"
 
 // mergeTag is YAML's resolved tag for the merge key, in every spelling of it.
 const mergeTag = "!!merge"
+
+// strTag is YAML's resolved tag for a string scalar. It is what tells a var whose
+// value is the author's own CEL from one Deputy has to marshal into CEL for them,
+// so the decoder and the walk share the spelling rather than each writing it out.
+const strTag = "!!str"
 
 // rewritesItsText reports whether a scalar's value is not the text the document
 // writes for it. A YAML tag can arrange exactly that: `action: !!binary ZGVueQ==`

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -116,6 +116,11 @@ type ValidateOptions struct {
 // still recognized as a policy and can be reported with located, specific errors
 // instead of being dismissed as an unknown format. Compiled bundles are ruled
 // out first: their JSON has a "policies" array too.
+//
+// A document whose "policies" key is not written directly still counts when the
+// decoder finds one anyway, which a top-level merge key does. Without that
+// fallback a bundle could inherit its whole policy list from an anchor and slip
+// past the checks that key off this probe, the anchor refusal among them.
 func LooksLikeStructuredBundle(data []byte) bool {
 	if IsCompiledBundle(data) {
 		return false
@@ -124,7 +129,23 @@ func LooksLikeStructuredBundle(data []byte) bool {
 	if err := yaml.Unmarshal(data, root); err != nil || len(root.Content) == 0 {
 		return false
 	}
-	return MappingValue(root.Content[0], "policies") != nil
+	if MappingValue(root.Content[0], "policies") != nil {
+		return true
+	}
+	return decodesWithPolicies(data)
+}
+
+// decodesWithPolicies reports whether data decodes into a bundle carrying at
+// least one policy. It is how the shape probe sees a policies key the node walk
+// cannot: the decoder resolves the aliases and merge keys the walk refuses to
+// follow, so this answers "would a reader that resolves them find policies here"
+// without any reader having to act on the resolved value.
+func decodesWithPolicies(data []byte) bool {
+	var bundle structuredBundle
+	if err := yaml.Unmarshal(data, &bundle); err != nil {
+		return false
+	}
+	return len(bundle.Policies) > 0
 }
 
 // ValidateBundle reports every structural problem in a structured policy bundle:
@@ -154,14 +175,16 @@ func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 	if doc.Kind != yaml.MappingNode {
 		return append(issues, issueAt(doc, IssueError, "root-not-mapping", "root must be a mapping")), nil
 	}
+	// Anchors are rejected before anything else reads the document, so the rest
+	// of validation, and every other reader of a bundle, sees only plain nodes.
+	// The check comes before the policies lookup because a root merge key can
+	// supply the whole list, which would otherwise read as a missing key.
+	if anchors := anchorIssues(root); len(anchors) > 0 {
+		return append(issues, anchors...), nil
+	}
 	policiesNode := MappingValue(doc, "policies")
 	if policiesNode == nil {
 		return append(issues, issueAt(doc, IssueError, "missing-policies", "missing required 'policies' list")), nil
-	}
-	// Anchors are rejected before anything else reads the document, so the rest
-	// of validation, and every other reader of a bundle, sees only plain nodes.
-	if anchors := anchorIssues(root); len(anchors) > 0 {
-		return append(issues, anchors...), nil
 	}
 	if policiesNode.Kind != yaml.SequenceNode {
 		return append(issues, issueAt(policiesNode, IssueError, "policies-not-list", "'policies' must be a list")), nil
@@ -556,15 +579,16 @@ func anchorIssues(node *yaml.Node) []Issue {
 // error naming the file and line, for callers that load a bundle rather than
 // validate it. It returns nil for a document that is not a policy bundle, and
 // for one that uses none of those constructs, which is every bundle Deputy
-// ships. The check keys off the presence of a policies key rather than a
-// well-formed policies list, so a bundle whose list is itself an alias is
-// refused instead of quietly resolved by the decoder.
+// ships. It gates on the same shape probe the linter uses rather than on a
+// well-formed policies list, so a bundle whose list is itself an alias, or whose
+// policies key arrives through a root merge key, is refused instead of quietly
+// resolved by the decoder.
 func bundleAnchorError(data []byte, path string) error {
-	root := &yaml.Node{}
-	if err := yaml.Unmarshal(data, root); err != nil || len(root.Content) == 0 {
+	if !LooksLikeStructuredBundle(data) {
 		return nil
 	}
-	if MappingValue(root.Content[0], "policies") == nil {
+	root := &yaml.Node{}
+	if err := yaml.Unmarshal(data, root); err != nil || len(root.Content) == 0 {
 		return nil
 	}
 	issues := anchorIssues(root)

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -175,19 +175,28 @@ func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 	if doc.Kind != yaml.MappingNode {
 		return append(issues, issueAt(doc, IssueError, "root-not-mapping", "root must be a mapping")), nil
 	}
-	// Anchors are rejected before anything else reads the document, so the rest
+	// Anchors are reported before anything else reads the document, so the rest
 	// of validation, and every other reader of a bundle, sees only plain nodes.
-	// The check comes before the policies lookup because a root merge key can
-	// supply the whole list, which would otherwise read as a missing key.
-	if anchors := anchorIssues(root); len(anchors) > 0 {
-		return append(issues, anchors...), nil
-	}
+	// The scan comes before the policies lookup because a root merge key can
+	// supply the whole list, which would otherwise read as a missing key. It does
+	// not stop the walk: a refused anchor must not hide an unrelated typo and
+	// cost the author a second lint run.
+	anchors := anchorIssues(root)
+	issues = append(issues, anchors...)
 	policiesNode := MappingValue(doc, "policies")
 	if policiesNode == nil {
-		return append(issues, issueAt(doc, IssueError, "missing-policies", "missing required 'policies' list")), nil
+		if len(anchors) == 0 {
+			issues = append(issues, issueAt(doc, IssueError, "missing-policies", "missing required 'policies' list"))
+		}
+		return issues, nil
 	}
 	if policiesNode.Kind != yaml.SequenceNode {
-		return append(issues, issueAt(policiesNode, IssueError, "policies-not-list", "'policies' must be a list")), nil
+		// An aliased list is a list once resolved, so saying it is not one would
+		// describe the alias rather than the mistake.
+		if len(anchors) == 0 {
+			issues = append(issues, issueAt(policiesNode, IssueError, "policies-not-list", "'policies' must be a list"))
+		}
+		return issues, nil
 	}
 	// An empty list is reported here rather than left to the loader backstop, so
 	// the diagnostic names the line the author has to fill in.
@@ -196,11 +205,23 @@ func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 	}
 	seenNames := map[string]struct{}{}
 	for _, item := range policiesNode.Content {
+		// Skip a policy that carries an anchor, an alias, or a merge key anywhere
+		// beneath it: it is already reported, and every further message the walk
+		// could produce would describe the alias node rather than the policy the
+		// author meant. Plain policies alongside it are still checked.
+		if len(anchorIssues(item)) > 0 {
+			continue
+		}
 		if item.Kind != yaml.MappingNode {
 			issues = append(issues, issueAt(item, IssueError, "policy-not-mapping", "policy must be a mapping"))
 			continue
 		}
 		issues = append(issues, validatePolicyNode(item, seenNames, opts)...)
+	}
+	// The loader stops at the first anchor it finds, so it has nothing to add to
+	// what the scan above already located.
+	if len(anchors) > 0 {
+		return issues, nil
 	}
 	// Load the whole bundle as a backstop for shapes the node walk does not model,
 	// such as a rule field of the wrong type. The loader stops at its first
@@ -504,8 +525,9 @@ func DeclaredVarNames(policyNode *yaml.Node) []string {
 
 // MappingValue returns the value node for a key inside a YAML mapping node, or
 // nil when the node is not a mapping or the key is absent. It reads only what
-// the document says: anchors, aliases, and merge keys are rejected before the
-// walk runs (see anchorIssues), so no reader has to resolve them.
+// the document says: anchors, aliases, and merge keys are rejected (see
+// anchorIssues) and the nodes carrying them are skipped, so no reader has to
+// resolve them.
 func MappingValue(mapNode *yaml.Node, key string) *yaml.Node {
 	if mapNode == nil || mapNode.Kind != yaml.MappingNode {
 		return nil

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -158,17 +158,18 @@ func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 	if policiesNode == nil {
 		return append(issues, issueAt(doc, IssueError, "missing-policies", "missing required 'policies' list")), nil
 	}
+	// Anchors are rejected before anything else reads the document, so the rest
+	// of validation, and every other reader of a bundle, sees only plain nodes.
+	if anchors := anchorIssues(root); len(anchors) > 0 {
+		return append(issues, anchors...), nil
+	}
 	if policiesNode.Kind != yaml.SequenceNode {
 		return append(issues, issueAt(policiesNode, IssueError, "policies-not-list", "'policies' must be a list")), nil
 	}
 	seenNames := map[string]struct{}{}
-	for _, entry := range policiesNode.Content {
-		// A policy may be written as an alias to an anchor defined elsewhere in
-		// the document. Report against the alias, which is where the author can
-		// see the problem, but validate what it points at.
-		item := ResolveAlias(entry)
-		if item == nil || item.Kind != yaml.MappingNode {
-			issues = append(issues, issueAt(entry, IssueError, "policy-not-mapping", "policy must be a mapping"))
+	for _, item := range policiesNode.Content {
+		if item.Kind != yaml.MappingNode {
+			issues = append(issues, issueAt(item, IssueError, "policy-not-mapping", "policy must be a mapping"))
 			continue
 		}
 		issues = append(issues, validatePolicyNode(item, seenNames, opts)...)
@@ -473,69 +474,18 @@ func DeclaredVarNames(policyNode *yaml.Node) []string {
 	return names
 }
 
-// aliasDepthLimit bounds how far alias and merge-key resolution will follow
-// references. YAML anchors can be nested, but a document deep enough to exceed
-// this is either generated or malicious, and refusing to follow it keeps
-// validation from looping on a self-referential anchor.
-const aliasDepthLimit = 32
-
-// ResolveAlias follows a YAML alias to the node its anchor defines, so callers
-// can treat `- *policy` exactly as the typed decoder does. A node that is not an
-// alias is returned unchanged.
-func ResolveAlias(node *yaml.Node) *yaml.Node {
-	for depth := 0; node != nil && node.Kind == yaml.AliasNode; depth++ {
-		if depth >= aliasDepthLimit {
-			return nil
-		}
-		node = node.Alias
-	}
-	return node
-}
-
 // MappingValue returns the value node for a key inside a YAML mapping node, or
-// nil when the node is not a mapping or the key is absent. Aliases are followed
-// on both the mapping and the value, and merge keys are searched after the
-// mapping's own keys, matching how the decoder resolves inherited fields: a key
-// written directly on a policy overrides one it merges in.
+// nil when the node is not a mapping or the key is absent. It reads only what
+// the document says: anchors, aliases, and merge keys are rejected before the
+// walk runs (see anchorIssues), so no reader has to resolve them.
 func MappingValue(mapNode *yaml.Node, key string) *yaml.Node {
-	return mappingValue(mapNode, key, 0)
-}
-
-// mappingValue is MappingValue with the recursion depth that merge keys need,
-// since a merged mapping may itself merge from another.
-func mappingValue(mapNode *yaml.Node, key string, depth int) *yaml.Node {
-	node := ResolveAlias(mapNode)
-	if node == nil || node.Kind != yaml.MappingNode || depth >= aliasDepthLimit {
+	if mapNode == nil || mapNode.Kind != yaml.MappingNode {
 		return nil
 	}
-	var merges []*yaml.Node
-	for i := 0; i+1 < len(node.Content); i += 2 {
-		k := node.Content[i]
-		if k.Kind != yaml.ScalarNode {
-			continue
-		}
-		if k.Value == key {
-			return ResolveAlias(node.Content[i+1])
-		}
-		if isMergeKey(k) {
-			merges = append(merges, node.Content[i+1])
-		}
-	}
-	for _, merge := range merges {
-		merged := ResolveAlias(merge)
-		if merged == nil {
-			continue
-		}
-		if merged.Kind == yaml.SequenceNode {
-			for _, item := range merged.Content {
-				if value := mappingValue(item, key, depth+1); value != nil {
-					return value
-				}
-			}
-			continue
-		}
-		if value := mappingValue(merged, key, depth+1); value != nil {
-			return value
+	for i := 0; i+1 < len(mapNode.Content); i += 2 {
+		k := mapNode.Content[i]
+		if k.Kind == yaml.ScalarNode && k.Value == key {
+			return mapNode.Content[i+1]
 		}
 	}
 	return nil
@@ -545,4 +495,76 @@ func mappingValue(mapNode *yaml.Node, key string, depth int) *yaml.Node {
 // pulls another mapping's entries into this one.
 func isMergeKey(key *yaml.Node) bool {
 	return key.Tag == "!!merge" || key.Value == "<<"
+}
+
+// Messages for the YAML constructs a policy bundle does not accept. Both name
+// the alternative, since the author is trying to avoid repeating themselves and
+// deserves to be told how.
+const (
+	anchorNotSupported = "policy bundles do not support YAML anchors and aliases; " +
+		"share rules with a separate --policy file or reuse expressions with vars:"
+	mergeKeyNotSupported = "policy bundles do not support YAML merge keys; " +
+		"share rules with a separate --policy file or reuse expressions with vars:"
+)
+
+// anchorIssues reports every YAML anchor, alias, and merge key in a bundle.
+//
+// Supporting them is closed for now rather than closed forever: nothing stops
+// Deputy from resolving them, and this can be revisited if a real need appears.
+// Two reasons to say no today. A policy bundle is a security control whose job
+// is to state plainly what it blocks, and an aliased policy means the text a
+// reviewer reads is not the policy that runs, while merge-key precedence adds a
+// rule the reviewer has to know before they can tell what a policy does. And
+// every YAML feature the format allows has to be implemented identically by
+// every reader of a bundle, of which there are already several walking nodes
+// directly; that divergence is what let an aliased bundle load fine and lint as
+// broken. The sharing these constructs offer is already served by repeatable
+// --policy files across bundles and by vars: within one.
+func anchorIssues(node *yaml.Node) []Issue {
+	if node == nil {
+		return nil
+	}
+	if node.Kind == yaml.AliasNode {
+		// Do not follow the alias: its target is reported where it is defined.
+		return []Issue{issueAt(node, IssueError, "yaml-anchor", anchorNotSupported)}
+	}
+	var issues []Issue
+	if node.Anchor != "" {
+		issues = append(issues, issueAt(node, IssueError, "yaml-anchor", anchorNotSupported))
+	}
+	for i := 0; i < len(node.Content); i++ {
+		child := node.Content[i]
+		// A mapping's content alternates key, value. A merge key names the
+		// construct, so report it and skip the alias it merges from, which would
+		// otherwise say the same thing twice.
+		if node.Kind == yaml.MappingNode && i%2 == 0 && isMergeKey(child) {
+			issues = append(issues, issueAt(child, IssueError, "yaml-merge-key", mergeKeyNotSupported))
+			i++
+			continue
+		}
+		issues = append(issues, anchorIssues(child)...)
+	}
+	return issues
+}
+
+// bundleAnchorError reports the first anchor, alias, or merge key in data as an
+// error naming the file and line, for callers that load a bundle rather than
+// validate it. It returns nil for a document that is not a policy bundle, and
+// for one that uses none of those constructs, which is every bundle Deputy
+// ships. The check keys off the presence of a policies key rather than a
+// well-formed policies list, so a bundle whose list is itself an alias is
+// refused instead of quietly resolved by the decoder.
+func bundleAnchorError(data []byte, path string) error {
+	root := &yaml.Node{}
+	if err := yaml.Unmarshal(data, root); err != nil || len(root.Content) == 0 {
+		return nil
+	}
+	if MappingValue(root.Content[0], "policies") == nil {
+		return nil
+	}
+	issues := anchorIssues(root)
+	if len(issues) == 0 {
+		return nil
+	}
+	return fmt.Errorf("%s:%d: %s", path, issues[0].Line, issues[0].Message)
 }

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -228,7 +229,8 @@ func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 	// failure, so its message is dropped when a located issue already reports the
 	// same thing, and is anchored on the line it names when it names one.
 	source := cmp.Or(opts.Source, "policy")
-	if _, err := ParseStructuredSources([]byte(text), source); err != nil {
+	sources, err := ParseStructuredSources([]byte(text), source)
+	if err != nil {
 		if message, duplicate := loaderMessage(err, source, issues); !duplicate {
 			issues = append(issues, Issue{
 				RuleIndex: NoRule,
@@ -239,8 +241,44 @@ func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 				Message:   message,
 			})
 		}
+		return issues, nil
 	}
-	return issues, nil
+	return append(issues, generatedSourceIssues(sources, policiesNode, opts.ExtraVars, issues)...), nil
+}
+
+// generatedSourceIssues compiles the CEL each policy expands into, so a bundle
+// that lints clean is a bundle `deputy policy bundle` can compile. Loading a
+// bundle only generates that CEL; nothing before this compiles it. A rule's
+// condition is checked on its own, while a policy's vars wrap every condition in
+// a comprehension, so a var whose value or name is not valid CEL breaks the
+// generated body alone and no per-rule check can see it.
+//
+// Nothing is reported once the walk has located an error, because the generated
+// body is then expected to fail too and restating that failure in expanded CEL
+// the author never wrote would only obscure the real defect. The loader returns
+// one source per policy in document order, which is how each failure is anchored
+// on the policy that produced it.
+func generatedSourceIssues(sources []Source, policiesNode *yaml.Node, extraVars []string, located []Issue) []Issue {
+	if slices.ContainsFunc(located, func(i Issue) bool { return i.Severity == IssueError }) {
+		return nil
+	}
+	var issues []Issue
+	for i, src := range sources {
+		err := Compile(src.Body, extraVars)
+		if err == nil {
+			continue
+		}
+		var node *yaml.Node
+		if i < len(policiesNode.Content) {
+			node = policiesNode.Content[i]
+		}
+		issue := issueAt(node, IssueError, "cel-error", err.Error())
+		if nameNode := MappingValue(node, "name"); nameNode != nil && nameNode.Kind == yaml.ScalarNode {
+			issue.Policy = strings.TrimSpace(nameNode.Value)
+		}
+		issues = append(issues, issue)
+	}
+	return issues
 }
 
 // validatePolicyNode checks one policy mapping: its name uniqueness, its

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -2,6 +2,7 @@ package policy
 
 import (
 	"cmp"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
@@ -662,8 +663,37 @@ func validateRules(item *yaml.Node, policyName string, declaredVars []string, ch
 			}
 		}
 		issues = append(issues, validateRuleAction(rule, idx)...)
+		issues = append(issues, validateRuleDetails(rule, idx)...)
 	}
 	return issues
+}
+
+// validateRuleDetails reports a rule's details that Deputy cannot put into the
+// action the policy generates. The details are marshaled to JSON when a rule is
+// expanded, and YAML writes values JSON has no spelling for, a NaN or an infinity
+// among them, so a rule carrying one cannot be expanded at all.
+//
+// It asks encoding/json rather than judging the value itself, so it recognizes
+// exactly what the expansion recognizes. Locating it here is what reports it on
+// the line it is written on and beside the rule's other defects: the expansion
+// refuses a field of the rule in a fixed order and stops, so an action typo above
+// the details used to withhold this until the typo was fixed and lint rerun.
+func validateRuleDetails(rule *yaml.Node, idx int) []Issue {
+	node := MappingValue(rule, "details")
+	if node == nil {
+		return nil
+	}
+	var details map[string]any
+	// A details value the decoder cannot read at all is the decoder's to report,
+	// on the line it names; this asks only about the values it can read.
+	if err := node.Decode(&details); err != nil {
+		return nil
+	}
+	if _, err := json.Marshal(details); err != nil {
+		message := fmt.Sprintf("'details' holds a value that cannot be represented: %v", err)
+		return []Issue{ruleIssue(idx, issueAt(node, IssueError, "details-not-representable", message))}
+	}
+	return nil
 }
 
 // validateRuleAction checks a rule's action against the allow/deny/warn

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -205,19 +205,29 @@ func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 		return append(issues, issueAt(policiesNode, IssueError, "empty-policies", "'policies' must contain at least one policy")), nil
 	}
 	seenNames := map[string]struct{}{}
-	for _, item := range policiesNode.Content {
+	// Policy positions the walk already reported an error for. Their generated
+	// CEL is expected to fail too, so it is not compiled again; every other
+	// policy still is.
+	reported := map[int]bool{}
+	for i, item := range policiesNode.Content {
 		// Skip a policy that carries an anchor, an alias, or a merge key anywhere
 		// beneath it: it is already reported, and every further message the walk
 		// could produce would describe the alias node rather than the policy the
 		// author meant. Plain policies alongside it are still checked.
 		if len(anchorIssues(item)) > 0 {
+			reported[i] = true
 			continue
 		}
 		if item.Kind != yaml.MappingNode {
 			issues = append(issues, issueAt(item, IssueError, "policy-not-mapping", "policy must be a mapping"))
+			reported[i] = true
 			continue
 		}
-		issues = append(issues, validatePolicyNode(item, seenNames, opts)...)
+		policyIssues := validatePolicyNode(item, seenNames, opts)
+		if slices.ContainsFunc(policyIssues, func(is Issue) bool { return is.Severity == IssueError }) {
+			reported[i] = true
+		}
+		issues = append(issues, policyIssues...)
 	}
 	// The loader stops at the first anchor it finds, so it has nothing to add to
 	// what the scan above already located.
@@ -243,7 +253,7 @@ func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 		}
 		return issues, nil
 	}
-	return append(issues, generatedSourceIssues(sources, policiesNode, opts.ExtraVars, issues)...), nil
+	return append(issues, generatedSourceIssues(sources, policiesNode, opts.ExtraVars, reported)...), nil
 }
 
 // generatedSourceIssues compiles the CEL each policy expands into, so a bundle
@@ -253,17 +263,20 @@ func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 // a comprehension, so a var whose value or name is not valid CEL breaks the
 // generated body alone and no per-rule check can see it.
 //
-// Nothing is reported once the walk has located an error, because the generated
-// body is then expected to fail too and restating that failure in expanded CEL
-// the author never wrote would only obscure the real defect. The loader returns
-// one source per policy in document order, which is how each failure is anchored
-// on the policy that produced it.
-func generatedSourceIssues(sources []Source, policiesNode *yaml.Node, extraVars []string, located []Issue) []Issue {
-	if slices.ContainsFunc(located, func(i Issue) bool { return i.Severity == IssueError }) {
-		return nil
-	}
+// A policy the walk already located an error in is skipped, because its
+// generated body is then expected to fail too and restating that failure in
+// expanded CEL the author never wrote would only obscure the real defect. The
+// skip is per policy rather than bundle-wide: one policy with a bad condition
+// must not hide an unrelated bad var in the next one and cost the author a
+// second lint run. The loader returns one source per policy in document order,
+// which is how reported positions and failures alike are matched to the policy
+// they belong to.
+func generatedSourceIssues(sources []Source, policiesNode *yaml.Node, extraVars []string, reported map[int]bool) []Issue {
 	var issues []Issue
 	for i, src := range sources {
+		if reported[i] {
+			continue
+		}
 		err := Compile(src.Body, extraVars)
 		if err == nil {
 			continue

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"errors"
 	"fmt"
+	"reflect"
 	"regexp"
 	"slices"
 	"strconv"
@@ -709,30 +710,36 @@ func loaderMessage(err error, source string, located []Issue) (string, bool) {
 		if strings.Contains(issue.Message, detail) || strings.Contains(detail, issue.Message) {
 			return message, true
 		}
-		if detail == policyNeedsRuleMessage && slices.Contains(valueShapeCodes, issue.Code) {
+		if _, shape := valueShapeTypes[issue.Code]; detail == policyNeedsRuleMessage && shape {
 			return message, true
 		}
 	}
 	return message, false
 }
 
-// valueShapeCodes are the codes the node walk reports for a value that is not the
-// shape a bundle needs: a policies list that is not a list, an entry of it that
-// is not a policy, and rules the walk cannot read as a list of rules. Every
-// reader of a bundle refuses each of them, so every one of these codes means the
-// loader is about to say the same thing in its own words, either as its refusal
-// of a policy with no rules to run or as the decoder's complaint about the
-// value's type. Neither wording contains the walk's, so the codes are what lets
-// the backstop recognize the restatement and leave one mistake as one issue.
+// valueShapeTypes maps each code the node walk reports for a value that is not
+// the shape a bundle needs, a policies list that is not a list, an entry of it
+// that is not a policy, and rules the walk cannot read as a list of rules, to the
+// Go type the decoder names when it refuses the same value. Every reader of a
+// bundle refuses each of these, so every one of these codes means the loader is
+// about to say the same thing in its own words, either as its refusal of a policy
+// with no rules to run or as the decoder's complaint about the value's type.
+// Neither wording contains the walk's, so this is what lets the backstop
+// recognize the restatement and leave one mistake as one issue.
+//
+// The types are read from the decoder's own targets rather than written out, so
+// renaming one cannot leave a restatement unrecognized. Pairing a code with its
+// type is what keeps the fold on the value the walk located instead of on
+// everything the decoder says about that line (see coversComplaint).
 //
 // TestValidateBundleReportsEachDefectOnce drives one bundle per shape check, so a
 // check added without its code here fails rather than reporting twice.
-var valueShapeCodes = []string{
-	"policies-not-list",
-	"policy-not-mapping",
-	"missing-rules",
-	"rules-not-list",
-	"empty-rules",
+var valueShapeTypes = map[string]string{
+	"policies-not-list":  reflect.TypeFor[[]structuredPolicy]().String(),
+	"policy-not-mapping": reflect.TypeFor[structuredPolicy]().String(),
+	"missing-rules":      reflect.TypeFor[[]structuredRule]().String(),
+	"rules-not-list":     reflect.TypeFor[[]structuredRule]().String(),
+	"empty-rules":        reflect.TypeFor[[]structuredRule]().String(),
 }
 
 // unlocatedDecodeMessage returns the loader's failure with the decoder
@@ -775,6 +782,14 @@ func unlocatedDecodeMessage(err error, located []Issue) (string, bool) {
 // unmarshal into its rule slice, one mistake in two vocabularies, and the line
 // the decoder names is the line the walk located it on. The same holds one level
 // up, for the policies list and for an entry of it that is not a policy.
+//
+// The line is not enough to tell a restatement from a second defect: a line
+// carries as many fields as the author writes on it, and the line a missing rules
+// list is reported on is the policy's first field whatever that field is. So the
+// complaint has to be about the value the located issue describes, which it says
+// by naming the type the decoder could not read that value into. Folding on the
+// line alone dropped a field only the decoder finds and handed it back a lint run
+// later, once the located defect beside it was fixed.
 func coversComplaint(issue Issue, complaint string) bool {
 	if issue.Severity == IssueHint {
 		return false
@@ -782,8 +797,12 @@ func coversComplaint(issue Issue, complaint string) bool {
 	if strings.Contains(issue.Message, complaint) {
 		return true
 	}
+	shape, ok := valueShapeTypes[issue.Code]
+	if !ok {
+		return false
+	}
 	line := lineFromYAMLError(complaint)
-	return line > 0 && line == issue.Line && slices.Contains(valueShapeCodes, issue.Code)
+	return line > 0 && line == issue.Line && strings.Contains(complaint, "into "+shape)
 }
 
 // lineFromYAMLError returns the 1-based line a YAML decode error names, or zero

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -4,7 +4,6 @@ import (
 	"cmp"
 	"errors"
 	"fmt"
-	"slices"
 	"strings"
 
 	yaml "gopkg.in/yaml.v3"
@@ -150,15 +149,15 @@ func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 		}
 		issues = append(issues, validatePolicyNode(item, seenNames, opts)...)
 	}
-	// Load the whole bundle so problems the node walk does not model (mode, vars,
-	// empty rule lists) are still reported, but only when nothing located said it
-	// first: the loader stops at the first failure and cannot point at a line.
-	if slices.ContainsFunc(issues, func(i Issue) bool { return i.Severity != IssueHint }) {
-		return issues, nil
-	}
+	// Load the whole bundle as a backstop for shapes the node walk does not model,
+	// such as a rule field of the wrong type. The loader stops at its first
+	// failure and cannot point at a line, so its message is dropped when a located
+	// issue already reports the same thing.
 	source := cmp.Or(opts.Source, "policy")
 	if _, err := ParseStructuredSources([]byte(text), source); err != nil {
-		issues = append(issues, Issue{RuleIndex: NoRule, Severity: IssueWarning, Code: "bundle-error", Message: err.Error()})
+		if message, duplicate := loaderMessage(err, source, issues); !duplicate {
+			issues = append(issues, Issue{RuleIndex: NoRule, Severity: IssueWarning, Code: "bundle-error", Message: message})
+		}
 	}
 	return issues, nil
 }
@@ -181,6 +180,8 @@ func validatePolicyNode(item *yaml.Node, seenNames map[string]struct{}, opts Val
 	}
 	issues = append(issues, validateListEnum(item, "entrypoints", IsAllowedEntrypoint)...)
 	issues = append(issues, validateListEnum(item, "commands", IsAllowedCommand)...)
+	issues = append(issues, validateMode(item)...)
+	issues = append(issues, validateVars(item)...)
 
 	declaredVars := DeclaredVarNames(item)
 	issues = append(issues, validateRules(item, name, append(declaredVars, opts.ExtraVars...), opts.CheckWhen)...)
@@ -188,6 +189,56 @@ func validatePolicyNode(item *yaml.Node, seenNames map[string]struct{}, opts Val
 		if issues[i].Policy == "" {
 			issues[i].Policy = name
 		}
+	}
+	return issues
+}
+
+// validateMode checks a policy's execution mode against the known vocabulary and
+// anchors the report on the mode node, so it is reported in the same pass as
+// every other defect rather than only once the loader gets that far.
+func validateMode(item *yaml.Node) []Issue {
+	node := MappingValue(item, "mode")
+	if node == nil {
+		return nil
+	}
+	if node.Kind != yaml.ScalarNode {
+		return []Issue{issueAt(node, IssueError, "mode-not-string", "'mode' must be a string")}
+	}
+	if strings.TrimSpace(node.Value) == "" {
+		return nil
+	}
+	if _, err := ValidateMode(node.Value); err != nil {
+		issue := issueAt(node, IssueError, "invalid-mode", err.Error())
+		issue.Length = len(node.Value)
+		return []Issue{issue}
+	}
+	return nil
+}
+
+// validateVars checks the vars mapping: it must be a mapping, and every variable
+// needs a unique non-empty name, since duplicates silently shadow each other
+// when the policy is expanded.
+func validateVars(item *yaml.Node) []Issue {
+	node := MappingValue(item, "vars")
+	if node == nil {
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return []Issue{issueAt(node, IssueError, "vars-not-mapping", "'vars' must be a mapping")}
+	}
+	var issues []Issue
+	seen := map[string]struct{}{}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := node.Content[i]
+		name := strings.TrimSpace(key.Value)
+		if key.Kind != yaml.ScalarNode || name == "" {
+			issues = append(issues, issueAt(key, IssueError, "empty-var-name", "vars must have non-empty names"))
+			continue
+		}
+		if _, dup := seen[name]; dup {
+			issues = append(issues, issueAt(key, IssueError, "duplicate-var", fmt.Sprintf("duplicate var name %q", name)))
+		}
+		seen[name] = struct{}{}
 	}
 	return issues
 }
@@ -227,6 +278,9 @@ func validateRules(item *yaml.Node, policyName string, declaredVars []string, ch
 	}
 	if rulesNode.Kind != yaml.SequenceNode {
 		return []Issue{issueAt(rulesNode, IssueError, "rules-not-list", "'rules' must be a list")}
+	}
+	if len(rulesNode.Content) == 0 {
+		return []Issue{issueAt(rulesNode, IssueError, "empty-rules", "policy must contain at least one rule")}
 	}
 	var issues []Issue
 	for idx, rule := range rulesNode.Content {
@@ -296,6 +350,39 @@ func checkRuleWhen(checkWhen func(RuleWhen) []Issue, when RuleWhen) []Issue {
 		}}
 	}
 	return nil
+}
+
+// loaderMessage prepares the loader's failure for reporting and says whether a
+// located issue already covers it. The loader prefixes its message with the
+// source and policy ("bundle.yaml/name: rule[0]: ..."), so comparison strips
+// that prefix and then treats the remainder as a duplicate when it and a located
+// message contain one another: the two describe the same defect in slightly
+// different words. Anything else is a shape the node walk does not model and is
+// reported as is.
+func loaderMessage(err error, source string, located []Issue) (string, bool) {
+	message := err.Error()
+	detail := strings.TrimPrefix(message, source+"/")
+	if _, rest, ok := strings.Cut(detail, ": "); ok {
+		detail = rest
+	}
+	if rest, ok := strings.CutPrefix(detail, "rule["); ok {
+		if _, tail, found := strings.Cut(rest, "]: "); found {
+			detail = tail
+		}
+	}
+	detail = strings.TrimSpace(detail)
+	if detail == "" {
+		return message, false
+	}
+	for _, issue := range located {
+		if issue.Severity == IssueHint {
+			continue
+		}
+		if strings.Contains(issue.Message, detail) || strings.Contains(detail, issue.Message) {
+			return message, true
+		}
+	}
+	return message, false
 }
 
 // issueAt builds an issue anchored at a YAML node.

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -475,7 +475,7 @@ func validateVars(item *yaml.Node) []Issue {
 	seen := map[string]struct{}{}
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		key := node.Content[i]
-		name := strings.TrimSpace(key.Value)
+		name := normalizeVarName(key.Value)
 		if key.Kind != yaml.ScalarNode || name == "" {
 			issues = append(issues, issueAt(key, IssueError, "empty-var-name", "vars must have non-empty names"))
 			continue
@@ -680,8 +680,10 @@ func DeclaredVarNames(policyNode *yaml.Node) []string {
 	}
 	for i := 0; i+1 < len(varsNode.Content); i += 2 {
 		k := varsNode.Content[i]
-		if k.Kind == yaml.ScalarNode && !isMergeKey(k) && strings.TrimSpace(k.Value) != "" {
-			names = append(names, k.Value)
+		if k.Kind == yaml.ScalarNode && !isMergeKey(k) && normalizeVarName(k.Value) != "" {
+			// The name is normalized because the expansion binds the normalized
+			// spelling, and a condition is compiled against the names it can use.
+			names = append(names, normalizeVarName(k.Value))
 		}
 	}
 	return names

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"errors"
 	"fmt"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -122,18 +123,64 @@ type ValidateOptions struct {
 // decoder finds one anyway, which a top-level merge key does. Without that
 // fallback a bundle could inherit its whole policy list from an anchor and slip
 // past the checks that key off this probe, the anchor refusal among them.
+//
+// A document that does not parse as YAML has no nodes to probe, so the raw text
+// is checked for the key instead. A syntax error is the mistake an author is
+// most likely to make and the one they most need pointed at a line, and without
+// this the file falls through to the unknown-format fallback while the editor,
+// which validates the text directly, names the line.
 func LooksLikeStructuredBundle(data []byte) bool {
 	if IsCompiledBundle(data) {
 		return false
 	}
 	root := &yaml.Node{}
-	if err := yaml.Unmarshal(data, root); err != nil || len(root.Content) == 0 {
+	if err := yaml.Unmarshal(data, root); err != nil {
+		return writesBundleKey(data)
+	}
+	if len(root.Content) == 0 {
 		return false
 	}
-	if MappingValue(root.Content[0], "policies") != nil {
+	// Key presence, not the value: `policies:` with nothing after it is a bundle
+	// missing its list, which has to be reported as such rather than dismissed.
+	if hasMappingKey(root.Content[0], bundlePoliciesKey) {
 		return true
 	}
 	return decodesWithPolicies(data)
+}
+
+// bundlePoliciesKey is the mapping key that marks a document as an authored
+// policy bundle. bundleKeyMatchesStructTag pins it to the field the decoder
+// reads, so the probe and the loader cannot drift apart.
+const bundlePoliciesKey = "policies"
+
+// unparsedBundleKey matches the bundle's policies key written at the top level
+// of a document, in raw text. It is deliberately a last resort: YAML that parses
+// is always probed by walking its nodes, and this runs only for a document the
+// parser rejected outright, where no structure is available to walk.
+var unparsedBundleKey = regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(bundlePoliciesKey) + `[ \t]*:`)
+
+// writesBundleKey reports whether raw text writes the bundle's policies key at
+// the top level, which is how a document the YAML parser rejected is still
+// recognized as an authored bundle with a syntax error in it.
+func writesBundleKey(data []byte) bool {
+	return unparsedBundleKey.Match(data)
+}
+
+// hasMappingKey reports whether a YAML mapping node carries a key, whatever its
+// value. MappingValue answers a different question, "what is this field set to",
+// and reads an explicit null as unset; a probe asking whether the document is a
+// bundle at all needs the key itself.
+func hasMappingKey(mapNode *yaml.Node, key string) bool {
+	if mapNode == nil || mapNode.Kind != yaml.MappingNode {
+		return false
+	}
+	for i := 0; i+1 < len(mapNode.Content); i += 2 {
+		k := mapNode.Content[i]
+		if k.Kind == yaml.ScalarNode && k.Value == key {
+			return true
+		}
+	}
+	return false
 }
 
 // decodesWithPolicies reports whether data decodes into a bundle carrying at
@@ -184,7 +231,7 @@ func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 	// cost the author a second lint run.
 	anchors := anchorIssues(root)
 	issues = append(issues, anchors...)
-	policiesNode := MappingValue(doc, "policies")
+	policiesNode := MappingValue(doc, bundlePoliciesKey)
 	if policiesNode == nil {
 		if len(anchors) == 0 {
 			issues = append(issues, issueAt(doc, IssueError, "missing-policies", "missing required 'policies' list"))

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -261,15 +261,15 @@ func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 	if doc.Kind != yaml.MappingNode {
 		return append(issues, issueAt(doc, IssueError, "root-not-mapping", "root must be a mapping")), nil
 	}
-	// Anchors are reported before anything else reads the document, so the rest of
-	// validation, and every other reader of a bundle, sees only plain nodes. The
-	// scan comes before the policies lookup because a root merge key can supply
-	// the whole list, which would otherwise read as a missing key. It stops none
-	// of the checks that follow: a refused anchor must not hide an unrelated typo,
-	// or an uncompilable var, and cost the author a second lint run. What a later
-	// check does skip is the node it cannot read, which is a reference and not
-	// every node an anchor names (see resolvesElsewhere).
-	issues = append(issues, anchorIssues(root)...)
+	// The refused constructs are reported before anything else reads the document,
+	// so the rest of validation, and every other reader of a bundle, sees only
+	// plain nodes. The scan comes before the policies lookup because a root merge
+	// key can supply the whole list, which would otherwise read as a missing key.
+	// It stops none of the checks that follow: a refused construct must not hide
+	// an unrelated typo, or an uncompilable var, and cost the author a second lint
+	// run. What a later check does skip is the node it cannot read, which is a
+	// reference and not every node an anchor names (see resolvesElsewhere).
+	issues = append(issues, refusedConstructIssues(root)...)
 	policiesNode := MappingValue(doc, bundlePoliciesKey)
 	if policiesNode == nil {
 		// A root merge key supplies the whole list, so a document carrying one is
@@ -785,8 +785,9 @@ func DeclaredVarNames(policyNode *yaml.Node) []string {
 // MappingValue returns the value node for a key inside a YAML mapping node, or
 // nil when the node is not a mapping, the key is absent, or the key is present
 // with an explicitly null value. It reads only what the document says: anchors,
-// aliases, and merge keys are rejected (see anchorIssues) and the nodes carrying
-// them are skipped, so no reader has to resolve them.
+// aliases, merge keys, and rewriting tags are rejected (see
+// refusedConstructIssues) and the nodes carrying a reference are skipped, so no
+// reader has to resolve them.
 func MappingValue(mapNode *yaml.Node, key string) *yaml.Node {
 	if mapNode == nil || mapNode.Kind != yaml.MappingNode {
 		return nil
@@ -837,30 +838,64 @@ func isMergeKey(key *yaml.Node) bool {
 	return key.Tag == "!!merge" || key.Value == "<<"
 }
 
-// Messages for the YAML constructs a policy bundle does not accept. Both name
-// the alternative, since the author is trying to avoid repeating themselves and
-// deserves to be told how.
+// Messages for the YAML constructs a policy bundle does not accept. Each names
+// the alternative, since the author is reaching for the construct to say
+// something and deserves to be told how to say it plainly.
 const (
 	anchorNotSupported = "policy bundles do not support YAML anchors and aliases; " +
 		"share rules with a separate --policy file or reuse expressions with vars:"
 	mergeKeyNotSupported = "policy bundles do not support YAML merge keys; " +
 		"share rules with a separate --policy file or reuse expressions with vars:"
+	opaqueScalarNotSupported = "policy bundles do not support YAML tags that rewrite a scalar; " +
+		"write the value the policy means"
 )
 
-// anchorIssues reports every YAML anchor, alias, and merge key in a bundle.
+// nullTag is YAML's resolved tag for every spelling of null.
+const nullTag = "!!null"
+
+// rewritesItsText reports whether a scalar's value is not the text the document
+// writes for it. A YAML tag can arrange exactly that: `action: !!binary ZGVueQ==`
+// is written as base64 and read as "deny", so the walk judging the written text
+// and the decoder reading the value disagree about the same field.
+//
+// The test is the divergence itself rather than a list of tags, so a tag nobody
+// thought of cannot reopen the gap. Null is excluded because it is the one
+// rewrite every reader of a bundle already models the same way: the decoder
+// leaves the field at its zero value and the walk reads the key as unset (see
+// isNullNode).
+func rewritesItsText(node *yaml.Node) bool {
+	if node == nil || node.Kind != yaml.ScalarNode || node.Tag == nullTag {
+		return false
+	}
+	var text string
+	// A scalar the decoder cannot read as a string rewrites nothing: it fails the
+	// same way for the loader, which is a disagreement neither reader can hide.
+	if err := node.Decode(&text); err != nil {
+		return false
+	}
+	return text != node.Value
+}
+
+// refusedConstructIssues reports every YAML construct a policy bundle does not
+// accept: anchors, aliases, merge keys, and tags that rewrite a scalar. It is
+// the one definition of that vocabulary, which is what keeps the linter and the
+// loader refusing the same documents; both reach it, validation directly and
+// loading through bundleRefusalError.
 //
 // Supporting them is closed for now rather than closed forever: nothing stops
 // Deputy from resolving them, and this can be revisited if a real need appears.
 // Two reasons to say no today. A policy bundle is a security control whose job
 // is to state plainly what it blocks, and an aliased policy means the text a
 // reviewer reads is not the policy that runs, while merge-key precedence adds a
-// rule the reviewer has to know before they can tell what a policy does. And
-// every YAML feature the format allows has to be implemented identically by
-// every reader of a bundle, of which there are already several walking nodes
-// directly; that divergence is what let an aliased bundle load fine and lint as
-// broken. The sharing these constructs offer is already served by repeatable
-// --policy files across bundles and by vars: within one.
-func anchorIssues(node *yaml.Node) []Issue {
+// rule the reviewer has to know before they can tell what a policy does. A
+// rewriting tag is the same defect spelled shorter: `action: !!binary ZGVueQ==`
+// reviews as base64 and denies. And every YAML feature the format allows has to
+// be implemented identically by every reader of a bundle, of which there are
+// already several walking nodes directly; that divergence is what let an aliased
+// bundle load fine and lint as broken, and what made a tagged action lint as
+// invalid and compile as deny. The sharing these constructs offer is already
+// served by repeatable --policy files across bundles and by vars: within one.
+func refusedConstructIssues(node *yaml.Node) []Issue {
 	if node == nil {
 		return nil
 	}
@@ -872,6 +907,9 @@ func anchorIssues(node *yaml.Node) []Issue {
 	if node.Anchor != "" {
 		issues = append(issues, issueAt(node, IssueError, "yaml-anchor", anchorNotSupported))
 	}
+	if rewritesItsText(node) {
+		issues = append(issues, issueAt(node, IssueError, "yaml-opaque-scalar", opaqueScalarNotSupported))
+	}
 	for i := 0; i < len(node.Content); i++ {
 		child := node.Content[i]
 		// A mapping's content alternates key, value. A merge key names the
@@ -882,7 +920,7 @@ func anchorIssues(node *yaml.Node) []Issue {
 			i++
 			continue
 		}
-		issues = append(issues, anchorIssues(child)...)
+		issues = append(issues, refusedConstructIssues(child)...)
 	}
 	return issues
 }
@@ -890,7 +928,7 @@ func anchorIssues(node *yaml.Node) []Issue {
 // resolvesElsewhere reports whether a node says part of what it means somewhere
 // other than where it is written: a YAML alias, whose value lives at the anchor
 // it names, or a merge key, which pulls another mapping's entries in. Deputy
-// refuses both (see anchorIssues), so no reader resolves them, and a walk that
+// refuses both (see refusedConstructIssues), so no reader resolves them, and a walk that
 // cannot follow them can only describe the reference rather than the value.
 // Nodes carrying one are therefore skipped by the checks that read a document's
 // values.
@@ -917,15 +955,18 @@ func resolvesElsewhere(node *yaml.Node) bool {
 	return false
 }
 
-// bundleAnchorError reports the first anchor, alias, or merge key in data as an
-// error naming the file and line, for callers that load a bundle rather than
-// validate it. It returns nil for a document that is not a policy bundle, and
-// for one that uses none of those constructs, which is every bundle Deputy
-// ships. It gates on the same shape probe the linter uses rather than on a
-// well-formed policies list, so a bundle whose list is itself an alias, or whose
-// policies key arrives through a root merge key, is refused instead of quietly
-// resolved by the decoder.
-func bundleAnchorError(data []byte, path string) error {
+// bundleRefusalError reports the first construct in data that a policy bundle
+// does not accept as an error naming the file and line, for callers that load a
+// bundle rather than validate it. It returns nil for a document that is not a
+// policy bundle, and for one that uses none of those constructs, which is every
+// bundle Deputy ships. It gates on the same shape probe the linter uses rather
+// than on a well-formed policies list, so a bundle whose list is itself an
+// alias, or whose policies key arrives through a root merge key, is refused
+// instead of quietly resolved by the decoder.
+//
+// It shares refusedConstructIssues with validation rather than restating the
+// vocabulary, so the loader cannot come to accept a document the linter rejects.
+func bundleRefusalError(data []byte, path string) error {
 	if !LooksLikeStructuredBundle(data) {
 		return nil
 	}
@@ -933,7 +974,7 @@ func bundleAnchorError(data []byte, path string) error {
 	if err := yaml.Unmarshal(data, root); err != nil || len(root.Content) == 0 {
 		return nil
 	}
-	issues := anchorIssues(root)
+	issues := refusedConstructIssues(root)
 	if len(issues) == 0 {
 		return nil
 	}

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -282,33 +282,62 @@ func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 	// run. What a later check does skip is the node it cannot read, which is a
 	// reference and not every node an anchor names (see resolvesElsewhere).
 	issues = append(issues, refusedConstructIssues(root)...)
+	source := cmp.Or(opts.Source, "policy")
+	// What the policies list is wrong about, and what each policy it holds is
+	// wrong about, are reported without returning, so the bundle-level backstop
+	// below still runs. A list the walk cannot iterate says nothing about the
+	// bundle metadata beside it, and returning here made the author fix the list
+	// and lint again to be told about the rest.
+	issues = append(issues, policiesListIssues(doc, source, opts)...)
+	// Decoding the whole bundle is the last backstop, for the shapes that belong
+	// to no single policy, such as bundle metadata of the wrong type. It stops at
+	// its first failure, which is why it runs after every policy has been expanded
+	// on its own and adds only what is not already reported. It is the decode
+	// alone: routing it through the loader would stop at the loader's refusal of
+	// an anchor this run has already located and named a line for, and hide the
+	// bundle-level shape behind it. A document that says part of itself elsewhere
+	// is skipped, since the decoder would resolve what no reader of a bundle may.
+	if !resolvesElsewhere(root) {
+		if _, _, err := decodeStructuredBundle([]byte(text), source, true); err != nil {
+			issues = append(issues, backstopIssue(err, source, doc, issues)...)
+		}
+	}
+	return issues, nil
+}
+
+// policiesListIssues reports what the bundle's policies list is wrong about, and
+// what each policy it holds is wrong about. It is everything ValidateBundle can
+// say by walking the document, split out from the bundle-level decode so that
+// neither withholds the other: a defect in the list itself is the one place a
+// walk cannot go further, and it used to end the whole run.
+func policiesListIssues(doc *yaml.Node, source string, opts ValidateOptions) []Issue {
 	policiesNode := MappingValue(doc, bundlePoliciesKey)
-	if policiesNode == nil {
+	switch {
+	case policiesNode == nil:
 		// A root merge key supplies the whole list, so a document carrying one is
 		// not missing it and the merge key is the only mistake to report. Nothing
 		// else the document does can put the key here, so an anchor elsewhere does
 		// not withhold this.
-		if !hasMergeKey(doc) {
-			issues = append(issues, issueAt(doc, IssueError, "missing-policies", "missing required 'policies' list"))
+		if hasMergeKey(doc) {
+			return nil
 		}
-		return issues, nil
-	}
-	if policiesNode.Kind != yaml.SequenceNode {
+		return []Issue{issueAt(doc, IssueError, "missing-policies", "missing required 'policies' list")}
+	case policiesNode.Kind == yaml.AliasNode:
 		// An aliased list is a list once resolved, so saying it is not one would
-		// describe the alias rather than the mistake. A value written directly is
-		// the mistake, whatever the document does elsewhere.
-		if policiesNode.Kind != yaml.AliasNode {
-			issues = append(issues, issueAt(policiesNode, IssueError, "policies-not-list", "'policies' must be a list"))
-		}
-		return issues, nil
+		// describe the alias rather than the mistake. The alias itself is already
+		// reported as a refused construct.
+		return nil
+	case policiesNode.Kind != yaml.SequenceNode:
+		// A value written directly is the mistake, whatever the document does
+		// elsewhere.
+		return []Issue{issueAt(policiesNode, IssueError, "policies-not-list", "'policies' must be a list")}
+	case len(policiesNode.Content) == 0:
+		// An empty list is reported here rather than left to the loader backstop,
+		// so the diagnostic names the line the author has to fill in.
+		return []Issue{issueAt(policiesNode, IssueError, "empty-policies", "'policies' must contain at least one policy")}
 	}
-	// An empty list is reported here rather than left to the loader backstop, so
-	// the diagnostic names the line the author has to fill in.
-	if len(policiesNode.Content) == 0 {
-		return append(issues, issueAt(policiesNode, IssueError, "empty-policies", "'policies' must contain at least one policy")), nil
-	}
+	var issues []Issue
 	seenNames := map[string]struct{}{}
-	source := cmp.Or(opts.Source, "policy")
 	for _, item := range policiesNode.Content {
 		// Skip a policy the walk cannot read: an alias or a merge key beneath it
 		// puts part of the policy somewhere else, so every further message would
@@ -326,20 +355,7 @@ func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 		issues = append(issues, located...)
 		issues = append(issues, expandedPolicyIssues(item, source, opts.ExtraVars, located)...)
 	}
-	// Decoding the whole bundle is the last backstop, for the shapes that belong
-	// to no single policy, such as bundle metadata of the wrong type. It stops at
-	// its first failure, which is why it runs after every policy has been expanded
-	// on its own and adds only what is not already reported. It is the decode
-	// alone: routing it through the loader would stop at the loader's refusal of
-	// an anchor this run has already located and named a line for, and hide the
-	// bundle-level shape behind it. A document that says part of itself elsewhere
-	// is skipped, since the decoder would resolve what no reader of a bundle may.
-	if !resolvesElsewhere(root) {
-		if _, _, err := decodeStructuredBundle([]byte(text), source); err != nil {
-			issues = append(issues, backstopIssue(err, source, doc, issues)...)
-		}
-	}
-	return issues, nil
+	return issues
 }
 
 // expandedPolicyIssues reports what only expanding one policy can find. Two
@@ -672,21 +688,31 @@ func loaderMessage(err error, source string, located []Issue) (string, bool) {
 		if strings.Contains(issue.Message, detail) || strings.Contains(detail, issue.Message) {
 			return message, true
 		}
-		if detail == policyNeedsRuleMessage && slices.Contains(ruleShapeCodes, issue.Code) {
+		if detail == policyNeedsRuleMessage && slices.Contains(valueShapeCodes, issue.Code) {
 			return message, true
 		}
 	}
 	return message, false
 }
 
-// ruleShapeCodes are the codes the node walk reports for a policy whose rules it
-// cannot read as a list of rules: absent, not a list, or empty. Every reader of
-// a bundle refuses such a policy, so each of these codes means the loader is
-// about to say the same thing in its own words, either as its refusal of a
-// policy with no rules to run or as the decoder's complaint about the value's
-// type. Neither wording contains the walk's, so the codes are what lets the
-// backstop recognize the restatement and leave one mistake as one issue.
-var ruleShapeCodes = []string{"missing-rules", "rules-not-list", "empty-rules"}
+// valueShapeCodes are the codes the node walk reports for a value that is not the
+// shape a bundle needs: a policies list that is not a list, an entry of it that
+// is not a policy, and rules the walk cannot read as a list of rules. Every
+// reader of a bundle refuses each of them, so every one of these codes means the
+// loader is about to say the same thing in its own words, either as its refusal
+// of a policy with no rules to run or as the decoder's complaint about the
+// value's type. Neither wording contains the walk's, so the codes are what lets
+// the backstop recognize the restatement and leave one mistake as one issue.
+//
+// TestValidateBundleReportsEachDefectOnce drives one bundle per shape check, so a
+// check added without its code here fails rather than reporting twice.
+var valueShapeCodes = []string{
+	"policies-not-list",
+	"policy-not-mapping",
+	"missing-rules",
+	"rules-not-list",
+	"empty-rules",
+}
 
 // unlocatedDecodeMessage returns the loader's failure with the decoder
 // complaints a located issue already reports removed, and false when that leaves
@@ -726,7 +752,8 @@ func unlocatedDecodeMessage(err error, located []Issue) (string, bool) {
 // decode from restating what it found. Otherwise only a rule shape is folded: a
 // rules value the walk calls "not a list" is a value the decoder cannot
 // unmarshal into its rule slice, one mistake in two vocabularies, and the line
-// the decoder names is the line the walk located it on.
+// the decoder names is the line the walk located it on. The same holds one level
+// up, for the policies list and for an entry of it that is not a policy.
 func coversComplaint(issue Issue, complaint string) bool {
 	if issue.Severity == IssueHint {
 		return false
@@ -735,7 +762,7 @@ func coversComplaint(issue Issue, complaint string) bool {
 		return true
 	}
 	line := lineFromYAMLError(complaint)
-	return line > 0 && line == issue.Line && slices.Contains(ruleShapeCodes, issue.Code)
+	return line > 0 && line == issue.Line && slices.Contains(valueShapeCodes, issue.Code)
 }
 
 // lineFromYAMLError returns the 1-based line a YAML decode error names, or zero

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -239,14 +239,15 @@ func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 	if doc.Kind != yaml.MappingNode {
 		return append(issues, issueAt(doc, IssueError, "root-not-mapping", "root must be a mapping")), nil
 	}
-	// Anchors are reported before anything else reads the document, so the rest
-	// of validation, and every other reader of a bundle, sees only plain nodes.
-	// The scan comes before the policies lookup because a root merge key can
-	// supply the whole list, which would otherwise read as a missing key. It does
-	// not stop the checks that follow: a refused anchor must not hide an unrelated
-	// typo, or an uncompilable var, and cost the author a second lint run.
-	anchors := anchorIssues(root)
-	issues = append(issues, anchors...)
+	// Anchors are reported before anything else reads the document, so the rest of
+	// validation, and every other reader of a bundle, sees only plain nodes. The
+	// scan comes before the policies lookup because a root merge key can supply
+	// the whole list, which would otherwise read as a missing key. It stops none
+	// of the checks that follow: a refused anchor must not hide an unrelated typo,
+	// or an uncompilable var, and cost the author a second lint run. What a later
+	// check does skip is the node it cannot read, which is a reference and not
+	// every node an anchor names (see resolvesElsewhere).
+	issues = append(issues, anchorIssues(root)...)
 	policiesNode := MappingValue(doc, bundlePoliciesKey)
 	if policiesNode == nil {
 		// A root merge key supplies the whole list, so a document carrying one is
@@ -297,14 +298,16 @@ func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 		}
 		issues = append(issues, expandedPolicyIssues(item, source, opts.ExtraVars, located)...)
 	}
-	// Loading the whole bundle is the last backstop, for the shapes that belong to
-	// no single policy, such as bundle metadata of the wrong type. It stops at its
-	// first failure, which is why it runs after every policy has been expanded on
-	// its own and adds only what is not already reported. A document carrying an
-	// anchor skips it outright: the loader stops at the first one, which the scan
-	// above already located.
-	if len(anchors) == 0 {
-		if _, err := ParseStructuredSources([]byte(text), source); err != nil {
+	// Decoding the whole bundle is the last backstop, for the shapes that belong
+	// to no single policy, such as bundle metadata of the wrong type. It stops at
+	// its first failure, which is why it runs after every policy has been expanded
+	// on its own and adds only what is not already reported. It is the decode
+	// alone: routing it through the loader would stop at the loader's refusal of
+	// an anchor this run has already located and named a line for, and hide the
+	// bundle-level shape behind it. A document that says part of itself elsewhere
+	// is skipped, since the decoder would resolve what no reader of a bundle may.
+	if !resolvesElsewhere(root) {
+		if _, _, err := decodeStructuredBundle([]byte(text), source); err != nil {
 			issues = append(issues, backstopIssue(err, source, doc, issues)...)
 		}
 	}

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -110,11 +110,12 @@ type ValidateOptions struct {
 }
 
 // LooksLikeStructuredBundle reports whether data has the shape of an authored
-// policy bundle: a mapping carrying a non-empty "policies" list. It deliberately
-// does not require the bundle to decode into Deputy's types, so a policy with a
-// mistyped field is still recognized as a policy and can be reported with
-// located, specific errors instead of being dismissed as an unknown format.
-// Compiled bundles are ruled out first: their JSON has a "policies" array too.
+// policy bundle: a mapping carrying a "policies" key. It deliberately does not
+// require the bundle to decode into Deputy's types, nor the key to hold a
+// well-formed list, so a policy with a mistyped field or a "policies" mapping is
+// still recognized as a policy and can be reported with located, specific errors
+// instead of being dismissed as an unknown format. Compiled bundles are ruled
+// out first: their JSON has a "policies" array too.
 func LooksLikeStructuredBundle(data []byte) bool {
 	if IsCompiledBundle(data) {
 		return false
@@ -123,8 +124,7 @@ func LooksLikeStructuredBundle(data []byte) bool {
 	if err := yaml.Unmarshal(data, root); err != nil || len(root.Content) == 0 {
 		return false
 	}
-	policies := MappingValue(root.Content[0], "policies")
-	return policies != nil && policies.Kind == yaml.SequenceNode && len(policies.Content) > 0
+	return MappingValue(root.Content[0], "policies") != nil
 }
 
 // ValidateBundle reports every structural problem in a structured policy bundle:
@@ -165,6 +165,11 @@ func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 	}
 	if policiesNode.Kind != yaml.SequenceNode {
 		return append(issues, issueAt(policiesNode, IssueError, "policies-not-list", "'policies' must be a list")), nil
+	}
+	// An empty list is reported here rather than left to the loader backstop, so
+	// the diagnostic names the line the author has to fill in.
+	if len(policiesNode.Content) == 0 {
+		return append(issues, issueAt(policiesNode, IssueError, "empty-policies", "'policies' must contain at least one policy")), nil
 	}
 	seenNames := map[string]struct{}{}
 	for _, item := range policiesNode.Content {

--- a/internal/policy/validate.go
+++ b/internal/policy/validate.go
@@ -249,15 +249,20 @@ func ValidateBundle(text string, opts ValidateOptions) ([]Issue, error) {
 	issues = append(issues, anchors...)
 	policiesNode := MappingValue(doc, bundlePoliciesKey)
 	if policiesNode == nil {
-		if len(anchors) == 0 {
+		// A root merge key supplies the whole list, so a document carrying one is
+		// not missing it and the merge key is the only mistake to report. Nothing
+		// else the document does can put the key here, so an anchor elsewhere does
+		// not withhold this.
+		if !hasMergeKey(doc) {
 			issues = append(issues, issueAt(doc, IssueError, "missing-policies", "missing required 'policies' list"))
 		}
 		return issues, nil
 	}
 	if policiesNode.Kind != yaml.SequenceNode {
 		// An aliased list is a list once resolved, so saying it is not one would
-		// describe the alias rather than the mistake.
-		if len(anchors) == 0 {
+		// describe the alias rather than the mistake. A value written directly is
+		// the mistake, whatever the document does elsewhere.
+		if policiesNode.Kind != yaml.AliasNode {
 			issues = append(issues, issueAt(policiesNode, IssueError, "policies-not-list", "'policies' must be a list"))
 		}
 		return issues, nil
@@ -676,6 +681,22 @@ func MappingValue(mapNode *yaml.Node, key string) *yaml.Node {
 // policy name two such policies would then collide on.
 func isNullNode(node *yaml.Node) bool {
 	return node != nil && node.Kind == yaml.ScalarNode && node.Tag == "!!null"
+}
+
+// hasMergeKey reports whether a mapping node merges another mapping's entries
+// into itself. Only a merge key on the mapping itself can add keys to it, which
+// is what makes a bundle whose policies key arrives that way not a bundle
+// missing the key.
+func hasMergeKey(mapNode *yaml.Node) bool {
+	if mapNode == nil || mapNode.Kind != yaml.MappingNode {
+		return false
+	}
+	for i := 0; i+1 < len(mapNode.Content); i += 2 {
+		if isMergeKey(mapNode.Content[i]) {
+			return true
+		}
+	}
+	return false
 }
 
 // isMergeKey reports whether a mapping key is YAML's merge key, the "<<" that

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -697,6 +697,22 @@ policies:
 `,
 		},
 		{
+			name: "policy names that differ only by surrounding whitespace",
+			bundle: `
+policies:
+  - name: same
+    rules:
+      - when: "true"
+        action: deny
+        reason: "r"
+  - name: "  same  "
+    rules:
+      - when: "true"
+        action: deny
+        reason: "r"
+`,
+		},
+		{
 			name: "a policies list supplied by a root merge key",
 			bundle: `
 defaults: &defaults

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -181,6 +181,30 @@ policies:
 	}
 }
 
+// TestValidateBundleRejectsCompiledBundle pins that a bundle compiled by
+// `deputy policy bundle` is not mistaken for an authored one. Its JSON parses as
+// YAML and has a "policies" array, so without the check every entry would be
+// reported as a policy missing its rules.
+func TestValidateBundleRejectsCompiledBundle(t *testing.T) {
+	compiled := `{
+  "schemaVersion": "policy.deputy.sh/v1alpha1",
+  "generated": "2026-01-01T00:00:00Z",
+  "policies": [
+    {"name": "compiled", "source": "[] + ((true) ? [{\"action\":\"deny\"}] : [])"}
+  ]
+}`
+	issues, err := ValidateBundle(compiled, ValidateOptions{})
+	if err == nil {
+		t.Fatalf("expected compiled bundle to be rejected, got issues %v", issues)
+	}
+	if !strings.Contains(err.Error(), "compiled policy bundle") {
+		t.Fatalf("error %q should name the compiled bundle shape", err)
+	}
+	if _, parsed, _ := TryParseStructuredBundleBytes([]byte(compiled)); parsed {
+		t.Fatal("compiled bundle must not be reported as a structured bundle")
+	}
+}
+
 // TestValidateBundleRejectsNonYAML pins that unparseable input is an error rather
 // than a silently clean bundle.
 func TestValidateBundleRejectsNonYAML(t *testing.T) {

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -315,6 +315,213 @@ policies:
 	}
 }
 
+// TestAnchorsRejectedAtEveryPosition pins that an anchor is refused wherever it
+// can appear, by both readers, with the same message. An alias is a node kind,
+// so it can stand in for a policy, a rule, a list item, a var value, or any
+// scalar, and a reader that resolves it at one position and rejects it at
+// another is the divergence this restriction removes: before the format refused
+// them, `rules: [*rule]` loaded fine and linted as "rule must be a mapping".
+func TestAnchorsRejectedAtEveryPosition(t *testing.T) {
+	cases := []struct {
+		name     string
+		bundle   string
+		wantCode string
+	}{
+		{
+			name: "a policy item",
+			bundle: `
+base: &base
+  name: aliased
+  rules:
+    - when: "true"
+      action: deny
+      reason: "r"
+
+policies:
+  - *base
+`,
+			wantCode: "yaml-anchor",
+		},
+		{
+			name: "an individual rule item",
+			bundle: `
+sharedRule: &rule
+  when: "true"
+  action: deny
+  reason: "r"
+
+policies:
+  - name: alias-rule-item
+    rules: [*rule]
+`,
+			wantCode: "yaml-anchor",
+		},
+		{
+			name: "the rules list itself",
+			bundle: `
+sharedRules: &rules
+  - when: "true"
+    action: deny
+    reason: "r"
+
+policies:
+  - name: alias-rules-list
+    rules: *rules
+`,
+			wantCode: "yaml-anchor",
+		},
+		{
+			name: "a vars value",
+			bundle: `
+blockedList: &blocked '["left-pad"]'
+
+policies:
+  - name: alias-var-value
+    vars:
+      blocked: *blocked
+    rules:
+      - when: "pkg.name in blocked"
+        action: deny
+        reason: "r"
+`,
+			wantCode: "yaml-anchor",
+		},
+		{
+			name: "the vars mapping itself",
+			bundle: `
+sharedVars: &vars
+  blocked: '["left-pad"]'
+
+policies:
+  - name: alias-vars-mapping
+    vars: *vars
+    rules:
+      - when: "pkg.name in blocked"
+        action: deny
+        reason: "r"
+`,
+			wantCode: "yaml-anchor",
+		},
+		{
+			name: "a nested sequence item",
+			bundle: `
+eco: &eco "npm"
+
+policies:
+  - name: alias-nested-seq
+    ecosystems: [*eco]
+    rules:
+      - when: "true"
+        action: deny
+        reason: "r"
+`,
+			wantCode: "yaml-anchor",
+		},
+		{
+			name: "a scalar field",
+			bundle: `
+policyName: &name "aliased-name"
+
+policies:
+  - name: *name
+    rules:
+      - when: "true"
+        action: deny
+        reason: "r"
+`,
+			wantCode: "yaml-anchor",
+		},
+		{
+			name:     "the policies list itself",
+			bundle:   "policies: &loop\n  - *loop\n",
+			wantCode: "yaml-anchor",
+		},
+		{
+			name: "an anchor that is never referenced",
+			bundle: `
+unused: &unused
+  name: never-referenced
+
+policies:
+  - name: plain
+    rules:
+      - when: "true"
+        action: deny
+        reason: "r"
+`,
+			wantCode: "yaml-anchor",
+		},
+		{
+			name: "a merge key on a policy",
+			bundle: `
+defaults: &defaults
+  rules:
+    - when: "true"
+      action: deny
+      reason: "r"
+
+policies:
+  - <<: *defaults
+    name: merged-policy
+`,
+			wantCode: "yaml-merge-key",
+		},
+		{
+			name: "a merge key inside a rule",
+			bundle: `
+ruleDefaults: &ruleDefaults
+  action: deny
+  reason: "r"
+
+policies:
+  - name: merged-rule
+    rules:
+      - <<: *ruleDefaults
+        when: "true"
+`,
+			wantCode: "yaml-merge-key",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			issues, err := ValidateBundle(tc.bundle, ValidateOptions{Source: "bundle.yaml"})
+			if err != nil {
+				t.Fatalf("ValidateBundle: %v", err)
+			}
+			var codes []string
+			for _, issue := range issues {
+				codes = append(codes, issue.Code)
+			}
+			if !slices.Contains(codes, tc.wantCode) {
+				t.Fatalf("expected issue code %q, got %v: %v", tc.wantCode, codes, issues)
+			}
+			for _, issue := range issues {
+				if issue.Line <= 0 {
+					t.Fatalf("issue %v should name the line the construct is on", issue)
+				}
+			}
+
+			// The loader has to refuse the same document, or a bundle that lints
+			// as broken would still compile.
+			_, loadErr := ParseStructuredSources([]byte(tc.bundle), "bundle.yaml")
+			if loadErr == nil {
+				t.Fatal("expected the loader to reject the bundle too")
+			}
+			if !strings.Contains(loadErr.Error(), "policy bundles do not support YAML") {
+				t.Fatalf("loader error %q should refuse the construct by name", loadErr)
+			}
+			for _, want := range []string{"--policy file", "vars:"} {
+				if !strings.Contains(loadErr.Error(), want) {
+					t.Fatalf("loader error %q should point at %q", loadErr, want)
+				}
+				if !strings.Contains(issues[0].Message, want) {
+					t.Fatalf("issue message %q should point at %q", issues[0].Message, want)
+				}
+			}
+		})
+	}
+}
+
 // TestValidateBundleAgreesWithLoader pins the equivalence the two paths must
 // keep: a bundle the loader compiles has to validate clean, and one the loader
 // rejects has to be reported. Validation walks YAML nodes while the loader

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -1388,6 +1388,22 @@ policies: none
 			wantCodes: []string{"yaml-anchor", "policies-not-list"},
 		},
 		{
+			name: "an unused anchor beside bundle metadata of the wrong type",
+			bundle: `
+unused: &u 1
+
+metadata: []
+
+policies:
+  - name: plain
+    rules:
+      - when: "true"
+        action: deny
+        reason: "r"
+`,
+			wantCodes: []string{"yaml-anchor", "bundle-error"},
+		},
+		{
 			name: "an unused anchor in a document with no policies key",
 			bundle: `
 unused: &u

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"reflect"
 	"slices"
 	"strings"
 	"testing"
@@ -992,8 +993,18 @@ func TestLooksLikeStructuredBundle(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "not YAML at all",
+			name: "a bundle whose YAML does not parse",
 			data: "policies: [\n  - name: broken\n",
+			want: true,
+		},
+		{
+			name: "a bundle whose YAML does not parse below the policies key",
+			data: "policies:\n  - name: broken\n    rules: [\n",
+			want: true,
+		},
+		{
+			name: "raw CEL that does not parse as YAML",
+			data: "// policy: legacy\npkg.name == \"left-pad\"\n  ? [{\"action\": \"deny\"}]\n  : []\n",
 		},
 	}
 	for _, tc := range cases {
@@ -1234,5 +1245,20 @@ policies:
 				}
 			}
 		})
+	}
+}
+
+// TestBundleKeyMatchesStructTag pins the shape probe's key to the field the
+// decoder actually reads. The probe recognizes an authored bundle by that key,
+// including in the raw text of a document YAML cannot parse, so a rename of the
+// struct tag alone would leave every bundle unrecognized.
+func TestBundleKeyMatchesStructTag(t *testing.T) {
+	field, ok := reflect.TypeFor[structuredBundle]().FieldByName("Policies")
+	if !ok {
+		t.Fatal("structuredBundle has no Policies field")
+	}
+	tag, _, _ := strings.Cut(field.Tag.Get("yaml"), ",")
+	if tag != bundlePoliciesKey {
+		t.Fatalf("bundlePoliciesKey = %q but the yaml tag is %q", bundlePoliciesKey, tag)
 	}
 }

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -591,6 +591,130 @@ defaults: &defaults
 	}
 }
 
+// TestMergeKeysRefusedByTagNotByText pins that a merge key is recognized by the
+// tag YAML resolves for it and not by the text it is spelled with. A quoted "<<"
+// is an ordinary string key: yaml.v3 tags it !!str and the decoder keeps it as a
+// key rather than merging anything, so a bundle whose free-form metadata or rule
+// details carry that name says nothing about a merge and has to lint and load.
+// Refusing it on the text alone named a construct the author did not write, and
+// withheld every other diagnostic for the policy carrying it, since the checks
+// that read a document's values step over the nodes a merge key makes unreadable.
+//
+// Every spelling the decoder does merge is still refused, whatever value it
+// merges from and however the tag is written, which is what keeps the tag a safe
+// signal to gate on. The two directions are pinned together so the check cannot
+// pass by accepting both. TestAnchorsRejectedAtEveryPosition covers the positions
+// a merge key can take; this covers the spellings.
+func TestMergeKeysRefusedByTagNotByText(t *testing.T) {
+	const plainPolicy = `
+policies:
+  - name: plain
+    rules:
+      - when: "true"
+        action: deny
+        reason: "r"
+`
+	cases := []struct {
+		name    string
+		bundle  string
+		refused bool
+	}{
+		{
+			name:   "a double-quoted key named << in bundle metadata",
+			bundle: "metadata:\n  \"<<\": literal\n" + plainPolicy,
+		},
+		{
+			name:   "a single-quoted key named << in bundle metadata",
+			bundle: "metadata:\n  '<<': literal\n" + plainPolicy,
+		},
+		{
+			name: "a quoted key named << in a rule's details",
+			bundle: `
+policies:
+  - name: quoted-detail
+    rules:
+      - when: "true"
+        action: deny
+        reason: "r"
+        details:
+          "<<": literal
+`,
+		},
+		{
+			name:    "a merge key with a mapping value",
+			bundle:  "metadata:\n  <<: {inherited: 1}\n" + plainPolicy,
+			refused: true,
+		},
+		{
+			name: "a merge key with an alias value",
+			bundle: `
+base: &base
+  inherited: 1
+
+metadata:
+  <<: *base
+` + plainPolicy,
+			refused: true,
+		},
+		{
+			name: "a merge key with a sequence of aliases",
+			bundle: `
+base: &base
+  inherited: 1
+
+metadata:
+  <<: [*base]
+` + plainPolicy,
+			refused: true,
+		},
+		{
+			name:    "a merge key tagged explicitly on a quoted key",
+			bundle:  "metadata:\n  !!merge \"<<\": {inherited: 1}\n" + plainPolicy,
+			refused: true,
+		},
+		{
+			name:    "a merge key tagged with the verbatim tag URI",
+			bundle:  "metadata:\n  !<tag:yaml.org,2002:merge> \"<<\": {inherited: 1}\n" + plainPolicy,
+			refused: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			issues, err := ValidateBundle(tc.bundle, ValidateOptions{Source: "bundle.yaml"})
+			if err != nil {
+				t.Fatalf("ValidateBundle: %v", err)
+			}
+			sources, loadErr := ParseStructuredSources([]byte(tc.bundle), "bundle.yaml")
+			if !tc.refused {
+				if len(issues) != 0 {
+					t.Fatalf("a key named << is not a merge key: %v", issues)
+				}
+				if loadErr != nil {
+					t.Fatalf("the loader refused a key named <<: %v", loadErr)
+				}
+				if len(sources) != 1 {
+					t.Fatalf("expected one compiled source, got %d", len(sources))
+				}
+				return
+			}
+			if !slices.ContainsFunc(issues, func(i Issue) bool { return i.Code == "yaml-merge-key" }) {
+				t.Fatalf("expected the merge key to be reported, got %v", issues)
+			}
+			// The loader has to refuse the same document, or a merge would expand
+			// into policy content nobody reviewed. It names the first refused
+			// construct, which is the anchor the merge inherits from when the
+			// document defines one, so the wording is pinned to the family and the
+			// merge key itself to the located diagnostic above.
+			if loadErr == nil {
+				t.Fatalf("expected the loader to refuse the merge key, got %d sources", len(sources))
+			}
+			if !strings.Contains(loadErr.Error(), "policy bundles do not support YAML") {
+				t.Fatalf("loader error %q should refuse the construct by name", loadErr)
+			}
+		})
+	}
+}
+
 // TestValidateBundleAgreesWithLoader pins the equivalence the two paths must
 // keep: a bundle the loader compiles has to validate clean, and one the loader
 // rejects has to be reported. Validation walks YAML nodes while the loader

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -2080,6 +2080,117 @@ policies:
 	}
 }
 
+// TestValidateBundleChecksBundleShapesBesideAReference pins that a reference the
+// format refuses does not withhold the bundle-level shapes only decoding finds. An
+// alias or a merge key is a refusal like any other: the author has to remove it,
+// and being told nothing else about the file until they do costs a lint run per
+// defect. The decoder resolves what no reader of a bundle may, but an anchor is
+// defined in the same document, so every line it names is a line the author wrote.
+//
+// The last case is the same bundle without the reference, so what the reference was
+// withholding is what the assertion turns on.
+func TestValidateBundleChecksBundleShapesBesideAReference(t *testing.T) {
+	cases := []struct {
+		name      string
+		bundle    string
+		wantCodes []string
+		wantText  []string
+	}{
+		{
+			name: "an alias elsewhere in the document",
+			bundle: `
+unused: &u 1
+also: *u
+
+metadata: []
+
+policies:
+  - name: plain
+    rules:
+      - when: "true"
+        action: deny
+        reason: r
+`,
+			wantCodes: []string{"yaml-anchor", "bundle-error"},
+			wantText:  []string{"line 5: cannot unmarshal"},
+		},
+		{
+			name: "a merge key elsewhere in the document",
+			bundle: `
+base: &b
+  k: 1
+also:
+  <<: *b
+
+metadata: []
+
+policies:
+  - name: plain
+    rules:
+      - when: "true"
+        action: deny
+        reason: r
+`,
+			wantCodes: []string{"yaml-merge-key", "bundle-error"},
+			wantText:  []string{"line 7: cannot unmarshal"},
+		},
+		{
+			name: "a policy list inherited through an alias holding a policy with no rules",
+			bundle: `
+base: &b
+  - name: inherited
+
+policies: *b
+`,
+			wantCodes: []string{"yaml-anchor", "bundle-error"},
+			wantText:  []string{policyNeedsRuleMessage},
+		},
+		{
+			name: "the same bundle shape without any reference",
+			bundle: `
+metadata: []
+
+policies:
+  - name: plain
+    rules:
+      - when: "true"
+        action: deny
+        reason: r
+`,
+			wantCodes: []string{"bundle-error"},
+			wantText:  []string{"line 2: cannot unmarshal"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			issues, err := ValidateBundle(tc.bundle, ValidateOptions{Source: "bundle.yaml"})
+			if err != nil {
+				t.Fatalf("ValidateBundle: %v", err)
+			}
+			for _, want := range tc.wantCodes {
+				if !slices.ContainsFunc(issues, func(i Issue) bool { return i.Code == want }) {
+					t.Fatalf("expected an issue with code %q, got %v", want, issues)
+				}
+			}
+			var reported strings.Builder
+			for _, issue := range issues {
+				reported.WriteString(issue.Message)
+				reported.WriteString("\n")
+			}
+			for _, want := range tc.wantText {
+				if !strings.Contains(reported.String(), want) {
+					t.Fatalf("expected the report to mention %q, got %v", want, issues)
+				}
+			}
+			for _, issue := range issues {
+				if issue.Line <= 0 {
+					t.Fatalf("issue %v should name the line it is on", issue)
+				}
+			}
+		})
+	}
+}
+
 // TestValidateBundleReadsPoliciesSuppliedByAMergeKey pins the one case where a
 // missing policies key is not missing: a root merge key supplies it. The merge
 // key is refused, and saying the list is absent as well would name a mistake the

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -1369,6 +1369,32 @@ policies:
 `,
 			wantCodes: []string{"yaml-anchor", "invalid-action"},
 		},
+		{
+			name: "an unused anchor beside a policies mapping",
+			bundle: `
+unused: &u 1
+
+policies: {}
+`,
+			wantCodes: []string{"yaml-anchor", "policies-not-list"},
+		},
+		{
+			name: "an unused anchor beside a policies scalar",
+			bundle: `
+unused: &u 1
+
+policies: none
+`,
+			wantCodes: []string{"yaml-anchor", "policies-not-list"},
+		},
+		{
+			name: "an unused anchor in a document with no policies key",
+			bundle: `
+unused: &u
+  name: never-referenced
+`,
+			wantCodes: []string{"yaml-anchor", "missing-policies"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1387,6 +1413,36 @@ policies:
 				}
 			}
 		})
+	}
+}
+
+// TestValidateBundleReadsPoliciesSuppliedByAMergeKey pins the one case where a
+// missing policies key is not missing: a root merge key supplies it. The merge
+// key is refused, and saying the list is absent as well would name a mistake the
+// author did not make.
+func TestValidateBundleReadsPoliciesSuppliedByAMergeKey(t *testing.T) {
+	bundle := `
+defaults: &defaults
+  policies:
+    - name: inherited
+      rules:
+        - when: "true"
+          action: deny
+          reason: "r"
+
+<<: *defaults
+`
+	issues, err := ValidateBundle(bundle, ValidateOptions{Source: "bundle.yaml"})
+	if err != nil {
+		t.Fatalf("ValidateBundle: %v", err)
+	}
+	for _, issue := range issues {
+		if issue.Code == "missing-policies" {
+			t.Fatalf("a merged policies list is not missing: %v", issues)
+		}
+	}
+	if !slices.ContainsFunc(issues, func(i Issue) bool { return i.Code == "yaml-merge-key" }) {
+		t.Fatalf("expected the merge key to be reported, got %v", issues)
 	}
 }
 

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -1317,6 +1317,79 @@ policies:
 	}
 }
 
+// TestValidateBundleReportsIndependentDefects pins that a defect the format
+// refuses does not withhold the diagnostics for an unrelated one. Anchors,
+// aliases, and merge keys are refused wherever they appear, but refusing them is
+// a diagnostic like any other: it must not cost the author a lint run per defect
+// on parts of the document that are written plainly and read the same either
+// way.
+func TestValidateBundleReportsIndependentDefects(t *testing.T) {
+	cases := []struct {
+		name      string
+		bundle    string
+		wantCodes []string
+	}{
+		{
+			name: "an anchored field beside a bad action in the same policy",
+			bundle: `
+policies:
+  - name: anchored-description
+    description: &text foo
+    rules:
+      - when: "true"
+        action: dney
+        reason: "r"
+`,
+			wantCodes: []string{"yaml-anchor", "invalid-action"},
+		},
+		{
+			name: "an anchored field beside a bad mode and an uncompilable condition",
+			bundle: `
+policies:
+  - name: anchored-scalar
+    mode: &m enfroce
+    rules:
+      - when: "this is not cel"
+        action: deny
+        reason: "r"
+`,
+			wantCodes: []string{"yaml-anchor", "invalid-mode", "cel-error"},
+		},
+		{
+			name: "an anchored policy beside a policy written as an alias",
+			bundle: `
+policies:
+  - &base
+    name: anchored-policy
+    rules:
+      - when: "true"
+        action: dney
+        reason: "r"
+  - *base
+`,
+			wantCodes: []string{"yaml-anchor", "invalid-action"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			issues, err := ValidateBundle(tc.bundle, ValidateOptions{Source: "bundle.yaml"})
+			if err != nil {
+				t.Fatalf("ValidateBundle: %v", err)
+			}
+			for _, want := range tc.wantCodes {
+				if !slices.ContainsFunc(issues, func(i Issue) bool { return i.Code == want }) {
+					t.Fatalf("expected an issue with code %q, got %v", want, issues)
+				}
+			}
+			for _, issue := range issues {
+				if issue.Line <= 0 {
+					t.Fatalf("issue %v should name the line it is on", issue)
+				}
+			}
+		})
+	}
+}
+
 // TestBundleKeyMatchesStructTag pins the shape probe's key to the field the
 // decoder actually reads. The probe recognizes an authored bundle by that key,
 // including in the raw text of a document YAML cannot parse, so a rename of the

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -1159,16 +1159,23 @@ policies:
 }
 
 // TestValidateBundleChecksEveryHealthyPolicy pins that one broken policy does
-// not hide a defect in another. Generated-source failures are suppressed for the
-// policy the node walk already reported, because restating that failure in
-// expanded CEL the author never wrote obscures the real defect, but every other
-// policy in the bundle still has its generated CEL compiled. Without that the
-// author fixes one policy, reruns lint, and is handed the next one.
+// not hide a defect in another. Expansion failures are suppressed for the policy
+// the node walk already reported, because restating that failure in expanded CEL
+// the author never wrote obscures the real defect, but every other policy in the
+// bundle is still expanded and compiled. Without that the author fixes one
+// policy, reruns lint, and is handed the next one.
+//
+// The suppression is per policy whatever the defect: a field the decoder refuses
+// and an anchor the format refuses are both reported alongside the rest of the
+// bundle, not instead of it. Reading the whole bundle to expand it is what made
+// those two swallow every later diagnostic, since the loader stops at its first
+// failure.
 func TestValidateBundleChecksEveryHealthyPolicy(t *testing.T) {
 	cases := []struct {
 		name         string
 		bundle       string
 		wantPolicies []string
+		wantCodes    []string
 	}{
 		{
 			name: "a bad var behind a policy with a bad condition",
@@ -1229,6 +1236,45 @@ policies:
 `,
 			wantPolicies: []string{"first-bad-var", "second-bad-var"},
 		},
+		{
+			name: "a bad var behind a policy whose field the decoder refuses",
+			bundle: `
+policies:
+  - name: bad-status
+    rules:
+      - when: "true"
+        action: deny
+        reason: "r"
+        status: "four-oh-three"
+  - name: bad-var
+    vars:
+      threshold: '1 +'
+    rules:
+      - when: "true"
+        action: warn
+        reason: "r"
+`,
+			wantPolicies: []string{"bad-var"},
+			wantCodes:    []string{"bundle-error", "cel-error"},
+		},
+		{
+			name: "a bad var alongside a refused anchor",
+			bundle: `
+unused: &unused
+  name: never-referenced
+
+policies:
+  - name: bad-var
+    vars:
+      threshold: '1 +'
+    rules:
+      - when: "true"
+        action: warn
+        reason: "r"
+`,
+			wantPolicies: []string{"bad-var"},
+			wantCodes:    []string{"yaml-anchor", "cel-error"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1242,6 +1288,11 @@ policies:
 				})
 				if !found {
 					t.Fatalf("expected an error on policy %q, got %v", want, issues)
+				}
+			}
+			for _, want := range tc.wantCodes {
+				if !slices.ContainsFunc(issues, func(i Issue) bool { return i.Code == want }) {
+					t.Fatalf("expected an issue with code %q, got %v", want, issues)
 				}
 			}
 		})

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -714,6 +714,20 @@ policies:
 `,
 		},
 		{
+			name: "var names that differ only by surrounding whitespace",
+			bundle: `
+policies:
+  - name: padded-var-names
+    vars:
+      blocked: '["left-pad"]'
+      " blocked ": '["right-pad"]'
+    rules:
+      - when: "pkg.name in blocked"
+        action: deny
+        reason: "r"
+`,
+		},
+		{
 			name: "a policies list supplied by a root merge key",
 			bundle: `
 defaults: &defaults
@@ -905,6 +919,19 @@ policies:
     rules:
       - when: "true"
         action: warn
+        reason: "r"
+`,
+		},
+		{
+			name: "a var name padded with whitespace",
+			bundle: `
+policies:
+  - name: padded-var-name
+    vars:
+      " blocked ": '["left-pad"]'
+    rules:
+      - when: "pkg.name in blocked"
+        action: deny
         reason: "r"
 `,
 		},

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -498,6 +498,21 @@ policies:
 `,
 			wantCode: "yaml-merge-key",
 		},
+		{
+			name: "the policies key itself supplied by a root merge key",
+			bundle: `
+defaults: &defaults
+  policies:
+    - name: inherited
+      rules:
+        - when: "true"
+          action: deny
+          reason: "r"
+
+<<: *defaults
+`,
+			wantCode: "yaml-merge-key",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -643,6 +658,20 @@ policies:
       - when: "true"
         action: dney
         reason: "r"
+`,
+		},
+		{
+			name: "a policies list supplied by a root merge key",
+			bundle: `
+defaults: &defaults
+  policies:
+    - name: inherited
+      rules:
+        - when: "true"
+          action: deny
+          reason: "r"
+
+<<: *defaults
 `,
 		},
 		{

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -100,14 +100,26 @@ policies:
 			wantText:  []string{"undeclared reference", `policy "unbound" rule[0]`},
 		},
 		{
-			name: "missing when and action",
+			name: "a missing when does not hide a missing action",
 			bundle: `
 policies:
   - name: empty-rule
     rules:
       - reason: "nothing here"
 `,
-			wantCodes: []string{"missing-when"},
+			wantCodes: []string{"missing-when", "missing-action"},
+		},
+		{
+			name: "a missing when does not hide a bad action",
+			bundle: `
+policies:
+  - name: both-defects
+    rules:
+      - action: dney
+        reason: "no when and a bad action"
+`,
+			wantCodes: []string{"missing-when", "invalid-action"},
+			wantText:  []string{"rule missing 'when' expression", `invalid action "dney"`},
 		},
 		{
 			name: "missing action",

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -734,6 +734,92 @@ defaults: &defaults
 	}
 }
 
+// TestValidateBundleAgreesWithCompilation pins the promise lint makes to an
+// author: a bundle that lints clean is a bundle `deputy policy bundle` can
+// compile. Rule conditions are checked one at a time, but a policy's vars wrap
+// every condition in a CEL comprehension, so a var whose value or name is not
+// valid CEL breaks only the body the policy expands into and is invisible to the
+// per-rule check.
+func TestValidateBundleAgreesWithCompilation(t *testing.T) {
+	cases := []struct {
+		name   string
+		bundle string
+	}{
+		{
+			name: "a policy with usable vars",
+			bundle: `
+policies:
+  - name: usable-vars
+    vars:
+      blocked: '["left-pad"]'
+    rules:
+      - when: "pkg.name in blocked"
+        action: deny
+        reason: "r"
+`,
+		},
+		{
+			name: "a var holding invalid CEL",
+			bundle: `
+policies:
+  - name: broken-var
+    vars:
+      threshold: '1 +'
+    rules:
+      - when: "true"
+        action: warn
+        reason: "r"
+`,
+		},
+		{
+			name: "a var name CEL cannot bind",
+			bundle: `
+policies:
+  - name: broken-var-name
+    vars:
+      not-an-identifier: '1'
+    rules:
+      - when: "true"
+        action: warn
+        reason: "r"
+`,
+		},
+		{
+			name: "a plain policy with no vars",
+			bundle: `
+policies:
+  - name: plain
+    rules:
+      - when: "true"
+        action: deny
+        reason: "r"
+`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			issues, err := ValidateBundle(tc.bundle, ValidateOptions{Source: "bundle.yaml"})
+			if err != nil {
+				t.Fatalf("ValidateBundle: %v", err)
+			}
+			reported := slices.ContainsFunc(issues, func(i Issue) bool { return i.Severity != IssueHint })
+			compiles := true
+			sources, loadErr := ParseStructuredSources([]byte(tc.bundle), "bundle.yaml")
+			if loadErr != nil {
+				compiles = false
+			}
+			for _, src := range sources {
+				if Compile(src.Body, nil) != nil {
+					compiles = false
+				}
+			}
+			if reported == compiles {
+				t.Fatalf("validation reported=%v but the bundle compiles=%v; issues=%v", reported, compiles, issues)
+			}
+		})
+	}
+}
+
 // TestLooksLikeStructuredBundle pins the shape probe callers use to decide
 // whether a file is an authored policy. It must say yes for a policy that does
 // not decode, so validation still runs and reports the offending field, and no

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -734,6 +734,113 @@ defaults: &defaults
 			name:   "an empty policies list",
 			bundle: "policies: []\n",
 		},
+		{
+			name: "optional fields written as an explicit null",
+			bundle: `
+policies:
+  - name: explicit-nulls
+    mode: null
+    entrypoints: null
+    commands: null
+    vars: null
+    rules:
+      - when: "true"
+        action: deny
+        reason: "r"
+`,
+		},
+		{
+			name: "optional fields written as a tilde",
+			bundle: `
+policies:
+  - name: tilde-nulls
+    mode: ~
+    entrypoints: ~
+    commands: ~
+    vars: ~
+    rules:
+      - when: "true"
+        action: deny
+        reason: "r"
+`,
+		},
+		{
+			name: "optional fields written with no value at all",
+			bundle: `
+policies:
+  - name: bare-keys
+    mode:
+    entrypoints:
+    commands:
+    vars:
+    rules:
+      - when: "true"
+        action: deny
+        reason: "r"
+`,
+		},
+		{
+			name: "two policies whose names are an explicit null",
+			bundle: `
+policies:
+  - name: null
+    rules:
+      - when: "true"
+        action: deny
+        reason: "r"
+  - name: null
+    rules:
+      - when: "true"
+        action: deny
+        reason: "r"
+`,
+		},
+		{
+			name: "two policies whose names are a tilde",
+			bundle: `
+policies:
+  - name: ~
+    rules:
+      - when: "true"
+        action: deny
+        reason: "r"
+  - name: ~
+    rules:
+      - when: "true"
+        action: deny
+        reason: "r"
+`,
+		},
+		{
+			name: "a rule whose condition is an explicit null",
+			bundle: `
+policies:
+  - name: null-when
+    rules:
+      - when: null
+        action: deny
+        reason: "r"
+`,
+		},
+		{
+			name: "a rule whose action is an explicit null",
+			bundle: `
+policies:
+  - name: null-action
+    rules:
+      - when: "true"
+        action: null
+        reason: "r"
+`,
+		},
+		{
+			name: "a rules list written as an explicit null",
+			bundle: `
+policies:
+  - name: null-rules
+    rules: null
+`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -1055,6 +1055,21 @@ func TestLooksLikeStructuredBundle(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "a policies list inherited through a merge key",
+			data: "defaults: &d\n  policies:\n    - name: p\n      rules:\n        - when: \"true\"\n          action: deny\n          reason: r\n\n<<: *d\n",
+			want: true,
+		},
+		{
+			name: "an empty policies list inherited through a merge key",
+			data: "defaults: &d\n  policies: []\n\n<<: *d\n",
+			want: true,
+		},
+		{
+			name: "a malformed policies value inherited through a merge key",
+			data: "defaults: &d\n  policies: {}\n\n<<: *d\n",
+			want: true,
+		},
+		{
 			name: "a document whose unparsed key only starts with the bundle key",
 			data: "policiesx:\n  - name: broken\n    rules: [\n",
 		},

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -1696,6 +1696,37 @@ unused: &u
 `,
 			wantCodes: []string{"yaml-anchor", "missing-policies"},
 		},
+		{
+			// The decoder reads a null key as the empty name every reader of a
+			// bundle refuses, so the walk has to read it the same way and locate
+			// it, rather than leaving it to a backstop an unrelated defect stops.
+			name: "an explicitly null var name beside a bad action",
+			bundle: `
+policies:
+  - name: null-var-name-and-action
+    vars:
+      null: pkg.name
+    rules:
+      - when: "true"
+        action: dney
+        reason: "r"
+`,
+			wantCodes: []string{"empty-var-name", "invalid-action"},
+		},
+		{
+			name: "a var name written as a tilde beside a bad action",
+			bundle: `
+policies:
+  - name: tilde-var-name-and-action
+    vars:
+      ~: pkg.name
+    rules:
+      - when: "true"
+        action: dney
+        reason: "r"
+`,
+			wantCodes: []string{"empty-var-name", "invalid-action"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -284,6 +284,23 @@ policies:
 			bundle:    "policies: &loop\n  - *loop\n",
 			wantCodes: []string{"yaml-anchor"},
 		},
+		{
+			name:      "a policies mapping is reported by shape",
+			bundle:    "policies: {}\n",
+			wantCodes: []string{"policies-not-list"},
+			wantText:  []string{"'policies' must be a list"},
+		},
+		{
+			name:      "a policies scalar is reported by shape",
+			bundle:    "policies: none\n",
+			wantCodes: []string{"policies-not-list"},
+		},
+		{
+			name:      "an empty policies list is reported",
+			bundle:    "policies: []\n",
+			wantCodes: []string{"empty-policies"},
+			wantText:  []string{"at least one policy"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -628,6 +645,14 @@ policies:
         reason: "r"
 `,
 		},
+		{
+			name:   "a policies key written as a mapping",
+			bundle: "policies: {}\n",
+		},
+		{
+			name:   "an empty policies list",
+			bundle: "policies: []\n",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -680,6 +705,17 @@ func TestLooksLikeStructuredBundle(t *testing.T) {
 		{
 			name: "empty policies list",
 			data: "policies: []\n",
+			want: true,
+		},
+		{
+			name: "policies written as a mapping",
+			data: "policies: {}\n",
+			want: true,
+		},
+		{
+			name: "policies written as a scalar",
+			data: "policies: none\n",
+			want: true,
 		},
 		{
 			name: "not YAML at all",

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -1802,6 +1802,57 @@ policies:
 `,
 			wantCodes: []string{"empty-var-name", "invalid-action"},
 		},
+		{
+			// A name the policy cannot bind is a defect of that one var, so the
+			// vars under it are still compiled: reporting them a lint run later
+			// makes the author fix a file one name at a time.
+			name: "a var with no name beside a var that does not compile",
+			bundle: `
+policies:
+  - name: unnamed-var-and-bad-var
+    vars:
+      "": '1'
+      threshold: '1 +'
+    rules:
+      - when: "threshold > 0"
+        action: deny
+        reason: "r"
+`,
+			wantCodes: []string{"empty-var-name", "cel-error"},
+		},
+		{
+			name: "a duplicate var name beside a var that does not compile",
+			bundle: `
+policies:
+  - name: duplicate-var-and-bad-var
+    vars:
+      blocked: '["a"]'
+      blocked: '["b"]'
+      threshold: '1 +'
+    rules:
+      - when: "threshold > 0"
+        action: deny
+        reason: "r"
+`,
+			wantCodes: []string{"duplicate-var", "cel-error"},
+		},
+		{
+			name: "two var names the policy cannot bind beside a var that does not compile",
+			bundle: `
+policies:
+  - name: two-bad-names-and-bad-var
+    vars:
+      "": '1'
+      blocked: '["a"]'
+      blocked: '["b"]'
+      threshold: '1 +'
+    rules:
+      - when: "threshold > 0"
+        action: deny
+        reason: "r"
+`,
+			wantCodes: []string{"empty-var-name", "duplicate-var", "cel-error"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -1,0 +1,232 @@
+package policy
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+// TestValidateBundle pins the vocabulary and structure checks that both the
+// linter and the editor rely on, including the ones a CEL-only check misses.
+func TestValidateBundle(t *testing.T) {
+	cases := []struct {
+		name      string
+		bundle    string
+		wantCodes []string
+		wantText  []string
+	}{
+		{
+			name: "valid policy has no issues",
+			bundle: `
+policies:
+  - name: ok
+    entrypoints: ["scan_vulnerability"]
+    rules:
+      - when: 'vulnerability.advisory.id == "CVE-2024-1"'
+        action: deny
+        reason: "known bad"
+`,
+		},
+		{
+			name: "unknown action",
+			bundle: `
+policies:
+  - name: typo-action
+    rules:
+      - when: "true"
+        action: dney
+        reason: "should deny"
+`,
+			wantCodes: []string{"invalid-action"},
+			wantText:  []string{`invalid action "dney"`, "allow|deny|warn", `policy "typo-action" rule[0]`},
+		},
+		{
+			name: "unknown entrypoint",
+			bundle: `
+policies:
+  - name: typo-entrypoint
+    entrypoints: ["scan_vulnerabilities"]
+    rules:
+      - when: "true"
+        action: deny
+        reason: "x"
+`,
+			wantCodes: []string{"invalid-entrypoint"},
+			wantText:  []string{`invalid entrypoint "scan_vulnerabilities"`},
+		},
+		{
+			name: "unknown command",
+			bundle: `
+policies:
+  - name: typo-command
+    commands: ["scna"]
+    rules:
+      - when: "true"
+        action: deny
+        reason: "x"
+`,
+			wantCodes: []string{"invalid-command"},
+			wantText:  []string{`invalid command "scna"`},
+		},
+		{
+			name: "duplicate policy names",
+			bundle: `
+policies:
+  - name: same
+    rules:
+      - when: "true"
+        action: deny
+        reason: "x"
+  - name: same
+    rules:
+      - when: "true"
+        action: deny
+        reason: "y"
+`,
+			wantCodes: []string{"duplicate-policy"},
+			wantText:  []string{`duplicate policy name "same"`},
+		},
+		{
+			name: "unbound variable in condition",
+			bundle: `
+policies:
+  - name: unbound
+    rules:
+      - when: "vulnerabilty.advisory.id != ''"
+        action: deny
+        reason: "x"
+`,
+			wantCodes: []string{"cel-error"},
+			wantText:  []string{"undeclared reference", `policy "unbound" rule[0]`},
+		},
+		{
+			name: "missing when and action",
+			bundle: `
+policies:
+  - name: empty-rule
+    rules:
+      - reason: "nothing here"
+`,
+			wantCodes: []string{"missing-when"},
+		},
+		{
+			name: "missing action",
+			bundle: `
+policies:
+  - name: no-action
+    rules:
+      - when: "true"
+        reason: "x"
+`,
+			wantCodes: []string{"missing-action"},
+		},
+		{
+			name: "deny without reason is a hint",
+			bundle: `
+policies:
+  - name: no-reason
+    rules:
+      - when: "true"
+        action: deny
+`,
+			wantCodes: []string{"missing-reason"},
+		},
+		{
+			name: "invalid mode is reported by the loader",
+			bundle: `
+policies:
+  - name: bad-mode
+    mode: enfroce
+    rules:
+      - when: "true"
+        action: deny
+        reason: "x"
+`,
+			wantCodes: []string{"bundle-error"},
+			wantText:  []string{`invalid mode "enfroce"`},
+		},
+		{
+			name:      "missing policies list",
+			bundle:    "rules: []\n",
+			wantCodes: []string{"missing-policies"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			issues, err := ValidateBundle(tc.bundle, ValidateOptions{})
+			if err != nil {
+				t.Fatalf("ValidateBundle: %v", err)
+			}
+			codes := make([]string, 0, len(issues))
+			var rendered strings.Builder
+			for _, issue := range issues {
+				codes = append(codes, issue.Code)
+				rendered.WriteString(issue.String())
+				rendered.WriteString("\n")
+			}
+			if len(tc.wantCodes) == 0 && len(issues) != 0 {
+				t.Fatalf("expected no issues, got:\n%s", rendered.String())
+			}
+			for _, want := range tc.wantCodes {
+				if !slices.Contains(codes, want) {
+					t.Fatalf("expected issue code %q, got %v:\n%s", want, codes, rendered.String())
+				}
+			}
+			for _, want := range tc.wantText {
+				if !strings.Contains(rendered.String(), want) {
+					t.Fatalf("expected output to mention %q, got:\n%s", want, rendered.String())
+				}
+			}
+		})
+	}
+}
+
+// TestValidateBundleRejectsNonYAML pins that unparseable input is an error rather
+// than a silently clean bundle.
+func TestValidateBundleRejectsNonYAML(t *testing.T) {
+	if _, err := ValidateBundle("policies: [\n  - name: broken\n", ValidateOptions{}); err == nil {
+		t.Fatal("expected error for malformed YAML")
+	}
+}
+
+// TestValidateBundleDeclaresPolicyVars pins that vars declared by the policy are
+// in scope for its conditions, so lint does not report them as unbound.
+func TestValidateBundleDeclaresPolicyVars(t *testing.T) {
+	bundle := `
+policies:
+  - name: with-vars
+    vars:
+      blocked: '["left-pad"]'
+    rules:
+      - when: "pkg.name in blocked"
+        action: deny
+        reason: "blocked package"
+`
+	issues, err := ValidateBundle(bundle, ValidateOptions{})
+	if err != nil {
+		t.Fatalf("ValidateBundle: %v", err)
+	}
+	if len(issues) != 0 {
+		t.Fatalf("expected no issues, got %v", issues)
+	}
+}
+
+// TestValidateBundleExtraVars pins that caller-declared names (lint --var) are in
+// scope too.
+func TestValidateBundleExtraVars(t *testing.T) {
+	bundle := `
+policies:
+  - name: extra-vars
+    rules:
+      - when: "custom_input == 1"
+        action: warn
+        reason: "custom"
+`
+	issues, err := ValidateBundle(bundle, ValidateOptions{ExtraVars: []string{"custom_input"}})
+	if err != nil {
+		t.Fatalf("ValidateBundle: %v", err)
+	}
+	if len(issues) != 0 {
+		t.Fatalf("expected no issues with extra var declared, got %v", issues)
+	}
+}

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -1382,6 +1382,36 @@ policies:
 			wantCodes: []string{"missing-rules", "cel-error"},
 		},
 		{
+			name: "a var holding invalid CEL beside a field the decoder refuses",
+			bundle: `
+policies:
+  - name: bad-var-and-status
+    vars:
+      threshold: '1 +'
+    rules:
+      - when: "true"
+        action: deny
+        reason: "r"
+        status: nope
+`,
+			wantCodes: []string{"bundle-error", "cel-error"},
+		},
+		{
+			name: "a var holding invalid CEL beside an unknown entrypoint",
+			bundle: `
+policies:
+  - name: bad-var-and-entrypoint
+    entrypoints: ["scan_vulnerabilities"]
+    vars:
+      threshold: '1 +'
+    rules:
+      - when: "true"
+        action: deny
+        reason: "r"
+`,
+			wantCodes: []string{"invalid-entrypoint", "cel-error"},
+		},
+		{
 			name: "an anchored field beside a bad action in the same policy",
 			bundle: `
 policies:

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -1040,8 +1040,35 @@ func TestLooksLikeStructuredBundle(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "an indented bundle key preceding a syntax error",
+			data: "  policies:\n    - name: broken\n      rules: [\n",
+			want: true,
+		},
+		{
+			name: "an indented bundle key below a comment, preceding a syntax error",
+			data: "# a bundle\n  policies:\n    - name: broken\n      rules: [\n",
+			want: true,
+		},
+		{
+			name: "an indented bundle key in a document that parses",
+			data: "  policies:\n    - name: p\n      rules:\n        - when: \"true\"\n          action: deny\n          reason: r\n",
+			want: true,
+		},
+		{
 			name: "a document whose unparsed key only starts with the bundle key",
 			data: "policiesx:\n  - name: broken\n    rules: [\n",
+		},
+		{
+			name: "a nested policies key in a document that does not parse",
+			data: "wrapper:\n  policies:\n    - name: broken\n      rules: [\n",
+		},
+		{
+			name: "raw CEL whose map literal keys the bundle key",
+			data: "// policy: legacy\npkg.name in {\"policies\": [\"left-pad\"]}.policies\n  ? [{\"action\": \"deny\"}]\n  : []\n",
+		},
+		{
+			name: "raw CEL whose map literal keys the bundle key on its own line",
+			data: "// policy: legacy\nsize(request.x) > 0 && {\n  \"policies\": [\"left-pad\"]\n}.policies.size() > 0\n  ? [{\"action\": \"deny\"}]\n  : []\n",
 		},
 		{
 			name: "a document that quotes a key the bundle does not have",

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -1003,6 +1003,24 @@ func TestLooksLikeStructuredBundle(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "a bundle whose double-quoted policies key precedes a syntax error",
+			data: "\"policies\":\n  - name: broken\n    rules: [\n",
+			want: true,
+		},
+		{
+			name: "a bundle whose single-quoted policies key precedes a syntax error",
+			data: "'policies':\n  - name: broken\n    rules: [\n",
+			want: true,
+		},
+		{
+			name: "a document whose unparsed key only starts with the bundle key",
+			data: "policiesx:\n  - name: broken\n    rules: [\n",
+		},
+		{
+			name: "a document that quotes a key the bundle does not have",
+			data: "\"rules\":\n  - when: [\n",
+		},
+		{
 			name: "raw CEL that does not parse as YAML",
 			data: "// policy: legacy\npkg.name == \"left-pad\"\n  ? [{\"action\": \"deny\"}]\n  : []\n",
 		},

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -132,7 +132,7 @@ policies:
 			wantCodes: []string{"missing-reason"},
 		},
 		{
-			name: "invalid mode is reported by the loader",
+			name: "invalid mode",
 			bundle: `
 policies:
   - name: bad-mode
@@ -142,8 +142,61 @@ policies:
         action: deny
         reason: "x"
 `,
+			wantCodes: []string{"invalid-mode"},
+			wantText:  []string{`4:11: error: policy "bad-mode": invalid mode "enfroce" (expected advisory|enforce)`},
+		},
+		{
+			name: "two unrelated defects are reported in one pass",
+			bundle: `
+policies:
+  - name: two-defects
+    mode: enfroce
+    rules:
+      - when: "true"
+        action: dney
+        reason: "x"
+`,
+			wantCodes: []string{"invalid-mode", "invalid-action"},
+			wantText:  []string{`invalid mode "enfroce"`, `invalid action "dney"`},
+		},
+		{
+			name: "duplicate var names",
+			bundle: `
+policies:
+  - name: dup-vars
+    vars:
+      blocked: '["a"]'
+      blocked: '["b"]'
+    rules:
+      - when: "true"
+        action: deny
+        reason: "x"
+`,
+			wantCodes: []string{"duplicate-var"},
+			wantText:  []string{`duplicate var name "blocked"`},
+		},
+		{
+			name: "empty rules list",
+			bundle: `
+policies:
+  - name: no-rules
+    rules: []
+`,
+			wantCodes: []string{"empty-rules"},
+			wantText:  []string{"policy must contain at least one rule"},
+		},
+		{
+			name: "loader backstop covers shapes the walk does not model",
+			bundle: `
+policies:
+  - name: bad-status
+    rules:
+      - when: "true"
+        action: deny
+        reason: "x"
+        status: "four-oh-three"
+`,
 			wantCodes: []string{"bundle-error"},
-			wantText:  []string{`invalid mode "enfroce"`},
 		},
 		{
 			name:      "missing policies list",
@@ -176,6 +229,74 @@ policies:
 				if !strings.Contains(rendered.String(), want) {
 					t.Fatalf("expected output to mention %q, got:\n%s", want, rendered.String())
 				}
+			}
+		})
+	}
+}
+
+// TestValidateBundleReportsEachDefectOnce pins that the loader backstop does not
+// restate a defect the node walk already located, so a single mistake produces a
+// single issue.
+func TestValidateBundleReportsEachDefectOnce(t *testing.T) {
+	cases := []struct {
+		name   string
+		bundle string
+	}{
+		{
+			name: "unknown action",
+			bundle: `
+policies:
+  - name: once
+    rules:
+      - when: "true"
+        action: dney
+        reason: "x"
+`,
+		},
+		{
+			name: "unknown entrypoint",
+			bundle: `
+policies:
+  - name: once
+    entrypoints: ["scan_vulnerabilities"]
+    rules:
+      - when: "true"
+        action: deny
+        reason: "x"
+`,
+		},
+		{
+			name: "invalid mode",
+			bundle: `
+policies:
+  - name: once
+    mode: enfroce
+    rules:
+      - when: "true"
+        action: deny
+        reason: "x"
+`,
+		},
+		{
+			name: "empty rules",
+			bundle: `
+policies:
+  - name: once
+    rules: []
+`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			issues, err := ValidateBundle(tc.bundle, ValidateOptions{})
+			if err != nil {
+				t.Fatalf("ValidateBundle: %v", err)
+			}
+			if len(issues) != 1 {
+				t.Fatalf("expected exactly one issue, got %d: %v", len(issues), issues)
+			}
+			if issues[0].Code == "bundle-error" {
+				t.Fatalf("expected a located issue, got the loader backstop: %v", issues[0])
 			}
 		})
 	}

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -1700,3 +1700,202 @@ func TestBundleKeyMatchesStructTag(t *testing.T) {
 		t.Fatalf("bundlePoliciesKey = %q but the yaml tag is %q", bundlePoliciesKey, tag)
 	}
 }
+
+// TestRewritingTagsRejectedAtEveryPosition pins the refusal of a YAML tag that
+// makes a scalar's value differ from its written text, in each field where the
+// two readers of a bundle would otherwise disagree about it. The walk judges the
+// text and the decoder reads the value, so before this an `action: !!binary
+// ZGVueQ==` linted as an invalid action and compiled as deny.
+//
+// Each case asserts both readers, since a construct only one of them refuses is
+// the divergence this closes.
+func TestRewritingTagsRejectedAtEveryPosition(t *testing.T) {
+	cases := []struct {
+		name   string
+		bundle string
+	}{
+		{
+			name: "a rule action",
+			bundle: `
+policies:
+  - name: tagged-action
+    rules:
+      - when: "true"
+        action: !!binary ZGVueQ==
+        reason: "r"
+`,
+		},
+		{
+			name: "a rule condition",
+			bundle: `
+policies:
+  - name: tagged-when
+    rules:
+      - when: !!binary MTwy
+        action: deny
+        reason: "r"
+`,
+		},
+		{
+			name: "the execution mode",
+			bundle: `
+policies:
+  - name: tagged-mode
+    mode: !!binary YWR2aXNvcnk=
+    rules:
+      - when: "true"
+        action: deny
+        reason: "r"
+`,
+		},
+		{
+			name: "an entrypoint list item",
+			bundle: `
+policies:
+  - name: tagged-entrypoint
+    entrypoints: [!!binary c2Nhbl92dWxuZXJhYmlsaXR5]
+    rules:
+      - when: "true"
+        action: deny
+        reason: "r"
+`,
+		},
+		{
+			name: "the policy name",
+			bundle: `
+policies:
+  - name: !!binary dGFnZ2VkLW5hbWU=
+    rules:
+      - when: "true"
+        action: deny
+        reason: "r"
+`,
+		},
+		{
+			name: "a var name",
+			bundle: `
+policies:
+  - name: tagged-var-name
+    vars:
+      ? !!binary YmxvY2tlZA==
+      : '["left-pad"]'
+    rules:
+      - when: "pkg.name in blocked"
+        action: deny
+        reason: "r"
+`,
+		},
+		{
+			name: "a rule reason",
+			bundle: `
+policies:
+  - name: tagged-reason
+    rules:
+      - when: "true"
+        action: deny
+        reason: !!binary cg==
+`,
+		},
+		{
+			name:   "the policies key itself",
+			bundle: "!!binary cG9saWNpZXM=:\n  - name: tagged-key\n    rules:\n      - when: \"true\"\n        action: deny\n        reason: \"r\"\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			issues, err := ValidateBundle(tc.bundle, ValidateOptions{Source: "bundle.yaml"})
+			if err != nil {
+				t.Fatalf("ValidateBundle: %v", err)
+			}
+			var codes []string
+			for _, issue := range issues {
+				codes = append(codes, issue.Code)
+			}
+			if !slices.Contains(codes, "yaml-opaque-scalar") {
+				t.Fatalf("expected issue code %q, got %v: %v", "yaml-opaque-scalar", codes, issues)
+			}
+			for _, issue := range issues {
+				if issue.Line <= 0 {
+					t.Fatalf("issue %v should name the line the construct is on", issue)
+				}
+			}
+
+			// The loader has to refuse the same document, or a bundle that lints as
+			// broken would still compile, which is how a tagged action got in.
+			_, loadErr := ParseStructuredSources([]byte(tc.bundle), "bundle.yaml")
+			if loadErr == nil {
+				t.Fatal("expected the loader to reject the bundle too")
+			}
+			if !strings.Contains(loadErr.Error(), opaqueScalarNotSupported) {
+				t.Fatalf("loader error %q should refuse the construct by name", loadErr)
+			}
+		})
+	}
+}
+
+// TestPlainScalarSpellingsStayAccepted pins the other side of the tag refusal:
+// it keys off a scalar whose value is not its text, not off a tag, so every way
+// an author writes a value plainly still loads. Quoting is the alternative the
+// refusal points at, so quoting must not itself be refused.
+func TestPlainScalarSpellingsStayAccepted(t *testing.T) {
+	cases := []struct {
+		name   string
+		bundle string
+	}{
+		{
+			name: "plain, quoted, and block scalars",
+			bundle: `
+policies:
+  - name: plain-spellings
+    description: >-
+      folded
+    mode: 'advisory'
+    rules:
+      - when: "true"
+        action: "deny"
+        reason: |
+          multi
+          line
+`,
+		},
+		{
+			name: "a tag that leaves the text alone",
+			bundle: `
+policies:
+  - name: explicit-str
+    rules:
+      - when: "true"
+        action: !!str deny
+        reason: "r"
+`,
+		},
+		{
+			name: "an explicitly null optional field",
+			bundle: `
+policies:
+  - name: null-mode
+    mode: ~
+    rules:
+      - when: "true"
+        action: deny
+        reason: "r"
+`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			issues, err := ValidateBundle(tc.bundle, ValidateOptions{Source: "bundle.yaml"})
+			if err != nil {
+				t.Fatalf("ValidateBundle: %v", err)
+			}
+			for _, issue := range issues {
+				if issue.Severity != IssueHint {
+					t.Fatalf("expected no problems, got %v", issue)
+				}
+			}
+			if _, err := ParseStructuredSources([]byte(tc.bundle), "bundle.yaml"); err != nil {
+				t.Fatalf("loader rejected a plainly written bundle: %v", err)
+			}
+		})
+	}
+}

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -230,6 +230,100 @@ policies:
 			bundle:    "rules: []\n",
 			wantCodes: []string{"missing-policies"},
 		},
+		{
+			name: "a policy written as an alias is validated",
+			bundle: `
+base: &base
+  name: aliased
+  entrypoints: ["scan_vulnerability"]
+  rules:
+    - when: "true"
+      action: deny
+      reason: "aliased policy"
+
+policies:
+  - *base
+`,
+		},
+		{
+			name: "merge keys supply inherited fields",
+			bundle: `
+defaults: &defaults
+  entrypoints: ["scan_vulnerability"]
+  rules:
+    - when: "true"
+      action: deny
+      reason: "inherited rule"
+
+policies:
+  - <<: *defaults
+    name: inherits-rules
+`,
+		},
+		{
+			name: "a direct key overrides the one it merges in",
+			bundle: `
+defaults: &defaults
+  mode: enfroce
+  rules:
+    - when: "true"
+      action: deny
+      reason: "r"
+
+policies:
+  - <<: *defaults
+    name: overrides-mode
+    mode: advisory
+`,
+		},
+		{
+			name: "a defect inside an anchor is still reported",
+			bundle: `
+base: &base
+  name: aliased
+  rules:
+    - when: "true"
+      action: dney
+      reason: "bad action inside an anchor"
+
+policies:
+  - *base
+`,
+			wantCodes: []string{"invalid-action"},
+			wantText:  []string{`invalid action "dney"`},
+		},
+		{
+			name: "a defect inherited through a merge key is still reported",
+			bundle: `
+defaults: &defaults
+  mode: enfroce
+  rules:
+    - when: "true"
+      action: deny
+      reason: "r"
+
+policies:
+  - <<: *defaults
+    name: inherits-bad-mode
+`,
+			wantCodes: []string{"invalid-mode"},
+			wantText:  []string{`invalid mode "enfroce"`},
+		},
+		{
+			name: "an alias to something that is not a policy is rejected",
+			bundle: `
+base: &base "just a string"
+
+policies:
+  - *base
+`,
+			wantCodes: []string{"policy-not-mapping"},
+		},
+		{
+			name:      "a self-referential anchor terminates",
+			bundle:    "policies: &loop\n  - *loop\n",
+			wantCodes: []string{"policy-not-mapping"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -256,6 +350,113 @@ policies:
 				if !strings.Contains(rendered.String(), want) {
 					t.Fatalf("expected output to mention %q, got:\n%s", want, rendered.String())
 				}
+			}
+		})
+	}
+}
+
+// TestValidateBundleAgreesWithLoader pins the equivalence the two paths must
+// keep: a bundle the loader compiles has to validate clean, and one the loader
+// rejects has to be reported. Validation walks YAML nodes while the loader
+// decodes into Go types, so anything the decoder resolves for free, aliases and
+// merge keys among them, has to be resolved by the walk as well.
+func TestValidateBundleAgreesWithLoader(t *testing.T) {
+	cases := []struct {
+		name   string
+		bundle string
+	}{
+		{
+			name: "plain policy",
+			bundle: `
+policies:
+  - name: plain
+    rules:
+      - when: "true"
+        action: deny
+        reason: "r"
+`,
+		},
+		{
+			name: "policy written as an alias",
+			bundle: `
+base: &base
+  name: aliased
+  rules:
+    - when: "true"
+      action: deny
+      reason: "r"
+
+policies:
+  - *base
+`,
+		},
+		{
+			name: "fields inherited through a merge key",
+			bundle: `
+defaults: &defaults
+  rules:
+    - when: "true"
+      action: deny
+      reason: "r"
+
+policies:
+  - <<: *defaults
+    name: inherits
+`,
+		},
+		{
+			name: "rules supplied by an alias",
+			bundle: `
+sharedRules: &sharedRules
+  - when: "true"
+    action: warn
+    reason: "r"
+
+policies:
+  - name: alias-rules
+    rules: *sharedRules
+`,
+		},
+		{
+			name: "unknown action inside an anchor",
+			bundle: `
+base: &base
+  name: aliased
+  rules:
+    - when: "true"
+      action: dney
+      reason: "r"
+
+policies:
+  - *base
+`,
+		},
+		{
+			name: "invalid mode inherited through a merge key",
+			bundle: `
+defaults: &defaults
+  mode: enfroce
+  rules:
+    - when: "true"
+      action: deny
+      reason: "r"
+
+policies:
+  - <<: *defaults
+    name: inherits-bad-mode
+`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, loadErr := ParseStructuredSources([]byte(tc.bundle), "bundle.yaml")
+			issues, err := ValidateBundle(tc.bundle, ValidateOptions{Source: "bundle.yaml"})
+			if err != nil {
+				t.Fatalf("ValidateBundle: %v", err)
+			}
+			reported := slices.ContainsFunc(issues, func(i Issue) bool { return i.Severity != IssueHint })
+			if reported != (loadErr != nil) {
+				t.Fatalf("validation reported=%v but loader error=%v; issues=%v", reported, loadErr, issues)
 			}
 		})
 	}

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -1139,6 +1139,38 @@ policies:
     rules: []
 `,
 		},
+		{
+			name: "missing rules",
+			bundle: `
+policies:
+  - name: once
+`,
+		},
+		{
+			name: "rules written as a mapping",
+			bundle: `
+policies:
+  - name: once
+    rules: {}
+`,
+		},
+		{
+			name: "rules written as a block mapping",
+			bundle: `
+policies:
+  - name: once
+    rules:
+      when: "true"
+`,
+		},
+		{
+			name: "rules written as a scalar",
+			bundle: `
+policies:
+  - name: once
+    rules: "when true deny"
+`,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1151,6 +1183,89 @@ policies:
 			}
 			if issues[0].Code == "bundle-error" {
 				t.Fatalf("expected a located issue, got the loader backstop: %v", issues[0])
+			}
+		})
+	}
+}
+
+// TestValidateBundleFoldsOnlyTheRestatedDefect pins that folding a loader
+// restatement drops that restatement alone. The decoder reports every field it
+// refuses in one error, so a defect the node walk already located travels
+// alongside defects only the decoder finds, and dropping the whole error would
+// hide them until the located one is fixed and lint rerun.
+func TestValidateBundleFoldsOnlyTheRestatedDefect(t *testing.T) {
+	cases := []struct {
+		name       string
+		bundle     string
+		wantIssues int
+		wantCodes  []string
+		wantText   []string
+		denyText   []string
+	}{
+		{
+			name: "bundle metadata of the wrong type beside a non-list rules value",
+			bundle: `
+metadata: []
+
+policies:
+  - name: once
+    rules: {}
+`,
+			wantIssues: 2,
+			wantCodes:  []string{"rules-not-list", "bundle-error"},
+			wantText:   []string{"line 2: cannot unmarshal"},
+			denyText:   []string{"structuredRule"},
+		},
+		{
+			name: "two policies whose fields the decoder refuses",
+			bundle: `
+policies:
+  - name: first
+    rules:
+      - when: "true"
+        action: deny
+        reason: "r"
+        status: nope
+  - name: second
+    rules:
+      - when: "true"
+        action: deny
+        reason: "r"
+        status: nah
+`,
+			wantIssues: 2,
+			wantCodes:  []string{"bundle-error"},
+			wantText:   []string{"nope", "nah"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			issues, err := ValidateBundle(tc.bundle, ValidateOptions{})
+			if err != nil {
+				t.Fatalf("ValidateBundle: %v", err)
+			}
+			if len(issues) != tc.wantIssues {
+				t.Fatalf("expected %d issues, got %d: %v", tc.wantIssues, len(issues), issues)
+			}
+			for _, want := range tc.wantCodes {
+				if !slices.ContainsFunc(issues, func(i Issue) bool { return i.Code == want }) {
+					t.Fatalf("expected an issue with code %q, got %v", want, issues)
+				}
+			}
+			var reported strings.Builder
+			for _, issue := range issues {
+				reported.WriteString(issue.Message)
+				reported.WriteString("\n")
+			}
+			for _, want := range tc.wantText {
+				if !strings.Contains(reported.String(), want) {
+					t.Fatalf("expected the report to mention %q, got %v", want, issues)
+				}
+			}
+			for _, deny := range tc.denyText {
+				if strings.Contains(reported.String(), deny) {
+					t.Fatalf("the report restates %q the walk already located: %v", deny, issues)
+				}
 			}
 		})
 	}

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -1186,6 +1186,22 @@ policies:
     rules: "when true deny"
 `,
 		},
+		{
+			name:   "policies written as a mapping",
+			bundle: "\npolicies: {}\n",
+		},
+		{
+			name:   "policies written as a scalar",
+			bundle: "\npolicies: none\n",
+		},
+		{
+			name:   "an empty policies list",
+			bundle: "\npolicies: []\n",
+		},
+		{
+			name:   "a policies entry that is not a policy",
+			bundle: "\npolicies:\n  - not-a-policy\n",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1230,6 +1246,36 @@ policies:
 			wantCodes:  []string{"rules-not-list", "bundle-error"},
 			wantText:   []string{"line 2: cannot unmarshal"},
 			denyText:   []string{"structuredRule"},
+		},
+		{
+			name: "bundle metadata of the wrong type beside a non-list policies value",
+			bundle: `
+metadata: []
+policies: {}
+`,
+			wantIssues: 2,
+			wantCodes:  []string{"policies-not-list", "bundle-error"},
+			wantText:   []string{"line 2: cannot unmarshal"},
+			denyText:   []string{"structuredPolicy"},
+		},
+		{
+			name: "bundle metadata of the wrong type beside an empty policies list",
+			bundle: `
+metadata: []
+policies: []
+`,
+			wantIssues: 2,
+			wantCodes:  []string{"empty-policies", "bundle-error"},
+			wantText:   []string{"line 2: cannot unmarshal"},
+		},
+		{
+			name: "bundle metadata of the wrong type beside a missing policies list",
+			bundle: `
+metadata: []
+`,
+			wantIssues: 2,
+			wantCodes:  []string{"missing-policies", "bundle-error"},
+			wantText:   []string{"line 2: cannot unmarshal"},
 		},
 		{
 			name: "two policies whose fields the decoder refuses",

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -231,7 +231,7 @@ policies:
 			wantCodes: []string{"missing-policies"},
 		},
 		{
-			name: "a policy written as an alias is validated",
+			name: "a policy written as an alias is rejected",
 			bundle: `
 base: &base
   name: aliased
@@ -244,9 +244,11 @@ base: &base
 policies:
   - *base
 `,
+			wantCodes: []string{"yaml-anchor"},
+			wantText:  []string{"do not support YAML anchors and aliases", "--policy file", "vars:"},
 		},
 		{
-			name: "merge keys supply inherited fields",
+			name: "a merge key is rejected",
 			bundle: `
 defaults: &defaults
   entrypoints: ["scan_vulnerability"]
@@ -259,70 +261,28 @@ policies:
   - <<: *defaults
     name: inherits-rules
 `,
+			wantCodes: []string{"yaml-anchor", "yaml-merge-key"},
+			wantText:  []string{"do not support YAML merge keys"},
 		},
 		{
-			name: "a direct key overrides the one it merges in",
+			name: "an unused anchor definition is rejected",
 			bundle: `
-defaults: &defaults
-  mode: enfroce
-  rules:
-    - when: "true"
-      action: deny
-      reason: "r"
+unused: &unused
+  name: never-referenced
 
 policies:
-  - <<: *defaults
-    name: overrides-mode
-    mode: advisory
+  - name: plain
+    rules:
+      - when: "true"
+        action: deny
+        reason: "r"
 `,
+			wantCodes: []string{"yaml-anchor"},
 		},
 		{
-			name: "a defect inside an anchor is still reported",
-			bundle: `
-base: &base
-  name: aliased
-  rules:
-    - when: "true"
-      action: dney
-      reason: "bad action inside an anchor"
-
-policies:
-  - *base
-`,
-			wantCodes: []string{"invalid-action"},
-			wantText:  []string{`invalid action "dney"`},
-		},
-		{
-			name: "a defect inherited through a merge key is still reported",
-			bundle: `
-defaults: &defaults
-  mode: enfroce
-  rules:
-    - when: "true"
-      action: deny
-      reason: "r"
-
-policies:
-  - <<: *defaults
-    name: inherits-bad-mode
-`,
-			wantCodes: []string{"invalid-mode"},
-			wantText:  []string{`invalid mode "enfroce"`},
-		},
-		{
-			name: "an alias to something that is not a policy is rejected",
-			bundle: `
-base: &base "just a string"
-
-policies:
-  - *base
-`,
-			wantCodes: []string{"policy-not-mapping"},
-		},
-		{
-			name:      "a self-referential anchor terminates",
+			name:      "an anchored policies list is rejected",
 			bundle:    "policies: &loop\n  - *loop\n",
-			wantCodes: []string{"policy-not-mapping"},
+			wantCodes: []string{"yaml-anchor"},
 		},
 	}
 	for _, tc := range cases {
@@ -358,8 +318,9 @@ policies:
 // TestValidateBundleAgreesWithLoader pins the equivalence the two paths must
 // keep: a bundle the loader compiles has to validate clean, and one the loader
 // rejects has to be reported. Validation walks YAML nodes while the loader
-// decodes into Go types, so anything the decoder resolves for free, aliases and
-// merge keys among them, has to be resolved by the walk as well.
+// decodes into Go types, and the decoder resolves anchors for free, so the
+// constructs the format refuses have to be refused by both. This test is what
+// makes that refusal safe to rely on.
 func TestValidateBundleAgreesWithLoader(t *testing.T) {
 	cases := []struct {
 		name   string
@@ -432,18 +393,32 @@ policies:
 `,
 		},
 		{
-			name: "invalid mode inherited through a merge key",
+			name:   "an anchored policies list",
+			bundle: "policies: &loop\n  - *loop\n",
+		},
+		{
+			name: "an unused anchor definition",
 			bundle: `
-defaults: &defaults
-  mode: enfroce
-  rules:
-    - when: "true"
-      action: deny
-      reason: "r"
+unused: &unused
+  name: never-referenced
 
 policies:
-  - <<: *defaults
-    name: inherits-bad-mode
+  - name: plain
+    rules:
+      - when: "true"
+        action: deny
+        reason: "r"
+`,
+		},
+		{
+			name: "a plain policy alongside an unknown action",
+			bundle: `
+policies:
+  - name: typo
+    rules:
+      - when: "true"
+        action: dney
+        reason: "r"
 `,
 		},
 	}

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -204,6 +204,40 @@ policies:
 			wantText:  []string{"9:11: error: policy \"nan-details\" rule[0]: 'details' holds a value that cannot be represented"},
 		},
 		{
+			name: "a var value that cannot be represented",
+			bundle: `
+policies:
+  - name: nan-var
+    vars:
+      threshold: .nan
+    rules:
+      - when: "threshold == null"
+        action: deny
+        reason: "x"
+`,
+			wantCodes: []string{"var-not-representable"},
+			wantText:  []string{"5:18: error: policy \"nan-var\": var \"threshold\" holds a value that cannot be represented"},
+		},
+		{
+			// A name that binds nothing says nothing about the value beside it,
+			// so both are reported: stopping at the name left the value to the
+			// expansion's unlocated backstop, which reported one mistake at a
+			// different severity and line depending on an unrelated one.
+			name: "a var value that cannot be represented under a name that binds nothing",
+			bundle: `
+policies:
+  - name: nan-unnamed-var
+    vars:
+      "": .nan
+    rules:
+      - when: "true"
+        action: deny
+        reason: "x"
+`,
+			wantCodes: []string{"empty-var-name", "var-not-representable"},
+			wantText:  []string{`var "" holds a value that cannot be represented`},
+		},
+		{
 			name: "duplicate var names",
 			bundle: `
 policies:
@@ -1291,6 +1325,21 @@ policies:
 policies:
   - name: once
     rules: []
+`,
+		},
+		{
+			// The walk names the value on its line and the expansion refuses the
+			// policy over it, so both readers describe one mistake.
+			name: "a var value that cannot be represented",
+			bundle: `
+policies:
+  - name: once
+    vars:
+      threshold: .nan
+    rules:
+      - when: "threshold == null"
+        action: deny
+        reason: "x"
 `,
 		},
 		{

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -189,6 +189,21 @@ policies:
 			wantText:  []string{`invalid mode "enfroce"`, `invalid action "dney"`, "cannot unmarshal"},
 		},
 		{
+			name: "a details value that cannot be represented",
+			bundle: `
+policies:
+  - name: nan-details
+    rules:
+      - when: "true"
+        action: deny
+        reason: "x"
+        details:
+          score: .nan
+`,
+			wantCodes: []string{"details-not-representable"},
+			wantText:  []string{"9:11: error: policy \"nan-details\" rule[0]: 'details' holds a value that cannot be represented"},
+		},
+		{
 			name: "duplicate var names",
 			bundle: `
 policies:
@@ -2007,6 +2022,25 @@ policies:
         reason: "r"
 `,
 			wantCodes: []string{"empty-var-name", "invalid-action"},
+		},
+		{
+			// The details of a rule are marshaled into the action the policy
+			// generates, so a value JSON has no spelling for stops the whole
+			// expansion. It is a defect of that field alone, and the expansion
+			// refuses the action above it first, so the walk has to locate it or
+			// the author fixes the action to be told about the details.
+			name: "a details value that cannot be represented beside a bad action",
+			bundle: `
+policies:
+  - name: nan-details-and-action
+    rules:
+      - when: "true"
+        action: dney
+        reason: "r"
+        details:
+          score: .nan
+`,
+			wantCodes: []string{"invalid-action", "details-not-representable"},
 		},
 		{
 			// A name the policy cannot bind is a defect of that one var, so the

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -10,10 +10,11 @@ import (
 // linter and the editor rely on, including the ones a CEL-only check misses.
 func TestValidateBundle(t *testing.T) {
 	cases := []struct {
-		name      string
-		bundle    string
-		wantCodes []string
-		wantText  []string
+		name         string
+		bundle       string
+		wantCodes    []string
+		unwantedCode string
+		wantText     []string
 	}{
 		{
 			name: "valid policy has no issues",
@@ -285,6 +286,38 @@ policies:
 			wantCodes: []string{"yaml-anchor"},
 		},
 		{
+			name: "an anchor does not hide an unrelated defect",
+			bundle: `
+unused: &unused
+  reason: "shared"
+
+policies:
+  - name: plain
+    mode: adivsory
+    rules:
+      - when: "true"
+        action: dney
+        reason: "r"
+`,
+			wantCodes: []string{"yaml-anchor", "invalid-action", "invalid-mode"},
+		},
+		{
+			name: "an aliased policy is reported only as an alias",
+			bundle: `
+base: &base
+  name: aliased
+  rules:
+    - when: "true"
+      action: dney
+      reason: "r"
+
+policies:
+  - *base
+`,
+			wantCodes:    []string{"yaml-anchor"},
+			unwantedCode: "policy-not-mapping",
+		},
+		{
 			name:      "a policies mapping is reported by shape",
 			bundle:    "policies: {}\n",
 			wantCodes: []string{"policies-not-list"},
@@ -322,6 +355,9 @@ policies:
 				if !slices.Contains(codes, want) {
 					t.Fatalf("expected issue code %q, got %v:\n%s", want, codes, rendered.String())
 				}
+			}
+			if tc.unwantedCode != "" && slices.Contains(codes, tc.unwantedCode) {
+				t.Fatalf("issue code %q should not be reported, got %v:\n%s", tc.unwantedCode, codes, rendered.String())
 			}
 			for _, want := range tc.wantText {
 				if !strings.Contains(rendered.String(), want) {

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -1332,6 +1332,81 @@ policies:
 	}
 }
 
+// TestValidateBundleKeepsComplaintsSharingALocatedLine pins that folding a
+// loader restatement is keyed on the value the located issue describes and not on
+// the line it sits on. A line carries more than one field whenever the author
+// writes a policy in flow style, and the line a missing rules list is reported on
+// is the policy's first field whatever that field is, so a fold keyed on the line
+// alone drops a defect only the decoder finds and hands it back one lint run
+// later. Each case pairs a shape the walk locates with a mistyped field the walk
+// does not model, and the last case is the same mistyped field on its own, so the
+// pairing is what the assertion turns on.
+func TestValidateBundleKeepsComplaintsSharingALocatedLine(t *testing.T) {
+	cases := []struct {
+		name      string
+		bundle    string
+		wantCodes []string
+		denyText  []string
+	}{
+		{
+			name:      "a mistyped field beside a rules value that is not a list",
+			bundle:    "\npolicies:\n  - {name: once, description: [1], rules: 5}\n",
+			wantCodes: []string{"rules-not-list", "bundle-error"},
+			denyText:  []string{"structuredRule"},
+		},
+		{
+			name:      "a mistyped field on the line a missing rules list is reported",
+			bundle:    "\npolicies:\n  - description: [1]\n    name: once\n",
+			wantCodes: []string{"missing-rules", "bundle-error"},
+		},
+		{
+			name:      "a mistyped field beside an empty rules list",
+			bundle:    "\npolicies:\n  - {name: once, description: [1], rules: []}\n",
+			wantCodes: []string{"empty-rules", "bundle-error"},
+		},
+		{
+			name:      "a mistyped field beside a policies entry that is not a policy",
+			bundle:    "\npolicies: [1, {name: once, description: [1], rules: 5}]\n",
+			wantCodes: []string{"policy-not-mapping", "rules-not-list", "bundle-error"},
+			denyText:  []string{"structuredPolicy"},
+		},
+		{
+			name:      "the mistyped field on its own",
+			bundle:    "\npolicies:\n  - name: once\n    description: [1]\n    rules:\n      - when: \"true\"\n        action: deny\n        reason: r\n",
+			wantCodes: []string{"bundle-error"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			issues, err := ValidateBundle(tc.bundle, ValidateOptions{})
+			if err != nil {
+				t.Fatalf("ValidateBundle: %v", err)
+			}
+			if len(issues) != len(tc.wantCodes) {
+				t.Fatalf("expected %d issues, got %d: %v", len(tc.wantCodes), len(issues), issues)
+			}
+			for _, want := range tc.wantCodes {
+				if !slices.ContainsFunc(issues, func(i Issue) bool { return i.Code == want }) {
+					t.Fatalf("expected an issue with code %q, got %v", want, issues)
+				}
+			}
+			var reported strings.Builder
+			for _, issue := range issues {
+				reported.WriteString(issue.Message)
+				reported.WriteString("\n")
+			}
+			if !strings.Contains(reported.String(), "cannot unmarshal !!seq into string") {
+				t.Fatalf("expected the report to name the mistyped field, got %v", issues)
+			}
+			for _, deny := range tc.denyText {
+				if strings.Contains(reported.String(), deny) {
+					t.Fatalf("the report restates %q the walk already located: %v", deny, issues)
+				}
+			}
+		})
+	}
+}
+
 // TestValidateBundleRejectsCompiledBundle pins that a bundle compiled by
 // `deputy policy bundle` is not mistaken for an authored one. Its JSON parses as
 // YAML and has a "policies" array, so without the check every entry would be

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -1039,3 +1039,93 @@ policies:
 		t.Fatalf("expected no issues with extra var declared, got %v", issues)
 	}
 }
+
+// TestValidateBundleChecksEveryHealthyPolicy pins that one broken policy does
+// not hide a defect in another. Generated-source failures are suppressed for the
+// policy the node walk already reported, because restating that failure in
+// expanded CEL the author never wrote obscures the real defect, but every other
+// policy in the bundle still has its generated CEL compiled. Without that the
+// author fixes one policy, reruns lint, and is handed the next one.
+func TestValidateBundleChecksEveryHealthyPolicy(t *testing.T) {
+	cases := []struct {
+		name         string
+		bundle       string
+		wantPolicies []string
+	}{
+		{
+			name: "a bad var behind a policy with a bad condition",
+			bundle: `
+policies:
+  - name: bad-condition
+    rules:
+      - when: "this is not cel"
+        action: deny
+        reason: "r"
+  - name: bad-var
+    vars:
+      threshold: '1 +'
+    rules:
+      - when: "true"
+        action: warn
+        reason: "r"
+`,
+			wantPolicies: []string{"bad-condition", "bad-var"},
+		},
+		{
+			name: "a bad var ahead of a policy with a bad condition",
+			bundle: `
+policies:
+  - name: bad-var-name
+    vars:
+      not-an-identifier: '1'
+    rules:
+      - when: "true"
+        action: warn
+        reason: "r"
+  - name: bad-condition
+    rules:
+      - when: "this is not cel"
+        action: deny
+        reason: "r"
+`,
+			wantPolicies: []string{"bad-var-name", "bad-condition"},
+		},
+		{
+			name: "two policies whose vars hold invalid CEL",
+			bundle: `
+policies:
+  - name: first-bad-var
+    vars:
+      threshold: '1 +'
+    rules:
+      - when: "true"
+        action: warn
+        reason: "r"
+  - name: second-bad-var
+    vars:
+      ceiling: '* 2'
+    rules:
+      - when: "true"
+        action: warn
+        reason: "r"
+`,
+			wantPolicies: []string{"first-bad-var", "second-bad-var"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			issues, err := ValidateBundle(tc.bundle, ValidateOptions{Source: "bundle.yaml"})
+			if err != nil {
+				t.Fatalf("ValidateBundle: %v", err)
+			}
+			for _, want := range tc.wantPolicies {
+				found := slices.ContainsFunc(issues, func(i Issue) bool {
+					return i.Policy == want && i.Severity == IssueError
+				})
+				if !found {
+					t.Fatalf("expected an error on policy %q, got %v", want, issues)
+				}
+			}
+		})
+	}
+}

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -1753,6 +1753,88 @@ policies:
 // on parts of the document that are written plainly and read the same either
 // way. A policy's vars are independent of its rules for the same reason, since
 // they are wrong or right on their own.
+// TestValidateBundleAsksEveryVarItsOwnQuestion pins that each var of a policy is
+// reported on its own terms: the name it binds, and separately the expression it
+// holds. A name the policy cannot bind does not withhold the expression beside it,
+// and the expression is compiled in the scope it would have been evaluated in,
+// which is the vars declared above it. Compiling it anywhere else would invent a
+// diagnostic: a name the file declares below cannot be read from above, and a
+// repeated name is read from the declaration already in scope.
+func TestValidateBundleAsksEveryVarItsOwnQuestion(t *testing.T) {
+	cases := []struct {
+		name      string
+		vars      string
+		wantCodes []string
+		denyCodes []string
+		wantText  []string
+	}{
+		{
+			name:      "an unnamed var holding an uncompilable expression",
+			vars:      "      \"\": 'no_such_function()'\n      good: '1'\n",
+			wantCodes: []string{"empty-var-name", "cel-error"},
+			wantText:  []string{"no_such_function"},
+		},
+		{
+			name:      "an unnamed var holding an expression that compiles",
+			vars:      "      \"\": '1'\n      good: '1'\n",
+			wantCodes: []string{"empty-var-name"},
+			denyCodes: []string{"cel-error"},
+		},
+		{
+			name:      "an unnamed var reading a name declared below it",
+			vars:      "      \"\": 'good'\n      good: '1'\n",
+			wantCodes: []string{"empty-var-name", "cel-error"},
+			wantText:  []string{"undeclared reference to 'good'"},
+		},
+		{
+			name:      "a repeated name whose expression reads the declaration above it",
+			vars:      "      dup: '1'\n      dup: 'dup + 1'\n",
+			wantCodes: []string{"duplicate-var"},
+			denyCodes: []string{"cel-error"},
+		},
+		{
+			name:      "a repeated name holding an uncompilable expression",
+			vars:      "      dup: '1'\n      dup: 'no_such_function()'\n",
+			wantCodes: []string{"duplicate-var", "cel-error"},
+			wantText:  []string{"no_such_function"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := "policies:\n  - name: vars\n    vars:\n" + tc.vars +
+				"    rules:\n      - when: \"true\"\n        action: deny\n        reason: r\n"
+			issues, err := ValidateBundle(bundle, ValidateOptions{Source: "bundle.yaml"})
+			if err != nil {
+				t.Fatalf("ValidateBundle: %v", err)
+			}
+			var reported strings.Builder
+			for _, issue := range issues {
+				reported.WriteString(issue.Message)
+				reported.WriteString("\n")
+			}
+			for _, want := range tc.wantCodes {
+				if !slices.ContainsFunc(issues, func(i Issue) bool { return i.Code == want }) {
+					t.Fatalf("expected an issue with code %q, got %v", want, issues)
+				}
+			}
+			for _, deny := range tc.denyCodes {
+				if slices.ContainsFunc(issues, func(i Issue) bool { return i.Code == deny }) {
+					t.Fatalf("did not expect an issue with code %q, got %v", deny, issues)
+				}
+			}
+			for _, want := range tc.wantText {
+				if !strings.Contains(reported.String(), want) {
+					t.Fatalf("expected the report to mention %q, got %v", want, issues)
+				}
+			}
+			// A var the policy cannot bind is never a var the policy may run.
+			if _, loadErr := ParseStructuredSources([]byte(bundle), "bundle.yaml"); loadErr == nil {
+				t.Fatal("expected the loader to refuse the bundle")
+			}
+		})
+	}
+}
+
 func TestValidateBundleReportsIndependentDefects(t *testing.T) {
 	cases := []struct {
 		name      string

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -1862,6 +1862,37 @@ func TestValidateBundleAsksEveryVarItsOwnQuestion(t *testing.T) {
 			wantCodes: []string{"duplicate-var", "cel-error"},
 			wantText:  []string{"no_such_function"},
 		},
+		{
+			// The nest is compiled once for every var that binds, so a value with
+			// no CEL spelling used to return before the compiler ran and reveal
+			// the var below it only after the first was fixed.
+			name:      "an unrepresentable value above a var that does not compile",
+			vars:      "      impossible: .nan\n      broken: 'no_such_function()'\n",
+			wantCodes: []string{"var-not-representable", "cel-error"},
+			wantText:  []string{"cannot be represented", "no_such_function"},
+		},
+		{
+			name:      "an unrepresentable value below a var that does not compile",
+			vars:      "      broken: 'no_such_function()'\n      impossible: .nan\n",
+			wantCodes: []string{"var-not-representable", "cel-error"},
+			wantText:  []string{"cannot be represented", "no_such_function"},
+		},
+		{
+			// The name is written right where the reader looks for it, so an
+			// undeclared reference would be a mistake the author did not make.
+			// Deputy cannot say what the var holds, and declaring it without a
+			// type is the honest form of that.
+			name:      "a var reading a name whose value cannot be represented",
+			vars:      "      impossible: .nan\n      derived: 'impossible + 1'\n",
+			wantCodes: []string{"var-not-representable"},
+			denyCodes: []string{"cel-error"},
+		},
+		{
+			name:      "an unnamed var reading a name whose value cannot be represented",
+			vars:      "      impossible: .nan\n      \"\": 'impossible + 1'\n",
+			wantCodes: []string{"var-not-representable", "empty-var-name"},
+			denyCodes: []string{"cel-error"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -172,6 +172,21 @@ policies:
 			wantText:  []string{`invalid mode "enfroce"`, `invalid action "dney"`},
 		},
 		{
+			name: "a typed field error does not hide located defects",
+			bundle: `
+policies:
+  - name: typed-error
+    mode: enfroce
+    rules:
+      - when: "true"
+        action: dney
+        reason: "x"
+        status: "four-oh-three"
+`,
+			wantCodes: []string{"invalid-mode", "invalid-action", "bundle-error"},
+			wantText:  []string{`invalid mode "enfroce"`, `invalid action "dney"`, "cannot unmarshal"},
+		},
+		{
 			name: "duplicate var names",
 			bundle: `
 policies:
@@ -241,6 +256,57 @@ policies:
 				if !strings.Contains(rendered.String(), want) {
 					t.Fatalf("expected output to mention %q, got:\n%s", want, rendered.String())
 				}
+			}
+		})
+	}
+}
+
+// TestLooksLikeStructuredBundle pins the shape probe callers use to decide
+// whether a file is an authored policy. It must say yes for a policy that does
+// not decode, so validation still runs and reports the offending field, and no
+// for a compiled bundle, whose JSON also carries a "policies" array.
+func TestLooksLikeStructuredBundle(t *testing.T) {
+	cases := []struct {
+		name string
+		data string
+		want bool
+	}{
+		{
+			name: "authored bundle",
+			data: "policies:\n  - name: p\n    rules:\n      - when: \"true\"\n        action: deny\n        reason: r\n",
+			want: true,
+		},
+		{
+			name: "authored bundle with a mistyped field",
+			data: "policies:\n  - name: p\n    rules:\n      - when: \"true\"\n        action: deny\n        reason: r\n        status: \"four-oh-three\"\n",
+			want: true,
+		},
+		{
+			name: "authored bundle with a malformed vars block",
+			data: "policies:\n  - name: p\n    vars: [1, 2]\n    rules:\n      - when: \"true\"\n        action: deny\n        reason: r\n",
+			want: true,
+		},
+		{
+			name: "compiled bundle",
+			data: `{"schemaVersion":"policy.deputy.sh/v1alpha1","policies":[{"name":"c","source":"[]"}]}`,
+		},
+		{
+			name: "raw CEL",
+			data: `pkg.name == "left-pad" ? [{"action": "deny"}] : []`,
+		},
+		{
+			name: "empty policies list",
+			data: "policies: []\n",
+		},
+		{
+			name: "not YAML at all",
+			data: "policies: [\n  - name: broken\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := LooksLikeStructuredBundle([]byte(tc.data)); got != tc.want {
+				t.Fatalf("LooksLikeStructuredBundle = %v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/internal/policy/validate_test.go
+++ b/internal/policy/validate_test.go
@@ -1317,18 +1317,43 @@ policies:
 	}
 }
 
-// TestValidateBundleReportsIndependentDefects pins that a defect the format
-// refuses does not withhold the diagnostics for an unrelated one. Anchors,
+// TestValidateBundleReportsIndependentDefects pins that one defect does not
+// withhold the diagnostics for an unrelated one anywhere in a document. Anchors,
 // aliases, and merge keys are refused wherever they appear, but refusing them is
 // a diagnostic like any other: it must not cost the author a lint run per defect
 // on parts of the document that are written plainly and read the same either
-// way.
+// way. A policy's vars are independent of its rules for the same reason, since
+// they are wrong or right on their own.
 func TestValidateBundleReportsIndependentDefects(t *testing.T) {
 	cases := []struct {
 		name      string
 		bundle    string
 		wantCodes []string
 	}{
+		{
+			name: "a var holding invalid CEL beside a bad action",
+			bundle: `
+policies:
+  - name: bad-var-and-action
+    vars:
+      threshold: '1 +'
+    rules:
+      - when: "true"
+        action: dney
+        reason: "r"
+`,
+			wantCodes: []string{"invalid-action", "cel-error"},
+		},
+		{
+			name: "a var name CEL cannot bind beside a missing rules list",
+			bundle: `
+policies:
+  - name: bad-var-name-and-no-rules
+    vars:
+      not-an-identifier: '1'
+`,
+			wantCodes: []string{"missing-rules", "cel-error"},
+		},
 		{
 			name: "an anchored field beside a bad action in the same policy",
 			bundle: `

--- a/policy/examples/container-base-image.yaml
+++ b/policy/examples/container-base-image.yaml
@@ -150,7 +150,7 @@ policies:
     description: Recommend distroless images for production
     entrypoints: ["scan_report"]
     rules:
-      - action: info
+      - action: warn
         when: |
           pkg.ecosystem == "docker" &&
           (pkg.name == "debian" || pkg.name == "ubuntu") &&


### PR DESCRIPTION
Closes #157, #158, #159.

Three cases where Deputy accepted an invalid value and produced a rule that quietly did the wrong thing. Each one fails in the permissive direction, which is the worst shape for a policy engine: the author sees a rule, the tool reports success, and nothing is enforced.

**A misspelled action disabled the rule (#157).** `action: dney` linted clean and the proxy served the package. Actions are now validated where the bundle is parsed:

```
policy.yaml:4:17: error: policy "t" rule[0]: invalid action "dney" (expected allow|deny|warn)
```

Values are trimmed and lowercased before comparison, matching the case-insensitive behavior already in `ActionTypeIs`, with the choice stated in the godoc.

**`severityAtLeast` matched everything on a typo (#158).** `severityRank` returned 0 for unknown strings, so an unrecognized level ranked below all findings. `severityAtLeast(v, "CRITCAL")` was true for a LOW finding while the correct spelling was false. The authored threshold now errors and names the valid set; observed severities stay tolerant, since real data can carry an unmodeled level, and that asymmetry is documented at the call site.

**Lint accepted what the engine rejects (#159).** Lint only compiled CEL, so invalid entrypoints, unknown actions, and duplicate policy names all passed, while `lsp/diagnostics.go` already caught them. The editor was stricter than CI. Structural validation moved into `internal/policy/validate.go`, and both lint and the LSP now call it. Lint reports one line per issue with file, line, column, policy, and rule, and exits nonzero.

LSP behavior was diffed old vs new across five documents: positions, severities, ranges, and quick-fix codes are identical. Three deliberate deltas are noted in the commit, the main one being that a duplicate bundle-level report at 0:0 is now suppressed when a located issue already fired.

## Corpus

All 61 examples and the three CI gates lint clean. One real defect surfaced and is fixed here: `container-base-image.yaml` used `action: info`, which was a no-op rule that never surfaced anything; it now says `warn`, which is what it meant.

Two findings routed rather than fixed, to keep this small:

- `policy/examples/future/risk-analysis-policies.yaml` produces 46 issues. It targets unimplemented entrypoints and unbound variables, and it already failed lint on main. It should move with the risk-analysis work or out of the lint path.
- Mis-cased constants such as `severity.CRITICAL` still lint clean, because `severity` and `scope` are `DynType` so CEL cannot reject the member access. That needs the typing work in #127.

Each fix has table-driven tests that fail against current main; the failing output is quoted in each commit message.