### PR TITLE
Convert policy payloads by declared type, not by value shape

### DIFF
--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -561,7 +561,15 @@ func convertAnyNumbers(v any) any {
 		return convertSchemalessNumbers(doc)
 	}
 	md := mt.Descriptor()
-	if inner, ok := doc["value"]; ok && md.Fields().ByTextName("value") == nil {
+	// A payload with a JSON form of its own is nested under "value", and one
+	// that flattens writes its fields beside "@type". The two are told apart by
+	// whether the payload declares a field of that name, because the wrappers
+	// declare a "value" whose kind is the JSON value, so reading it as a field
+	// converts it correctly. An Any payload is the exception: its "value" field
+	// holds the wire-level bytes while its JSON "value" is another Any document,
+	// so reading that as a bytes field would leave the whole nested payload
+	// unconverted.
+	if inner, ok := doc["value"]; ok && (md.FullName() == wktAny || md.Fields().ByTextName("value") == nil) {
 		doc["value"] = convertMessageNumbers(inner, md)
 		return doc
 	}

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -392,9 +392,9 @@ func ProtoToMap(msg proto.Message) (map[string]any, error) {
 	if err := dec.Decode(&result); err != nil {
 		return nil, fmt.Errorf("unmarshal json: %w", err)
 	}
-	// Give CEL numbers where the schema declares numbers, using the message
-	// descriptor rather than the shape of each value.
-	result = convertPayloadNumbers(result, msg.ProtoReflect().Descriptor())
+	// Give CEL the Go type the schema declares for each value, using the message
+	// descriptor rather than the shape of the value.
+	result = convertPayload(result, msg.ProtoReflect().Descriptor())
 	// Remove null values so has() checks work correctly.
 	// EmitUnpopulated emits nil message fields as null, but CEL's has() returns
 	// true for keys that exist with null values, causing subsequent field access
@@ -415,10 +415,11 @@ const (
 	wktUint64Value protoreflect.FullName = "google.protobuf.UInt64Value"
 )
 
-// convertPayloadNumbers rewrites the numbers in doc, the protojson document for
-// md, so CEL sees a number wherever the schema declares one. It dispatches on md
-// rather than walking doc's keys directly, because a message with a JSON form of
-// its own (a Struct, or an Any) is a document whose keys are not its fields.
+// convertPayload rewrites doc, the protojson document for md, into the Go types
+// CEL evaluates, deciding every value by the type md declares for it rather than
+// by the shape protojson wrote. It dispatches on md rather than walking doc's
+// keys directly, because a message with a JSON form of its own (a Struct, or an
+// Any) is a document whose keys are not its fields.
 //
 // protojson quotes the 64-bit integer kinds (int64, uint64, sint64, sfixed64,
 // fixed64) so they survive JavaScript's 53-bit floats, so those are the only
@@ -430,8 +431,8 @@ const (
 // shape instead is lossy in a way nothing downstream can repair ("1.20" becomes
 // 1.2). json.Number values become int64 or float64 because CEL cannot compare a
 // json.Number.
-func convertPayloadNumbers(doc map[string]any, md protoreflect.MessageDescriptor) map[string]any {
-	converted, ok := convertMessageNumbers(doc, md).(map[string]any)
+func convertPayload(doc map[string]any, md protoreflect.MessageDescriptor) map[string]any {
+	converted, ok := convertMessage(doc, md).(map[string]any)
 	if !ok {
 		return doc
 	}
@@ -457,15 +458,15 @@ func convertMessageFields(doc map[string]any, md protoreflect.MessageDescriptor)
 			// this walk exists to remove.
 			continue
 		}
-		doc[key] = convertFieldNumbers(val, fd)
+		doc[key] = convertField(val, fd)
 	}
 }
 
-// convertFieldNumbers converts one field's protojson value. Cardinality is
-// resolved first because a list holds element values and a map holds its value
-// type's values, so it is the element kind that decides, never the field's own
-// shape.
-func convertFieldNumbers(v any, fd protoreflect.FieldDescriptor) any {
+// convertField converts one field's protojson value to the Go type fd declares.
+// Cardinality is resolved first because a list holds element values and a map
+// holds its value type's values, so it is the element kind that decides, never
+// the field's own shape.
+func convertField(v any, fd protoreflect.FieldDescriptor) any {
 	switch {
 	case fd.IsMap():
 		entries, ok := v.(map[string]any)
@@ -476,7 +477,7 @@ func convertFieldNumbers(v any, fd protoreflect.FieldDescriptor) any {
 		// can carry a number.
 		value := fd.MapValue()
 		for key, elem := range entries {
-			entries[key] = convertSingularNumbers(elem, value)
+			entries[key] = convertSingularValue(elem, value)
 		}
 		return entries
 	case fd.IsList():
@@ -485,20 +486,20 @@ func convertFieldNumbers(v any, fd protoreflect.FieldDescriptor) any {
 			return v
 		}
 		for i, elem := range elems {
-			elems[i] = convertSingularNumbers(elem, fd)
+			elems[i] = convertSingularValue(elem, fd)
 		}
 		return elems
 	default:
-		return convertSingularNumbers(v, fd)
+		return convertSingularValue(v, fd)
 	}
 }
 
-// convertSingularNumbers converts a single value of fd's declared type, which
+// convertSingularValue converts a single value of fd's declared type, which
 // for a repeated or map field is one element rather than the whole field.
-func convertSingularNumbers(v any, fd protoreflect.FieldDescriptor) any {
+func convertSingularValue(v any, fd protoreflect.FieldDescriptor) any {
 	switch fd.Kind() {
 	case protoreflect.MessageKind, protoreflect.GroupKind:
-		return convertMessageNumbers(v, fd.Message())
+		return convertMessage(v, fd.Message())
 	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind,
 		protoreflect.Uint64Kind, protoreflect.Fixed64Kind:
 		return parseQuotedInteger(v)
@@ -515,9 +516,9 @@ func convertSingularNumbers(v any, fd protoreflect.FieldDescriptor) any {
 	}
 }
 
-// convertMessageNumbers converts the protojson value of a message-typed field,
-// whose descriptor decides how protojson rendered it.
-func convertMessageNumbers(v any, md protoreflect.MessageDescriptor) any {
+// convertMessage converts the protojson value of a message-typed field, whose
+// descriptor decides how protojson rendered it.
+func convertMessage(v any, md protoreflect.MessageDescriptor) any {
 	if md == nil {
 		return v
 	}
@@ -527,7 +528,7 @@ func convertMessageNumbers(v any, md protoreflect.MessageDescriptor) any {
 		// string, whatever either looks like.
 		return convertSchemalessNumbers(v)
 	case wktAny:
-		return convertAnyNumbers(v)
+		return convertAny(v)
 	case wktInt64Value, wktUint64Value:
 		// protojson quotes a wrapped 64-bit integer exactly as it quotes a bare
 		// one.
@@ -544,11 +545,11 @@ func convertMessageNumbers(v any, md protoreflect.MessageDescriptor) any {
 	return doc
 }
 
-// convertAnyNumbers converts a google.protobuf.Any document. protojson writes
-// the payload's fields beside an "@type" key, or under a "value" key when the
+// convertAny converts a google.protobuf.Any document. protojson writes the
+// payload's fields beside an "@type" key, or under a "value" key when the
 // payload has a JSON form of its own, so the payload's descriptor is what
 // decides how to read either shape.
-func convertAnyNumbers(v any) any {
+func convertAny(v any) any {
 	doc, ok := v.(map[string]any)
 	if !ok {
 		return convertJSONNumber(v)
@@ -570,7 +571,7 @@ func convertAnyNumbers(v any) any {
 	// so reading that as a bytes field would leave the whole nested payload
 	// unconverted.
 	if inner, ok := doc["value"]; ok && (md.FullName() == wktAny || md.Fields().ByTextName("value") == nil) {
-		doc["value"] = convertMessageNumbers(inner, md)
+		doc["value"] = convertMessage(inner, md)
 		return doc
 	}
 	convertMessageFields(doc, md)

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -445,6 +445,10 @@ func convertMessageFields(doc map[string]any, md protoreflect.MessageDescriptor)
 	for key, val := range doc {
 		fd := fields.ByTextName(key)
 		if fd == nil {
+			// ProtoToMap marshals with UseProtoNames, so the text name resolves
+			// every field today. The lowerCamelCase lookup is here so that a
+			// caller who drops that option gets typed values rather than a
+			// document the walk silently declines to convert.
 			fd = fields.ByJSONName(key)
 		}
 		if fd == nil {

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -15,6 +15,8 @@ import (
 	"github.com/temporalio/deputy/internal/otel"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
 )
 
 // Evaluator is the interface for evaluating policies against a payload.
@@ -390,8 +392,9 @@ func ProtoToMap(msg proto.Message) (map[string]any, error) {
 	if err := dec.Decode(&result); err != nil {
 		return nil, fmt.Errorf("unmarshal json: %w", err)
 	}
-	// Convert json.Number to proper numeric types for CEL
-	convertJSONNumbers(result)
+	// Give CEL numbers where the schema declares numbers, using the message
+	// descriptor rather than the shape of each value.
+	result = convertPayloadNumbers(result, msg.ProtoReflect().Descriptor())
 	// Remove null values so has() checks work correctly.
 	// EmitUnpopulated emits nil message fields as null, but CEL's has() returns
 	// true for keys that exist with null values, causing subsequent field access
@@ -400,50 +403,217 @@ func ProtoToMap(msg proto.Message) (map[string]any, error) {
 	return result, nil
 }
 
-// convertJSONNumbers recursively converts json.Number and numeric strings to
-// int64 or float64 for proper CEL numeric comparison. Protojson serializes
-// int64 as quoted strings to avoid JavaScript precision issues, but CEL needs
-// proper numeric types.
-func convertJSONNumbers(v any) {
-	switch val := v.(type) {
-	case map[string]any:
-		for k, elem := range val {
-			val[k] = convertNumericValue(elem)
-			convertJSONNumbers(val[k])
+// Well-known types whose protojson form the walk cannot read off a field kind.
+// Timestamp, Duration, FieldMask and the string-ish wrappers are absent because
+// they render as JSON strings, which the walk already leaves alone.
+const (
+	wktAny         protoreflect.FullName = "google.protobuf.Any"
+	wktStruct      protoreflect.FullName = "google.protobuf.Struct"
+	wktValue       protoreflect.FullName = "google.protobuf.Value"
+	wktListValue   protoreflect.FullName = "google.protobuf.ListValue"
+	wktInt64Value  protoreflect.FullName = "google.protobuf.Int64Value"
+	wktUint64Value protoreflect.FullName = "google.protobuf.UInt64Value"
+)
+
+// convertPayloadNumbers rewrites the numbers in doc, the protojson document for
+// md, so CEL sees a number wherever the schema declares one. It dispatches on md
+// rather than walking doc's keys directly, because a message with a JSON form of
+// its own (a Struct, or an Any) is a document whose keys are not its fields.
+//
+// protojson quotes the 64-bit integer kinds (int64, uint64, sint64, sfixed64,
+// fixed64) so they survive JavaScript's 53-bit floats, so those are the only
+// strings in the document that carry a number, and the only ones parsed back.
+// Every field the descriptor calls a string stays a string, however numeric its
+// contents look: a version of "1.20", a 21-digit account id, or base64 bytes
+// that happen to be all digits. Consulting the declared type is what keeps a
+// policy comparing such a field to a string literal working, and parsing by
+// shape instead is lossy in a way nothing downstream can repair ("1.20" becomes
+// 1.2). json.Number values become int64 or float64 because CEL cannot compare a
+// json.Number.
+func convertPayloadNumbers(doc map[string]any, md protoreflect.MessageDescriptor) map[string]any {
+	converted, ok := convertMessageNumbers(doc, md).(map[string]any)
+	if !ok {
+		return doc
+	}
+	return converted
+}
+
+// convertMessageFields converts each field of doc, an ordinary protojson object
+// for md.
+func convertMessageFields(doc map[string]any, md protoreflect.MessageDescriptor) {
+	fields := md.Fields()
+	for key, val := range doc {
+		fd := fields.ByTextName(key)
+		if fd == nil {
+			fd = fields.ByJSONName(key)
 		}
-	case []any:
-		for i, elem := range val {
-			val[i] = convertNumericValue(elem)
-			convertJSONNumbers(val[i])
+		if fd == nil {
+			// An extension, the "@type" of an Any, or a key from a newer
+			// schema. Leave it as protojson wrote it: guessing is the defect
+			// this walk exists to remove.
+			continue
 		}
+		doc[key] = convertFieldNumbers(val, fd)
 	}
 }
 
-// convertNumericValue converts json.Number or numeric strings to native Go numbers.
-func convertNumericValue(elem any) any {
-	switch v := elem.(type) {
-	case json.Number:
-		// Try int64 first, fall back to float64
-		if i, err := v.Int64(); err == nil {
-			return i
+// convertFieldNumbers converts one field's protojson value. Cardinality is
+// resolved first because a list holds element values and a map holds its value
+// type's values, so it is the element kind that decides, never the field's own
+// shape.
+func convertFieldNumbers(v any, fd protoreflect.FieldDescriptor) any {
+	switch {
+	case fd.IsMap():
+		entries, ok := v.(map[string]any)
+		if !ok {
+			return v
 		}
-		if f, err := v.Float64(); err == nil {
-			return f
+		// A JSON object key is always a string, so only the map's value type
+		// can carry a number.
+		value := fd.MapValue()
+		for key, elem := range entries {
+			entries[key] = convertSingularNumbers(elem, value)
 		}
-	case string:
-		// Protojson serializes int64/uint64 as quoted strings.
-		// Try to parse as int64 first (handles most cases), then float64.
-		if len(v) > 0 && (v[0] == '-' || (v[0] >= '0' && v[0] <= '9')) {
-			// Looks like it might be a number, try parsing
-			if i, err := strconv.ParseInt(v, 10, 64); err == nil {
-				return i
-			}
-			if f, err := strconv.ParseFloat(v, 64); err == nil {
-				return f
-			}
+		return entries
+	case fd.IsList():
+		elems, ok := v.([]any)
+		if !ok {
+			return v
 		}
+		for i, elem := range elems {
+			elems[i] = convertSingularNumbers(elem, fd)
+		}
+		return elems
+	default:
+		return convertSingularNumbers(v, fd)
 	}
-	return elem
+}
+
+// convertSingularNumbers converts a single value of fd's declared type, which
+// for a repeated or map field is one element rather than the whole field.
+func convertSingularNumbers(v any, fd protoreflect.FieldDescriptor) any {
+	switch fd.Kind() {
+	case protoreflect.MessageKind, protoreflect.GroupKind:
+		return convertMessageNumbers(v, fd.Message())
+	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind,
+		protoreflect.Uint64Kind, protoreflect.Fixed64Kind:
+		return parseQuotedInteger(v)
+	case protoreflect.StringKind, protoreflect.BytesKind, protoreflect.BoolKind:
+		// A declared string stays a string, and so does the base64 text of a
+		// bytes field.
+		return v
+	default:
+		// The 32-bit integer kinds, float, double, and enums (UseEnumNumbers)
+		// all arrive as JSON numbers.
+		return convertJSONNumber(v)
+	}
+}
+
+// convertMessageNumbers converts the protojson value of a message-typed field,
+// whose descriptor decides how protojson rendered it.
+func convertMessageNumbers(v any, md protoreflect.MessageDescriptor) any {
+	if md == nil {
+		return v
+	}
+	switch md.FullName() {
+	case wktStruct, wktValue, wktListValue:
+		// JSON with no schema behind it: a number is a number and a string is a
+		// string, whatever either looks like.
+		return convertSchemalessNumbers(v)
+	case wktAny:
+		return convertAnyNumbers(v)
+	case wktInt64Value, wktUint64Value:
+		// protojson quotes a wrapped 64-bit integer exactly as it quotes a bare
+		// one.
+		return parseQuotedInteger(v)
+	}
+	doc, ok := v.(map[string]any)
+	if !ok {
+		// Timestamp, Duration, FieldMask and the string-ish wrappers render as
+		// JSON strings, the numeric wrappers as JSON numbers, and an unset
+		// message field as null.
+		return convertJSONNumber(v)
+	}
+	convertMessageFields(doc, md)
+	return doc
+}
+
+// convertAnyNumbers converts a google.protobuf.Any document. protojson writes
+// the payload's fields beside an "@type" key, or under a "value" key when the
+// payload has a JSON form of its own, so the payload's descriptor is what
+// decides how to read either shape.
+func convertAnyNumbers(v any) any {
+	doc, ok := v.(map[string]any)
+	if !ok {
+		return convertJSONNumber(v)
+	}
+	url, _ := doc["@type"].(string)
+	mt, err := protoregistry.GlobalTypes.FindMessageByURL(url)
+	if err != nil || mt == nil {
+		// A payload this binary does not link: repair the JSON numbers CEL
+		// cannot read and leave every string alone.
+		return convertSchemalessNumbers(doc)
+	}
+	md := mt.Descriptor()
+	if inner, ok := doc["value"]; ok && md.Fields().ByTextName("value") == nil {
+		doc["value"] = convertMessageNumbers(inner, md)
+		return doc
+	}
+	convertMessageFields(doc, md)
+	return doc
+}
+
+// convertSchemalessNumbers converts the json.Number values in a document no
+// descriptor describes (a Struct, Value or ListValue field, or an Any whose
+// payload type is not registered), leaving every string untouched.
+func convertSchemalessNumbers(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		for key, elem := range val {
+			val[key] = convertSchemalessNumbers(elem)
+		}
+		return val
+	case []any:
+		for i, elem := range val {
+			val[i] = convertSchemalessNumbers(elem)
+		}
+		return val
+	default:
+		return convertJSONNumber(v)
+	}
+}
+
+// convertJSONNumber converts a json.Number to the int64 or float64 CEL can
+// compare, preferring int64. Any other value is returned unchanged.
+func convertJSONNumber(v any) any {
+	n, ok := v.(json.Number)
+	if !ok {
+		return v
+	}
+	if i, err := n.Int64(); err == nil {
+		return i
+	}
+	if f, err := n.Float64(); err == nil {
+		return f
+	}
+	return v
+}
+
+// parseQuotedInteger parses the string protojson writes for a 64-bit integer
+// field. A uint64 above the int64 range has no CEL integer to land in and
+// becomes a float64, which is lossy but is the only value CEL can hold.
+func parseQuotedInteger(v any) any {
+	s, ok := v.(string)
+	if !ok {
+		return convertJSONNumber(v)
+	}
+	if i, err := strconv.ParseInt(s, 10, 64); err == nil {
+		return i
+	}
+	if f, err := strconv.ParseFloat(s, 64); err == nil {
+		return f
+	}
+	return v
 }
 
 // removeNullValues recursively removes null values from maps.

--- a/internal/policy/engine.go
+++ b/internal/policy/engine.go
@@ -498,13 +498,15 @@ func convertSingularNumbers(v any, fd protoreflect.FieldDescriptor) any {
 	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind,
 		protoreflect.Uint64Kind, protoreflect.Fixed64Kind:
 		return parseQuotedInteger(v)
+	case protoreflect.DoubleKind, protoreflect.FloatKind:
+		return parseFloat(v)
 	case protoreflect.StringKind, protoreflect.BytesKind, protoreflect.BoolKind:
 		// A declared string stays a string, and so does the base64 text of a
 		// bytes field.
 		return v
 	default:
-		// The 32-bit integer kinds, float, double, and enums (UseEnumNumbers)
-		// all arrive as JSON numbers.
+		// The 32-bit integer kinds and enums (UseEnumNumbers) arrive as JSON
+		// numbers.
 		return convertJSONNumber(v)
 	}
 }
@@ -595,6 +597,31 @@ func convertJSONNumber(v any) any {
 	}
 	if f, err := n.Float64(); err == nil {
 		return f
+	}
+	return v
+}
+
+// parseFloat converts the protojson form of a float or double field to a
+// float64, whatever the value looks like.
+//
+// Two shapes reach here. protojson writes a whole-numbered double without a
+// decimal point, so 9.0 arrives as the JSON number 9, and reading that as an
+// int64 would leave the Go type dependent on the data: 9.8 would be a double
+// while 9.0 was an integer, and a policy dividing a CVSS score would get
+// integer division for exactly the scores that are whole. protojson also writes
+// the three values JSON cannot spell, NaN, Infinity and -Infinity, as strings,
+// and a score comparison has to behave the same for all three rather than for
+// the one the shape guess happened to parse.
+func parseFloat(v any) any {
+	switch val := v.(type) {
+	case string:
+		if f, err := strconv.ParseFloat(val, 64); err == nil {
+			return f
+		}
+	case json.Number:
+		if f, err := val.Float64(); err == nil {
+			return f
+		}
 	}
 	return v
 }

--- a/internal/policy/payload_types_test.go
+++ b/internal/policy/payload_types_test.go
@@ -145,12 +145,32 @@ func TestProtoToMapConvertsByDeclaredType(t *testing.T) {
 			want: int64(2),
 		},
 		{
-			name: "map with message values is walked",
+			name: "second map with string values keeps its values",
 			msg: &triagev1.PackageSummary{
 				DatabaseSpecific: map[string]string{"review_status": "1.20"},
 			},
 			path: []any{"database_specific", "review_status"},
 			want: "1.20",
+		},
+		{
+			name: "string in a map with message values stays a string",
+			msg: &vulnerabilityv1.GetAdvisoriesResponse{
+				Advisories: map[string]*vulnerabilityv1.Advisory{
+					"GHSA-1234": {Id: "GHSA-1234", Summary: "1.20", Severity: &vulnerabilityv1.Severity{Score: 9}},
+				},
+			},
+			path: []any{"advisories", "GHSA-1234", "summary"},
+			want: "1.20",
+		},
+		{
+			name: "double in a map with message values holds a number",
+			msg: &vulnerabilityv1.GetAdvisoriesResponse{
+				Advisories: map[string]*vulnerabilityv1.Advisory{
+					"GHSA-1234": {Id: "GHSA-1234", Summary: "1.20", Severity: &vulnerabilityv1.Severity{Score: 9}},
+				},
+			},
+			path: []any{"advisories", "GHSA-1234", "severity", "score"},
+			want: float64(9),
 		},
 		{
 			name: "string in a nested message stays a string",

--- a/internal/policy/payload_types_test.go
+++ b/internal/policy/payload_types_test.go
@@ -471,6 +471,35 @@ func TestProtoToMapConvertsSchemalessValues(t *testing.T) {
 			t.Errorf("payload[value] = %#v (%T), want %#v", got["value"], got["value"], want)
 		}
 	})
+
+	// An Any is the one payload whose JSON "value" is not its "value" field: the
+	// field carries wire-level bytes while the JSON carries another Any document.
+	// Read as a bytes field, the entire nested payload goes unconverted, which is
+	// the silent half of the defect this walk removes.
+	t.Run("any payload nested in an any is walked", func(t *testing.T) {
+		inner, err := anypb.New(&vulnerabilityv1.Severity{Score: 9, Raw: "1.20"})
+		if err != nil {
+			t.Fatalf("anypb.New: %v", err)
+		}
+		outer, err := anypb.New(inner)
+		if err != nil {
+			t.Fatalf("anypb.New: %v", err)
+		}
+		got, err := ProtoToMap(outer)
+		if err != nil {
+			t.Fatalf("ProtoToMap: %v", err)
+		}
+		nested, ok := got["value"].(map[string]any)
+		if !ok {
+			t.Fatalf("payload[value] = %#v (%T), want an object", got["value"], got["value"])
+		}
+		if want := float64(9); nested["score"] != want {
+			t.Errorf("payload[value][score] = %#v (%T), want %#v", nested["score"], nested["score"], want)
+		}
+		if want := "1.20"; nested["raw"] != want {
+			t.Errorf("payload[value][raw] = %#v (%T), want %#v", nested["raw"], nested["raw"], want)
+		}
+	})
 }
 
 // quotedIntegerShapes builds a message descriptor for the 64-bit integer field

--- a/internal/policy/payload_types_test.go
+++ b/internal/policy/payload_types_test.go
@@ -1,0 +1,610 @@
+package policy
+
+import (
+	"encoding/base64"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/dynamicpb"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	containerv1 "github.com/temporalio/deputy/gen/deputy/container/v1"
+	dependencyv1 "github.com/temporalio/deputy/gen/deputy/dependency/v1"
+	policyv1 "github.com/temporalio/deputy/gen/deputy/policy/v1"
+	targetv1 "github.com/temporalio/deputy/gen/deputy/target/v1"
+	triagev1 "github.com/temporalio/deputy/gen/deputy/triage/v1"
+)
+
+// payloadAt resolves a path through a ProtoToMap payload, so a case can name one
+// value inside a nested message, a repeated field, or a map without restating
+// every sibling key EmitUnpopulated adds.
+func payloadAt(t *testing.T, payload map[string]any, path ...any) any {
+	t.Helper()
+	var cur any = payload
+	for i, step := range path {
+		switch key := step.(type) {
+		case string:
+			obj, ok := cur.(map[string]any)
+			if !ok {
+				t.Fatalf("path %v: element %d (%q): have %T, want an object", path, i, key, cur)
+			}
+			val, ok := obj[key]
+			if !ok {
+				t.Fatalf("path %v: element %d: no key %q in %v", path, i, key, obj)
+			}
+			cur = val
+		case int:
+			list, ok := cur.([]any)
+			if !ok {
+				t.Fatalf("path %v: element %d (%d): have %T, want a list", path, i, key, cur)
+			}
+			if key >= len(list) {
+				t.Fatalf("path %v: element %d: index %d out of range in %v", path, i, key, list)
+			}
+			cur = list[key]
+		default:
+			t.Fatalf("path %v: element %d: unsupported step type %T", path, i, step)
+		}
+	}
+	return cur
+}
+
+// TestProtoToMapConvertsByDeclaredType pins the rule the payload conversion
+// follows: the field's declared type decides whether a value is a number, not
+// the shape of the value.
+//
+// protojson quotes the 64-bit integer kinds, so those are the only strings that
+// carry a number. A version, a subject, or a base64 blob that happens to parse
+// as a number is still a string, and a policy comparing it to a string literal
+// has to see one.
+func TestProtoToMapConvertsByDeclaredType(t *testing.T) {
+	created := timestamppb.New(mustTime(t, "2024-01-02T03:04:05Z"))
+	// Six bytes whose base64 encoding is all digits, which is what makes a
+	// bytes field indistinguishable from a number by shape alone.
+	blob, err := base64.StdEncoding.DecodeString("12345678")
+	if err != nil {
+		t.Fatalf("decode base64 fixture: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		msg  proto.Message
+		path []any
+		want any
+	}{
+		{
+			name: "two component version stays a string",
+			msg:  &dependencyv1.Package{Name: "numpy", Version: "1.21"},
+			path: []any{"version"},
+			want: "1.21",
+		},
+		{
+			name: "trailing zero version survives",
+			msg:  &dependencyv1.Package{Name: "numpy", Version: "1.20"},
+			path: []any{"version"},
+			want: "1.20",
+		},
+		{
+			name: "major only version survives",
+			msg:  &dependencyv1.Package{Name: "numpy", Version: "2.0"},
+			path: []any{"version"},
+			want: "2.0",
+		},
+		{
+			name: "three component version is unaffected",
+			msg:  &dependencyv1.Package{Name: "numpy", Version: "1.21.6"},
+			path: []any{"version"},
+			want: "1.21.6",
+		},
+		{
+			name: "purl beside the version keeps agreeing with it",
+			msg:  &dependencyv1.Package{Name: "numpy", Version: "1.21", Purl: "pkg:pypi/numpy@1.21"},
+			path: []any{"purl"},
+			want: "pkg:pypi/numpy@1.21",
+		},
+		{
+			name: "twenty one digit subject stays a string",
+			msg:  &policyv1.JWTClaims{Sub: "104567890123456789012"},
+			path: []any{"sub"},
+			want: "104567890123456789012",
+		},
+		{
+			name: "declared int64 parses back to a number",
+			msg:  &policyv1.JWTClaims{Exp: 1699999999},
+			path: []any{"exp"},
+			want: int64(1699999999),
+		},
+		{
+			name: "int64 beyond float53 keeps every digit",
+			msg:  &policyv1.JWTClaims{Iat: 9007199254740993},
+			path: []any{"iat"},
+			want: int64(9007199254740993),
+		},
+		{
+			name: "map with string values keeps its values",
+			msg:  &policyv1.JWTClaims{CustomClaims: map[string]string{"repository_owner_id": "12345"}},
+			path: []any{"custom_claims", "repository_owner_id"},
+			want: "12345",
+		},
+		{
+			name: "map with int32 values holds numbers",
+			msg:  &triagev1.PackageSummary{SeverityCounts: map[string]int32{"critical": 2}},
+			path: []any{"severity_counts", "critical"},
+			want: int64(2),
+		},
+		{
+			name: "map with message values is walked",
+			msg: &triagev1.PackageSummary{
+				DatabaseSpecific: map[string]string{"review_status": "1.20"},
+			},
+			path: []any{"database_specific", "review_status"},
+			want: "1.20",
+		},
+		{
+			name: "string in a nested message stays a string",
+			msg: &dependencyv1.Package{
+				Name:         "numpy",
+				LayerDetails: &containerv1.LayerDetails{DiffId: "12345", Index: 3},
+			},
+			path: []any{"layer_details", "diff_id"},
+			want: "12345",
+		},
+		{
+			name: "int32 in a nested message holds a number",
+			msg: &dependencyv1.Package{
+				Name:         "numpy",
+				LayerDetails: &containerv1.LayerDetails{DiffId: "12345", Index: 3},
+			},
+			path: []any{"layer_details", "index"},
+			want: int64(3),
+		},
+		{
+			name: "string in a repeated message stays a string",
+			msg: &dependencyv1.Package{
+				ManifestRefs: []*dependencyv1.ManifestRef{
+					{Path: "12345", Manager: "pip"},
+					{Path: "requirements.txt", Manager: "pip"},
+				},
+			},
+			path: []any{"manifest_refs", 0, "path"},
+			want: "12345",
+		},
+		{
+			name: "repeated string elements stay strings",
+			msg:  &dependencyv1.Package{Licenses: []string{"1.20", "MIT"}},
+			path: []any{"licenses", 0},
+			want: "1.20",
+		},
+		{
+			name: "enum holds its number",
+			msg:  &targetv1.Target{Kind: targetv1.TargetKind_TARGET_KIND_DIR},
+			path: []any{"kind"},
+			want: int64(targetv1.TargetKind_TARGET_KIND_DIR),
+		},
+		{
+			name: "timestamp keeps its RFC 3339 string",
+			msg:  &containerv1.ImageMetadata{Created: created},
+			path: []any{"created"},
+			want: "2024-01-02T03:04:05Z",
+		},
+		{
+			name: "os version with a trailing zero survives",
+			msg:  &containerv1.ImageMetadata{OsVersion: "1.20", DockerVersion: "24.0"},
+			path: []any{"os_version"},
+			want: "1.20",
+		},
+		{
+			name: "declared int64 size parses back to a number",
+			msg:  &containerv1.ImageMetadata{Size: 1099511627776},
+			path: []any{"size"},
+			want: int64(1099511627776),
+		},
+		{
+			name: "string member of a oneof stays a string",
+			msg:  &policyv1.PolicySource{Source: &policyv1.PolicySource_Inline{Inline: "1.20"}},
+			path: []any{"inline"},
+			want: "1.20",
+		},
+		{
+			name: "message member of a oneof is walked",
+			msg: &policyv1.EvaluateRequest{
+				Input: &policyv1.EvaluateRequest_ScanVulnerability{
+					ScanVulnerability: &policyv1.ScanVulnerabilityPolicyInput{
+						Pkg: &dependencyv1.Package{Name: "numpy", Version: "1.20"},
+					},
+				},
+			},
+			path: []any{"scan_vulnerability", "pkg", "version"},
+			want: "1.20",
+		},
+		{
+			name: "bytes keep their base64 text",
+			msg: &policyv1.EvaluateRequest{
+				Input: &policyv1.EvaluateRequest_CustomPayload{CustomPayload: blob},
+			},
+			path: []any{"custom_payload"},
+			want: "12345678",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			payload, err := ProtoToMap(tt.msg)
+			if err != nil {
+				t.Fatalf("ProtoToMap: %v", err)
+			}
+			got := payloadAt(t, payload, tt.path...)
+			if got != tt.want {
+				t.Errorf("payload%v = %#v (%T), want %#v (%T)", tt.path, got, got, tt.want, tt.want)
+			}
+		})
+	}
+}
+
+// TestProtoToMapConvertsQuotedIntegerShapes covers the field shapes no Deputy
+// proto declares today but the walk still has to get right: a repeated 64-bit
+// integer, a map whose values are 64-bit integers, and the remaining 64-bit
+// kinds protojson quotes. Each is paired with a string-typed sibling holding a
+// numeric-looking value, because the point is that cardinality and kind decide
+// per field rather than once per document.
+func TestProtoToMapConvertsQuotedIntegerShapes(t *testing.T) {
+	md := quotedIntegerShapes(t)
+
+	tests := []struct {
+		name string
+		json string
+		want map[string]any
+	}{
+		{
+			name: "quoted integers parse and their string siblings do not",
+			json: `{
+				"ids": ["7", "9007199254740993"],
+				"tags": ["1.20", "2.0"],
+				"counters": {"builds": "12", "runs": "0"},
+				"labels": {"version": "1.20", "channel": "2"},
+				"delta": "-5",
+				"checksum": "9007199254740993",
+				"offset": "-9007199254740993",
+				"total": "18446744073709551615",
+				"choice_name": "2.0"
+			}`,
+			want: map[string]any{
+				"ids":      []any{int64(7), int64(9007199254740993)},
+				"tags":     []any{"1.20", "2.0"},
+				"counters": map[string]any{"builds": int64(12), "runs": int64(0)},
+				"labels":   map[string]any{"version": "1.20", "channel": "2"},
+				"delta":    int64(-5),
+				"checksum": int64(9007199254740993),
+				"offset":   int64(-9007199254740993),
+				// A uint64 above the int64 range has no CEL integer to land in,
+				// so it becomes a float64. That is unchanged by the typed walk
+				// and is the one lossy case left.
+				"total":       float64(18446744073709551615),
+				"choice_name": "2.0",
+			},
+		},
+		{
+			name: "integer member of a oneof parses",
+			json: `{"choice_id": "11"}`,
+			want: map[string]any{
+				"ids":         []any{},
+				"tags":        []any{},
+				"counters":    map[string]any{},
+				"labels":      map[string]any{},
+				"delta":       int64(0),
+				"checksum":    int64(0),
+				"offset":      int64(0),
+				"total":       int64(0),
+				"choice_id":   int64(11),
+				"choice_name": nil,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := dynamicpb.NewMessage(md)
+			if err := protojson.Unmarshal([]byte(tt.json), msg); err != nil {
+				t.Fatalf("protojson.Unmarshal: %v", err)
+			}
+			got, err := ProtoToMap(msg)
+			if err != nil {
+				t.Fatalf("ProtoToMap: %v", err)
+			}
+			// An unset oneof member is absent rather than null; naming it in
+			// want documents that, and removeNullValues deletes nulls anyway.
+			want := make(map[string]any, len(tt.want))
+			for k, v := range tt.want {
+				if v == nil {
+					continue
+				}
+				want[k] = v
+			}
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("ProtoToMap mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestProtoToMapConvertsSchemalessValues covers the well-known types where a
+// number genuinely is a number and no field kind applies: Struct, Value and
+// ListValue carry JSON, and an Any carries whatever its payload declares.
+func TestProtoToMapConvertsSchemalessValues(t *testing.T) {
+	t.Run("struct numbers stay numbers and struct strings stay strings", func(t *testing.T) {
+		props, err := structpb.NewStruct(map[string]any{
+			"count":   3,
+			"ratio":   0.5,
+			"version": "1.20",
+			"mixed":   []any{1, "12"},
+			"nested":  map[string]any{"build": 7, "tag": "2.0"},
+		})
+		if err != nil {
+			t.Fatalf("structpb.NewStruct: %v", err)
+		}
+		got, err := ProtoToMap(props)
+		if err != nil {
+			t.Fatalf("ProtoToMap: %v", err)
+		}
+		want := map[string]any{
+			"count":   int64(3),
+			"ratio":   0.5,
+			"version": "1.20",
+			"mixed":   []any{int64(1), "12"},
+			"nested":  map[string]any{"build": int64(7), "tag": "2.0"},
+		}
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Errorf("ProtoToMap mismatch (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("any payload is walked with its own descriptor", func(t *testing.T) {
+		packed, err := anypb.New(&dependencyv1.Package{Name: "numpy", Version: "1.20"})
+		if err != nil {
+			t.Fatalf("anypb.New: %v", err)
+		}
+		got, err := ProtoToMap(packed)
+		if err != nil {
+			t.Fatalf("ProtoToMap: %v", err)
+		}
+		if want := "type.googleapis.com/deputy.dependency.v1.Package"; got["@type"] != want {
+			t.Errorf("payload[@type] = %#v, want %#v", got["@type"], want)
+		}
+		if want := "1.20"; got["version"] != want {
+			t.Errorf("payload[version] = %#v (%T), want %#v", got["version"], got["version"], want)
+		}
+	})
+
+	t.Run("any payload with its own json form is walked under value", func(t *testing.T) {
+		packed, err := anypb.New(wrapperspb.Int64(9007199254740993))
+		if err != nil {
+			t.Fatalf("anypb.New: %v", err)
+		}
+		got, err := ProtoToMap(packed)
+		if err != nil {
+			t.Fatalf("ProtoToMap: %v", err)
+		}
+		if want := int64(9007199254740993); got["value"] != want {
+			t.Errorf("payload[value] = %#v (%T), want %#v", got["value"], got["value"], want)
+		}
+	})
+}
+
+// quotedIntegerShapes builds a message descriptor for the 64-bit integer field
+// shapes the Deputy protos do not declare today. It is synthesized rather than
+// generated so the walk is tested against the whole of protojson's quoting rule
+// instead of only the parts a shipped message happens to use.
+func quotedIntegerShapes(t *testing.T) protoreflect.MessageDescriptor {
+	t.Helper()
+
+	const pkg = "deputy.policy.payloadtest"
+	field := func(name string, num int32, typ descriptorpb.FieldDescriptorProto_Type, label descriptorpb.FieldDescriptorProto_Label) *descriptorpb.FieldDescriptorProto {
+		return &descriptorpb.FieldDescriptorProto{
+			Name:     proto.String(name),
+			JsonName: proto.String(name),
+			Number:   proto.Int32(num),
+			Type:     typ.Enum(),
+			Label:    label.Enum(),
+		}
+	}
+	mapEntry := func(name string, valueType descriptorpb.FieldDescriptorProto_Type) *descriptorpb.DescriptorProto {
+		return &descriptorpb.DescriptorProto{
+			Name: proto.String(name),
+			Field: []*descriptorpb.FieldDescriptorProto{
+				field("key", 1, descriptorpb.FieldDescriptorProto_TYPE_STRING, descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL),
+				field("value", 2, valueType, descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL),
+			},
+			Options: &descriptorpb.MessageOptions{MapEntry: proto.Bool(true)},
+		}
+	}
+	mapField := func(name string, num int32, entry string) *descriptorpb.FieldDescriptorProto {
+		f := field(name, num, descriptorpb.FieldDescriptorProto_TYPE_MESSAGE, descriptorpb.FieldDescriptorProto_LABEL_REPEATED)
+		f.TypeName = proto.String("." + pkg + ".Shapes." + entry)
+		return f
+	}
+	oneofMember := func(f *descriptorpb.FieldDescriptorProto) *descriptorpb.FieldDescriptorProto {
+		f.OneofIndex = proto.Int32(0)
+		return f
+	}
+
+	file := &descriptorpb.FileDescriptorProto{
+		Name:    proto.String("deputy/policy/payloadtest.proto"),
+		Package: proto.String(pkg),
+		Syntax:  proto.String("proto3"),
+		MessageType: []*descriptorpb.DescriptorProto{{
+			Name: proto.String("Shapes"),
+			Field: []*descriptorpb.FieldDescriptorProto{
+				field("ids", 1, descriptorpb.FieldDescriptorProto_TYPE_INT64, descriptorpb.FieldDescriptorProto_LABEL_REPEATED),
+				field("tags", 2, descriptorpb.FieldDescriptorProto_TYPE_STRING, descriptorpb.FieldDescriptorProto_LABEL_REPEATED),
+				mapField("counters", 3, "CountersEntry"),
+				mapField("labels", 4, "LabelsEntry"),
+				field("delta", 5, descriptorpb.FieldDescriptorProto_TYPE_SINT64, descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL),
+				field("checksum", 6, descriptorpb.FieldDescriptorProto_TYPE_FIXED64, descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL),
+				field("offset", 7, descriptorpb.FieldDescriptorProto_TYPE_SFIXED64, descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL),
+				field("total", 8, descriptorpb.FieldDescriptorProto_TYPE_UINT64, descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL),
+				oneofMember(field("choice_name", 9, descriptorpb.FieldDescriptorProto_TYPE_STRING, descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL)),
+				oneofMember(field("choice_id", 10, descriptorpb.FieldDescriptorProto_TYPE_INT64, descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL)),
+			},
+			NestedType: []*descriptorpb.DescriptorProto{
+				mapEntry("CountersEntry", descriptorpb.FieldDescriptorProto_TYPE_INT64),
+				mapEntry("LabelsEntry", descriptorpb.FieldDescriptorProto_TYPE_STRING),
+			},
+			OneofDecl: []*descriptorpb.OneofDescriptorProto{{Name: proto.String("choice")}},
+		}},
+	}
+
+	fd, err := protodesc.NewFile(file, nil)
+	if err != nil {
+		t.Fatalf("protodesc.NewFile: %v", err)
+	}
+	return fd.Messages().Get(0)
+}
+
+// mustTime parses an RFC 3339 timestamp for a fixture.
+func mustTime(t *testing.T, value string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		t.Fatalf("time.Parse(%q): %v", value, err)
+	}
+	return parsed
+}
+
+// TestSBOMComponentDeniesExactVersion drives the defect through a shipped
+// entrypoint end to end, which is where it was demonstrated: a deny policy
+// naming the exact version an author would copy out of an SBOM has to fire, and
+// a version the policy does not name has to pass.
+func TestSBOMComponentDeniesExactVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		version  string
+		wantDeny bool
+	}{
+		{name: "equality on a two component version", body: `pkg.version == "1.21"`, version: "1.21", wantDeny: true},
+		{name: "equality on a trailing zero version", body: `pkg.version == "1.20"`, version: "1.20", wantDeny: true},
+		{name: "equality on a major only version", body: `pkg.version == "2.0"`, version: "2.0", wantDeny: true},
+		{name: "equality on a three component version", body: `pkg.version == "1.21.6"`, version: "1.21.6", wantDeny: true},
+		{name: "equality does not fire for another version", body: `pkg.version == "1.20"`, version: "1.21", wantDeny: false},
+		{name: "prefix match on a two component version", body: `pkg.version.startsWith("1.2")`, version: "1.21", wantDeny: true},
+		{name: "prefix match with the v prefix an author writes", body: `("v" + pkg.version) == "v1.21"`, version: "1.21", wantDeny: true},
+		{name: "ordering against a version baseline", body: `pkg.version < "1.21"`, version: "1.20", wantDeny: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := fmt.Sprintf(`%s ? [{"action": "deny", "reason": "version denied"}] : []`, tt.body)
+			engine, err := NewEngine([]Source{{Name: "deny-exact-version", Body: body}})
+			if err != nil {
+				t.Fatalf("NewEngine: %v", err)
+			}
+			input := &policyv1.SbomComponentPolicyInput{
+				Pkg: &dependencyv1.Package{
+					Name:      "numpy",
+					Version:   tt.version,
+					Ecosystem: "pypi",
+					Purl:      "pkg:pypi/numpy@" + tt.version,
+				},
+				Env: &policyv1.Environment{Command: "sbom", Entrypoint: string(EntrypointSBOMComponent)},
+			}
+			actions, err := engine.EvaluateAll(t.Context(), input, "sbom", string(EntrypointSBOMComponent))
+			if err != nil {
+				t.Fatalf("EvaluateAll(version=%q): %v", tt.version, err)
+			}
+			denied := false
+			for _, action := range actions {
+				if ActionTypeIs(action.Type, ActionDeny) {
+					denied = true
+				}
+			}
+			if denied != tt.wantDeny {
+				t.Errorf("%s against version %q denied = %v, want %v (actions %+v)", tt.body, tt.version, denied, tt.wantDeny, actions)
+			}
+		})
+	}
+}
+
+// TestServiceRequestJWTClaimTypes drives the JWT half of the defect through a
+// service entrypoint: a subject that is all digits has to behave as the string
+// the token carried, a declared int64 claim has to stay comparable to a numeric
+// literal, and the custom claim flattening that makes jwt.roles iterable has to
+// keep working over values that are strings again.
+func TestServiceRequestJWTClaimTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		body     string
+		jwt      *policyv1.JWTClaims
+		wantDeny bool
+	}{
+		{
+			name:     "equality against a twenty one digit subject",
+			body:     `jwt.sub == "104567890123456789012"`,
+			jwt:      &policyv1.JWTClaims{Sub: "104567890123456789012"},
+			wantDeny: true,
+		},
+		{
+			name:     "prefix match on a twenty one digit subject",
+			body:     `jwt.sub.startsWith("1045")`,
+			jwt:      &policyv1.JWTClaims{Sub: "104567890123456789012"},
+			wantDeny: true,
+		},
+		{
+			name:     "declared int64 claim compares to a numeric literal",
+			body:     `jwt.exp == 1699999999`,
+			jwt:      &policyv1.JWTClaims{Sub: "104567890123456789012", Exp: 1699999999},
+			wantDeny: true,
+		},
+		{
+			name:     "bracketed claim list stays iterable",
+			body:     `jwt.roles.exists(r, r == "scanner")`,
+			jwt:      &policyv1.JWTClaims{Sub: "user@example.com", CustomClaims: map[string]string{"roles": "[scanner security]"}},
+			wantDeny: true,
+		},
+		{
+			name:     "comma separated claim list stays iterable",
+			body:     `jwt.roles.exists(r, r == "scanner")`,
+			jwt:      &policyv1.JWTClaims{Sub: "user@example.com", CustomClaims: map[string]string{"roles": "admin,scanner"}},
+			wantDeny: true,
+		},
+		{
+			name:     "numeric custom claim is the string the schema declares",
+			body:     `jwt.repository_owner_id == "12345"`,
+			jwt:      &policyv1.JWTClaims{Sub: "repo:acme/app:ref:refs/heads/main", CustomClaims: map[string]string{"repository_owner_id": "12345"}},
+			wantDeny: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := fmt.Sprintf(`%s ? [{"action": "deny", "reason": "identity denied"}] : []`, tt.body)
+			engine, err := NewEngine([]Source{{Name: "jwt-claim-types", Body: body}})
+			if err != nil {
+				t.Fatalf("NewEngine: %v", err)
+			}
+			input := serviceRequestInput[EntrypointServiceScanRequest](tt.jwt, "/deputy.test.v1.TestService/Probe", "github.com/acme/app")
+			actions, err := engine.EvaluateAll(t.Context(), input, "server", string(EntrypointServiceScanRequest))
+			if err != nil {
+				t.Fatalf("EvaluateAll: %v", err)
+			}
+			denied := false
+			for _, action := range actions {
+				if ActionTypeIs(action.Type, ActionDeny) {
+					denied = true
+				}
+			}
+			if denied != tt.wantDeny {
+				t.Errorf("%s denied = %v, want %v (actions %+v)", tt.body, denied, tt.wantDeny, actions)
+			}
+		})
+	}
+}

--- a/internal/policy/payload_types_test.go
+++ b/internal/policy/payload_types_test.go
@@ -3,6 +3,7 @@ package policy
 import (
 	"encoding/base64"
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -23,6 +24,7 @@ import (
 	policyv1 "github.com/temporalio/deputy/gen/deputy/policy/v1"
 	targetv1 "github.com/temporalio/deputy/gen/deputy/target/v1"
 	triagev1 "github.com/temporalio/deputy/gen/deputy/triage/v1"
+	vulnerabilityv1 "github.com/temporalio/deputy/gen/deputy/vulnerability/v1"
 )
 
 // payloadAt resolves a path through a ProtoToMap payload, so a case can name one
@@ -186,6 +188,40 @@ func TestProtoToMapConvertsByDeclaredType(t *testing.T) {
 			want: "1.20",
 		},
 		{
+			name: "raw score text stays a string beside the scored double",
+			msg:  &vulnerabilityv1.Severity{Score: 9.8, Raw: "9.8"},
+			path: []any{"raw"},
+			want: "9.8",
+		},
+		{
+			name: "declared double holds a number",
+			msg:  &vulnerabilityv1.Severity{Score: 9.8, Raw: "9.8"},
+			path: []any{"score"},
+			want: 9.8,
+		},
+		{
+			// protojson writes a whole-numbered double with no decimal point, so
+			// this is where reading the value's shape would leave the Go type
+			// depending on the score: 9.8 a double, 9.0 an integer, and score / 2
+			// integer division for half the CVSS scale.
+			name: "whole numbered double is still a double",
+			msg:  &vulnerabilityv1.Severity{Score: 9},
+			path: []any{"score"},
+			want: float64(9),
+		},
+		{
+			name: "infinite double holds a number",
+			msg:  &vulnerabilityv1.Severity{Score: math.Inf(1)},
+			path: []any{"score"},
+			want: math.Inf(1),
+		},
+		{
+			name: "negative infinite double holds a number",
+			msg:  &vulnerabilityv1.Severity{Score: math.Inf(-1)},
+			path: []any{"score"},
+			want: math.Inf(-1),
+		},
+		{
 			name: "enum holds its number",
 			msg:  &targetv1.Target{Kind: targetv1.TargetKind_TARGET_KIND_DIR},
 			path: []any{"kind"},
@@ -248,6 +284,23 @@ func TestProtoToMapConvertsByDeclaredType(t *testing.T) {
 				t.Errorf("payload%v = %#v (%T), want %#v (%T)", tt.path, got, got, tt.want, tt.want)
 			}
 		})
+	}
+}
+
+// TestProtoToMapConvertsNaNScore covers the one float value that needs its own
+// test, because NaN never equals itself. A policy comparing a score has to get a
+// number rather than the text protojson writes for it.
+func TestProtoToMapConvertsNaNScore(t *testing.T) {
+	payload, err := ProtoToMap(&vulnerabilityv1.Severity{Score: math.NaN()})
+	if err != nil {
+		t.Fatalf("ProtoToMap: %v", err)
+	}
+	score, ok := payload["score"].(float64)
+	if !ok {
+		t.Fatalf("payload[score] = %#v (%T), want a float64", payload["score"], payload["score"])
+	}
+	if !math.IsNaN(score) {
+		t.Errorf("payload[score] = %v, want NaN", score)
 	}
 }
 

--- a/internal/policy/service_example_coverage_test.go
+++ b/internal/policy/service_example_coverage_test.go
@@ -155,16 +155,6 @@ type oidcIdentity struct {
 	// trusted and untrusted differ only in the claim the gate examines.
 	trusted   *policyv1.JWTClaims
 	untrusted *policyv1.JWTClaims
-	// admitOnly restricts the admit direction to these entrypoints. A provider
-	// lists one when another rule in the file denies it for an unrelated
-	// reason, which is a finding about that rule rather than about coverage.
-	admitOnly []Entrypoint
-	// why explains a non-empty admitOnly.
-	why string
-	// blocked names the defect that stops this provider being evaluated at all,
-	// in either direction. Set it rather than dropping the provider, so the
-	// coverage arrives on its own when the defect is fixed.
-	blocked string
 }
 
 // oidcIdentities enumerates the providers the federation example gates on.
@@ -215,13 +205,12 @@ func oidcIdentities() []oidcIdentity {
 				Iss:          "https://accounts.google.com",
 				CustomClaims: map[string]string{"email": "attacker@untrusted-project.iam.gserviceaccount.com"},
 			},
-			// A Google service account subject is a 21-digit account id, and
-			// the payload conversion turns any numeric-looking string into a
-			// number, so kubernetes-namespace-restriction calls .startsWith on
-			// a float64 and the whole evaluation errors. The interceptor turns
-			// that into CodeInternal, so this identity cannot be allowed or
-			// denied, only failed.
-			blocked: "#248: numeric-looking strings are coerced to numbers, so jwt.sub is a float64 for this provider",
+			// A Google service account subject is a 21-digit account id, which
+			// the payload conversion used to rewrite into a float64, so
+			// kubernetes-namespace-restriction called .startsWith on a number
+			// and the whole evaluation errored. The payload now keeps a
+			// declared string as a string, so this identity is decidable in
+			// both directions at every entrypoint.
 		},
 		{
 			provider: "aws-sts",
@@ -308,12 +297,6 @@ func TestShippedOIDCFederationGatesEveryServiceEntrypoint(t *testing.T) {
 	}
 
 	for _, id := range oidcIdentities() {
-		if id.blocked != "" {
-			t.Run(id.provider, func(t *testing.T) {
-				t.Skipf("cannot evaluate this provider: %s", id.blocked)
-			})
-			continue
-		}
 		for _, ep := range EntrypointsService {
 			if _, ok := serviceRequestInput[ep]; !ok {
 				continue
@@ -323,17 +306,11 @@ func TestShippedOIDCFederationGatesEveryServiceEntrypoint(t *testing.T) {
 					t.Errorf("untrusted %s identity was not denied at %s: the gate for this provider does not reach this entrypoint", id.provider, ep)
 				}
 			})
-			if len(id.admitOnly) > 0 && !slices.Contains(id.admitOnly, ep) {
-				continue
-			}
 			t.Run(id.provider+"/"+string(ep)+"/admits-trusted", func(t *testing.T) {
 				if got, by := denied(t, ep, id.trusted); got {
 					t.Errorf("trusted %s identity was denied at %s by %s: a gate that refuses the callers it names is not an allowlist", id.provider, ep, by)
 				}
 			})
-		}
-		if id.why != "" {
-			t.Logf("%s: admit direction not asserted at service_secrets_request, because %s", id.provider, id.why)
 		}
 	}
 }


### PR DESCRIPTION
`convertNumericValue` rewrote any string in a policy payload that parsed as a number, so a deny policy naming an exact version silently stopped denying as soon as the version had two components, while the same policy worked for `1.21.6`. The same guess made `.startsWith` on a 21-digit JWT subject return `no such overload`, which the server reports as `CodeInternal`, so one defect either denied nothing or refused everything depending on which CEL operator the author reached for.

```
numpy 1.21     payload version=1.21     (float64)  deny on "1.21"    -> NOT DENIED, err=nil
numpy 1.21.6   payload version=1.21.6   (string )  deny on "1.21.6"  -> denied
numpy 4.17     payload version=4.17     (float64)  deny on "4.17"    -> NOT DENIED, err=nil
```

It was lossy before any consumer saw the value, so no downstream repair was possible: `"1.20"` became `1.2` and `"2.0"` became `2`.

## What changed

`ProtoToMap` walks the message descriptor alongside the document protojson produced and converts each value by the field's declared type. protojson quotes only the 64-bit integer kinds (`int64`, `uint64`, `sint64`, `sfixed64`, `fixed64`), so those are the only strings parsed back to numbers, and everything a descriptor calls a string stays a string. `Struct`, `Value`, `ListValue` and `Any` carry JSON that no field kind describes, so those subtrees convert `json.Number` and leave strings alone; `Timestamp`, `Duration`, `FieldMask` and the string wrappers need no case of their own because they render as JSON strings the walk already leaves untouched. No Deputy proto uses any of those five today, so that handling is defensive and tested directly against `structpb`/`anypb`.

Walking beside protojson's own output, rather than rebuilding the map from `protoreflect.Range`, keeps field naming, well-known type rendering and `EmitUnpopulated` exactly as they are, so the numeric coercion is the only behavior that moves.

Behavioral evidence beyond the unit tests: a standalone npm proxy whose policy denies `pkg.version == "4.17"` answers `403 lodash 4.17 is denied by policy` for `/lodash/-/lodash-4.17.tgz`. The same request against the same policy on `main` was proxied upstream and returned `404`.

## Behavior changes a reviewer might disagree with

A numeric custom JWT claim such as `repository_owner_id: "12345"` now arrives as the string `custom_claims` declares (`map<string, string>`) rather than as a number. That matches the schema and the generated reference, and typed claims are #243's problem; the list splitting that makes `jwt.roles` iterable is unaffected and covered.

Floats get the same treatment, which is a change of its own in two directions. protojson writes a whole-numbered double with no decimal point, so a CVSS score of `9.0` used to arrive as an `int64` while `9.8` arrived as a double, and `score / 2` was integer division for exactly the scores that are whole; it is now always a `float64`. protojson also writes `NaN`, `Infinity` and `-Infinity` as strings, and the old guess parsed exactly one of the three, so a score comparison errored for two values and evaluated for the third; all three are now numbers. Comparisons against an integer literal still work: `severity.score >= 7` denies for a score of `9.0`.

`policy/examples/service-oidc-federation.yaml` becomes decidable for a GCP service account identity, which `kubernetes-namespace-restriction` previously failed on for every caller. The coverage test carried that provider with a `blocked` note so the coverage would arrive with the fix; the note and the skip are gone, and with machine identities now recognized before MFA is required, the `admitOnly`/`why` pair that excused one entrypoint goes too, so the identity is asserted in both directions at all six. Two shipped expressions that were quietly broken by the same guess also start working: `nodeVersion(node)` returned `""` for a numeric-looking version, and `dockerfile-no-privileged-ports` errored with `no such overload: split(int, string)` on a bare numeric port.

## Limits

A `uint64` above the `int64` range still becomes a `float64`. Parsing it as an unsigned integer would keep the digits, but only for values above that range, which puts the Go type back at the mercy of the data; making every unsigned 64-bit field a CEL `uint` would be uniform but would then disagree with `uint32`, which lands as an integer. No shipped field declares either kind, so this is left as it is rather than guessed at.

Extension fields, which protojson writes under `[full.name]` keys, are left exactly as protojson wrote them rather than resolved through the registry. No Deputy payload has one.

Fixes #248.
