### PR TITLE
Ignore locally built binaries and agent worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,13 @@
 # Test binary, built with `go test -c`
 *.test
 
+# Deputy binaries built at the repo root. The build commands in AGENTS.md and
+# docs/development/contributing.md write here, and the plugin and sandbox
+# examples in docs/guides build alongside them. Root-anchored so it does not
+# shadow tracked files such as examples/sandbox-plugins/vz/deputy-init.
+/deputy
+/deputy-*
+
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
@@ -23,3 +30,9 @@ go.work.sum
 
 # env file
 .env
+
+# Local agent tooling. Shared config under .claude/ stays tracked; these two are
+# per-machine. Worktrees in particular hold full checkouts and reach hundreds of
+# megabytes.
+.claude/worktrees/
+.claude/settings.local.json

--- a/.gitignore
+++ b/.gitignore
@@ -11,12 +11,14 @@
 # Test binary, built with `go test -c`
 *.test
 
-# Deputy binaries built at the repo root. The build commands in AGENTS.md and
-# docs/development/contributing.md write here, and the plugin and sandbox
-# examples in docs/guides build alongside them. Root-anchored so it does not
-# shadow tracked files such as examples/sandbox-plugins/vz/deputy-init.
+# Deputy binaries. AGENTS.md and docs/development/contributing.md build `deputy`
+# at the repo root, so those two patterns are anchored there. The plugin and
+# sandbox READMEs build inside their own package directories, so those two are
+# not anchored. Neither prefix matches the tracked deputy-init shell script.
 /deputy
 /deputy-*
+deputy-extractor-*
+deputy-sandbox-*
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out


### PR DESCRIPTION
The build commands our own docs give contributors produce artifacts that `.gitignore` does not cover.

`AGENTS.md` and `docs/development/contributing.md` both say:

```bash
go build -o deputy .
```

and the plugin and sandbox guides build `deputy-extractor-*` and `deputy-sandbox-*` beside it. None were ignored, so following the docs leaves the working tree dirty and puts a binary one `git add -A` away from being committed.

That is not hypothetical. A 94 MB build output was committed in `bdd2881` and removed in `dbc4979`. It is not reachable from `main`, so `main` itself is clean and nothing over 1 MB is reachable from it.

Agent worktrees under `.claude/` had the same exposure and currently hold 185 MB.

## What this does

| pattern | why |
| --- | --- |
| `/deputy`, `/deputy-*` | documented build outputs, root-anchored |
| `.claude/worktrees/` | full checkouts, hundreds of MB |
| `.claude/settings.local.json` | per-machine, already conventional |

Shared config under `.claude/` stays tracked so it can be committed deliberately.

## Checks

- Both binary patterns are root-anchored and do not shadow tracked files. `examples/sandbox-plugins/vz/deputy-init` stays tracked, verified.
- `git ls-files | git check-ignore --stdin` returns nothing, so no tracked file becomes ignored.
- After `go build -o deputy .`, `git status --porcelain` is empty.
- `coverage.out` was already covered by `*.out`; no speculative patterns added.

## Not included

Removing the old binary from history needs a force push and is a separate call. `origin/proto-first`, merged 7 months ago as #7, is the only ref still carrying that blob and is most of the 50 MB a fresh clone pulls. Deleting that stale branch would reclaim it without rewriting anything.