### PR TITLE
Decide report color from the output destination, not from stdout

### DIFF
--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -83,6 +83,10 @@ $ deputy list --format json | jq '.packages[] | select(.direct) | .purl'
 
 Use exit codes for CI gating.
 
+## Color
+
+Text output is colored only when it lands on a terminal. The decision is made per destination, so `--output report.txt` writes a plain file even when you run the command from a terminal, and a redirected or piped stdout is plain for the same reason. `NO_COLOR` turns color off everywhere; `CLICOLOR_FORCE` turns it on for a destination that would otherwise be plain.
+
 ## Detailed Documentation
 
 ### Core Workflow

--- a/docs/commands/scan.md
+++ b/docs/commands/scan.md
@@ -89,6 +89,8 @@ can plug into the same scan flow as providers are added.
 | `--detect-base-image` | | `false` | Detect base image layers in container scans (requires network, queries deps.dev) |
 | `--no-verify-fixes` | | `false` | Skip Go module proxy verification of fixed versions (offline; trusts advisory data verbatim) |
 
+`text` output is colored only when it lands on a terminal, so `--output` to a file and a redirected stdout are both plain. See [Color](README.md#color).
+
 ### Date Format
 
 Date flags accept: `YYYY`, `YYYY-MM`, `YYYY-MM-DD`, or RFC3339.

--- a/go.mod
+++ b/go.mod
@@ -199,7 +199,7 @@ require (
 	github.com/muesli/mango-cobra v1.3.0 // indirect
 	github.com/muesli/mango-pflag v0.2.0 // indirect
 	github.com/muesli/roff v0.1.0 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
+	github.com/muesli/termenv v0.16.0
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/olekukonko/cat v0.0.0-20250911104152-50322a0618f6 // indirect
 	github.com/olekukonko/errors v1.3.0 // indirect

--- a/internal/cli/cmd/diff.go
+++ b/internal/cli/cmd/diff.go
@@ -136,15 +136,12 @@ Can be disabled with --skip-vuln-scan for faster execution.`,
 			}
 
 			// Set up output writer
-			var outW io.Writer = cmd.OutOrStdout()
-			if outPath != "" && outPath != "-" {
-				f, err := os.Create(outPath)
-				if err != nil {
-					return fmt.Errorf("failed to create output file: %w", err)
-				}
-				defer f.Close()
-				outW = f
+			out, err := openOutputWriter(cmd, outPath)
+			if err != nil {
+				return err
 			}
+			defer out.Close()
+			outW := out.Writer
 
 			// Render-only mode: re-render a previously saved structured output
 			// without re-running analysis. CI uses this to derive both counts

--- a/internal/cli/cmd/graph.go
+++ b/internal/cli/cmd/graph.go
@@ -196,15 +196,12 @@ OUTPUT FORMATS:
 			}
 
 			// Prepare output writer
-			var w io.Writer = cmd.OutOrStdout()
-			if outPath != "" && outPath != "-" {
-				f, err := os.Create(outPath)
-				if err != nil {
-					return fmt.Errorf("failed to create output file: %w", err)
-				}
-				defer f.Close()
-				w = f
+			out, err := openOutputWriter(cmd, outPath)
+			if err != nil {
+				return err
 			}
+			defer out.Close()
+			w := out.Writer
 
 			// Stats only mode
 			if statsOnly {

--- a/internal/cli/cmd/list.go
+++ b/internal/cli/cmd/list.go
@@ -177,15 +177,12 @@ FILTERING & FORMATTING:
 
 			sortListItems(items)
 
-			var w io.Writer = cmd.OutOrStdout()
-			if outPath != "" && outPath != "-" {
-				f, err := os.Create(outPath)
-				if err != nil {
-					return fmt.Errorf("failed to create output file: %w", err)
-				}
-				defer f.Close()
-				w = f
+			out, err := openOutputWriter(cmd, outPath)
+			if err != nil {
+				return err
 			}
+			defer out.Close()
+			w := out.Writer
 
 			switch strings.ToLower(format) {
 			case "", FormatText:

--- a/internal/cli/cmd/output_writer.go
+++ b/internal/cli/cmd/output_writer.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	ui "github.com/temporalio/deputy/internal/ui"
+)
+
+// outputWriter is a report destination: the writer to render into, whatever
+// needs closing afterwards, and the color decision made for it.
+type outputWriter struct {
+	Writer  io.Writer
+	closer  io.Closer
+	restore func()
+}
+
+// Close restores the color profile that was in effect before the destination
+// was opened and closes the underlying writer if it's a file.
+func (ow *outputWriter) Close() error {
+	if ow.restore != nil {
+		ow.restore()
+		ow.restore = nil
+	}
+	if ow.closer != nil {
+		return ow.closer.Close()
+	}
+	return nil
+}
+
+// openOutputWriter opens the destination named by outPath: stdout when it is
+// empty or "-", otherwise a newly created file. Every command that can write a
+// rendered report to --output goes through here, because this is also where the
+// color profile is decided from the destination rather than from the process's
+// stdout. Without that, a report written to a file while stdout is a terminal
+// gets ANSI escapes it cannot use.
+//
+// The caller must Close the returned outputWriter, which is what ends the
+// color decision as well as closing the file.
+func openOutputWriter(cmd *cobra.Command, outPath string) (*outputWriter, error) {
+	if outPath == "" || outPath == "-" {
+		w := cmd.OutOrStdout()
+		return &outputWriter{Writer: w, restore: ui.UseColorProfileFor(w)}, nil
+	}
+
+	f, err := os.Create(outPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create output file: %w", err)
+	}
+	return &outputWriter{Writer: f, closer: f, restore: ui.UseColorProfileFor(f)}, nil
+}

--- a/internal/cli/cmd/output_writer_test.go
+++ b/internal/cli/cmd/output_writer_test.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+	"github.com/spf13/cobra"
+
+	ui "github.com/temporalio/deputy/internal/ui"
+)
+
+// asColorTerminal puts the process in the state a pty produces: lipgloss has
+// resolved a color profile from stdout and every package level style renders
+// with it. Tests that use it cannot be parallel, because that profile is
+// process wide. It restores the previous profile on cleanup.
+func asColorTerminal(t *testing.T) {
+	t.Helper()
+
+	original := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(original) })
+
+	if !strings.Contains(ui.StyleHeader.Render("Scan Results:"), "\x1b") {
+		t.Fatal("precondition failed: styles are not colored, an escape leak could not be detected")
+	}
+}
+
+// TestOpenOutputWriter_FileDestinationIsNotColored is the regression test for
+// #285: with a terminal on stdout, a report written to --output must not carry
+// ANSI escapes into the file.
+func TestOpenOutputWriter_FileDestinationIsNotColored(t *testing.T) {
+	asColorTerminal(t)
+
+	outPath := filepath.Join(t.TempDir(), "vulnerabilities.txt")
+	cmd := &cobra.Command{Use: "test"}
+
+	out, err := openOutputWriter(cmd, outPath)
+	if err != nil {
+		t.Fatalf("openOutputWriter() error = %v", err)
+	}
+
+	if _, err := out.Writer.Write([]byte(ui.StyleHeader.Render("Scan Results:") + "\n")); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	content, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if bytes.Contains(content, []byte{0x1b}) {
+		t.Errorf("output file contains ANSI escapes: %q", content)
+	}
+	if got, want := string(content), "Scan Results:\n"; got != want {
+		t.Errorf("output file = %q, want %q", got, want)
+	}
+}
+
+// TestOpenOutputWriter_RestoresColorForTheTerminal checks the other half of the
+// contract: the file destination must not leave the process unable to color a
+// later terminal write.
+func TestOpenOutputWriter_RestoresColorForTheTerminal(t *testing.T) {
+	asColorTerminal(t)
+
+	cmd := &cobra.Command{Use: "test"}
+	out, err := openOutputWriter(cmd, filepath.Join(t.TempDir(), "report.txt"))
+	if err != nil {
+		t.Fatalf("openOutputWriter() error = %v", err)
+	}
+	if err := out.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	if got := ui.StyleHeader.Render("Scan Results:"); !strings.Contains(got, "\x1b") {
+		t.Errorf("color was not restored after the file destination closed: %q", got)
+	}
+}
+
+// TestOpenOutputWriter_StdoutDestinationFollowsTheStream covers the "-" and
+// empty cases, where the destination is whatever the command writes to. A
+// buffer is not a terminal, so it must be plain too.
+func TestOpenOutputWriter_StdoutDestinationFollowsTheStream(t *testing.T) {
+	asColorTerminal(t)
+
+	for _, outPath := range []string{"", "-"} {
+		t.Run("outPath="+outPath, func(t *testing.T) {
+			var buf bytes.Buffer
+			cmd := &cobra.Command{Use: "test"}
+			cmd.SetOut(&buf)
+
+			out, err := openOutputWriter(cmd, outPath)
+			if err != nil {
+				t.Fatalf("openOutputWriter() error = %v", err)
+			}
+			if _, err := out.Writer.Write([]byte(ui.StyleHeader.Render("Scan Results:"))); err != nil {
+				t.Fatalf("Write() error = %v", err)
+			}
+			if err := out.Close(); err != nil {
+				t.Fatalf("Close() error = %v", err)
+			}
+
+			if got := buf.String(); strings.Contains(got, "\x1b") {
+				t.Errorf("non-terminal stdout contains ANSI escapes: %q", got)
+			}
+		})
+	}
+}

--- a/internal/cli/cmd/pin.go
+++ b/internal/cli/cmd/pin.go
@@ -459,16 +459,13 @@ func resolveDir(args []string) (string, error) {
 
 // outputPinReport writes the report in the requested format. dryRun adjusts the
 // human-readable wording so a preview never claims files were modified.
-func outputPinReport(_ *cobra.Command, report *pin.Report, format, outPath string, dryRun bool) error {
-	var w io.Writer = os.Stdout
-	if outPath != "" && outPath != "-" {
-		f, err := os.Create(outPath)
-		if err != nil {
-			return fmt.Errorf("creating output file: %w", err)
-		}
-		defer f.Close()
-		w = f
+func outputPinReport(cmd *cobra.Command, report *pin.Report, format, outPath string, dryRun bool) error {
+	out, err := openOutputWriter(cmd, outPath)
+	if err != nil {
+		return err
 	}
+	defer out.Close()
+	w := out.Writer
 
 	switch format {
 	case "json":

--- a/internal/cli/cmd/policy.go
+++ b/internal/cli/cmd/policy.go
@@ -232,15 +232,12 @@ DETAIL LEVELS:
 			}
 
 			// Output
-			out := cmd.OutOrStdout()
-			if output != "" && output != "-" {
-				f, err := os.Create(output)
-				if err != nil {
-					return fmt.Errorf("create output file: %w", err)
-				}
-				defer f.Close()
-				out = f
+			dest, err := openOutputWriter(cmd, output)
+			if err != nil {
+				return err
 			}
+			defer dest.Close()
+			out := dest.Writer
 
 			// Write header comment if to stdout
 			if output == "" || output == "-" {

--- a/internal/cli/cmd/sbom.go
+++ b/internal/cli/cmd/sbom.go
@@ -185,15 +185,12 @@ The --enrich flag adds comprehensive metadata from deps.dev:
 
 			doc := result.Document
 
-			var w io.Writer = cmd.OutOrStdout()
-			if outPath != "" && outPath != "-" {
-				f, err := os.Create(outPath)
-				if err != nil {
-					return fmt.Errorf("failed to create output file: %w", err)
-				}
-				defer f.Close()
-				w = f
+			out, err := openOutputWriter(cmd, outPath)
+			if err != nil {
+				return err
 			}
+			defer out.Close()
+			w := out.Writer
 
 			fmtFmt, err := flags.NormalizeSBOMOutputFormat(format)
 			if err != nil {

--- a/internal/cli/cmd/sbom_enrich.go
+++ b/internal/cli/cmd/sbom_enrich.go
@@ -111,15 +111,12 @@ USAGE:
 			}
 
 			// Write output
-			var w io.Writer = cmd.OutOrStdout()
-			if outPath != "" && outPath != "-" {
-				f, err := os.Create(outPath)
-				if err != nil {
-					return fmt.Errorf("failed to create output file: %w", err)
-				}
-				defer f.Close()
-				w = f
+			out, err := openOutputWriter(cmd, outPath)
+			if err != nil {
+				return err
 			}
+			defer out.Close()
+			w := out.Writer
 
 			// Write in requested format
 			switch strings.ToLower(format) {

--- a/internal/cli/cmd/scan.go
+++ b/internal/cli/cmd/scan.go
@@ -86,7 +86,9 @@ RubyGems, containers, operating system packages, GitHub Actions workflows/action
 Use --ecosystems to limit scanning to specific sets when you don't need the full inventory.
 
 OUTPUT FORMATS:
-• text: Human-readable colored output with severity indicators and fix suggestions
+• text: Human-readable output with severity indicators and fix suggestions. Color is
+  decided from the destination: a terminal gets it, --output to a file or a redirected
+  stdout does not, and NO_COLOR turns it off everywhere.
 • json: Machine-readable structured output for integration with CI/CD and other tools
 
 The scan command automatically detects your module's dependencies and queries for

--- a/internal/cli/cmd/scan_flags.go
+++ b/internal/cli/cmd/scan_flags.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"time"
 
@@ -226,35 +225,6 @@ func unionStrings(lists ...[]string) []string {
 		}
 	}
 	return out
-}
-
-// outputWriter represents a writer that may need to be closed.
-type outputWriter struct {
-	Writer io.Writer
-	closer io.Closer
-}
-
-// Close closes the underlying writer if it's a file.
-func (ow *outputWriter) Close() error {
-	if ow.closer != nil {
-		return ow.closer.Close()
-	}
-	return nil
-}
-
-// openOutputWriter creates an output writer based on the output path.
-// If outPath is empty or "-", it returns stdout. Otherwise, it creates a file.
-// The caller must call Close() on the returned outputWriter.
-func openOutputWriter(cmd *cobra.Command, outPath string) (*outputWriter, error) {
-	if outPath == "" || outPath == "-" {
-		return &outputWriter{Writer: cmd.OutOrStdout()}, nil
-	}
-
-	f, err := os.Create(outPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create output file: %w", err)
-	}
-	return &outputWriter{Writer: f, closer: f}, nil
 }
 
 // loadIgnoreRules loads ignore rules from the specified file or auto-discovers them.

--- a/internal/ui/color.go
+++ b/internal/ui/color.go
@@ -1,0 +1,49 @@
+package ui
+
+import (
+	"io"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+)
+
+// ColorProfileFor reports the color profile a destination can actually render,
+// so styling is decided from the writer the output is going to instead of from
+// the process's stdout. The styles in this package are package level, so they
+// bind to lipgloss's default renderer, which probes os.Stdout once at init;
+// without asking per destination, a report redirected to a file inherits the
+// answer for the terminal and carries SGR escapes into the file.
+//
+// The answer is termenv.Ascii (no escapes at all, not even bold) for any
+// destination that is not a terminal, which covers files, pipes, and in-memory
+// buffers. Terminal destinations get the profile the environment advertises.
+// NO_COLOR, CLICOLOR, CLICOLOR_FORCE, and CI are honored because termenv
+// honors them.
+func ColorProfileFor(w io.Writer) termenv.Profile {
+	return colorProfileFor(w)
+}
+
+// colorProfileFor carries the termenv options seam that lets tests describe a
+// destination (terminal or not, environment) instead of depending on the
+// terminal the test process happens to have.
+func colorProfileFor(w io.Writer, opts ...termenv.OutputOption) termenv.Profile {
+	if w == nil {
+		return termenv.Ascii
+	}
+	return termenv.NewOutput(w, opts...).EnvColorProfile()
+}
+
+// UseColorProfileFor points the styles in this package at what w can render and
+// returns a function that restores the previous profile. Callers own the
+// window: apply it when the destination opens, restore when it closes.
+//
+// The profile is process wide because the styles are, so while it is applied
+// every writer renders with w's capabilities, including a progress spinner on
+// stderr. That is why the restore exists: it keeps the window no longer than
+// the destination's lifetime. Building styles per writer would remove the
+// window entirely and is the larger follow-up.
+func UseColorProfileFor(w io.Writer) (restore func()) {
+	previous := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(ColorProfileFor(w))
+	return func() { lipgloss.SetColorProfile(previous) }
+}

--- a/internal/ui/color_test.go
+++ b/internal/ui/color_test.go
@@ -1,0 +1,182 @@
+package ui
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
+)
+
+// testEnviron is a fixed environment so profile decisions can be asserted
+// without depending on the terminal or CI variables the test process inherits.
+type testEnviron map[string]string
+
+// Environ returns the environment in the KEY=VALUE form termenv expects.
+func (e testEnviron) Environ() []string {
+	out := make([]string, 0, len(e))
+	for k, v := range e {
+		out = append(out, k+"="+v)
+	}
+	return out
+}
+
+// Getenv returns the value for key, or the empty string when unset.
+func (e testEnviron) Getenv(key string) string {
+	return e[key]
+}
+
+// trueColorTerminalEnv is the environment of a color-capable terminal, used to
+// prove that a non-terminal destination stays plain even when the process is
+// attached to one.
+func trueColorTerminalEnv() testEnviron {
+	return testEnviron{"TERM": "xterm-256color", "COLORTERM": "truecolor"}
+}
+
+func TestColorProfileFor(t *testing.T) {
+	t.Parallel()
+
+	tmpFile, err := os.Create(filepath.Join(t.TempDir(), "report.txt"))
+	if err != nil {
+		t.Fatalf("os.Create() error = %v", err)
+	}
+	t.Cleanup(func() { _ = tmpFile.Close() })
+
+	tests := []struct {
+		name   string
+		writer io.Writer
+		tty    bool
+		env    testEnviron
+		want   termenv.Profile
+	}{
+		{
+			// The defect in #285: a file destination inherited the terminal's
+			// answer and got SGR escapes written into it.
+			name:   "file destination is plain even on a color terminal",
+			writer: tmpFile,
+			env:    trueColorTerminalEnv(),
+			want:   termenv.Ascii,
+		},
+		{
+			name:   "buffer destination is plain",
+			writer: &bytes.Buffer{},
+			env:    trueColorTerminalEnv(),
+			want:   termenv.Ascii,
+		},
+		{
+			name:   "nil destination is plain",
+			writer: nil,
+			env:    trueColorTerminalEnv(),
+			want:   termenv.Ascii,
+		},
+		{
+			name:   "terminal destination gets true color",
+			writer: &bytes.Buffer{},
+			tty:    true,
+			env:    trueColorTerminalEnv(),
+			want:   termenv.TrueColor,
+		},
+		{
+			name:   "terminal destination gets 256 colors without COLORTERM",
+			writer: &bytes.Buffer{},
+			tty:    true,
+			env:    testEnviron{"TERM": "xterm-256color"},
+			want:   termenv.ANSI256,
+		},
+		{
+			name:   "terminal destination honors NO_COLOR",
+			writer: &bytes.Buffer{},
+			tty:    true,
+			env:    testEnviron{"TERM": "xterm-256color", "COLORTERM": "truecolor", "NO_COLOR": "1"},
+			want:   termenv.Ascii,
+		},
+		{
+			name:   "terminal destination honors CLICOLOR=0",
+			writer: &bytes.Buffer{},
+			tty:    true,
+			env:    testEnviron{"TERM": "xterm-256color", "COLORTERM": "truecolor", "CLICOLOR": "0"},
+			want:   termenv.Ascii,
+		},
+		{
+			name:   "dumb terminal is plain",
+			writer: &bytes.Buffer{},
+			tty:    true,
+			env:    testEnviron{"TERM": "dumb"},
+			want:   termenv.Ascii,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			opts := []termenv.OutputOption{termenv.WithEnvironment(tt.env)}
+			if tt.tty {
+				opts = append(opts, termenv.WithTTY(true))
+			}
+
+			if got := colorProfileFor(tt.writer, opts...); got != tt.want {
+				t.Errorf("colorProfileFor() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestColorProfileFor_ExportedUsesProcessEnvironment covers the exported entry
+// point, which reads the real environment: whatever the terminal advertises, a
+// file destination must still be plain.
+func TestColorProfileFor_ExportedUsesProcessEnvironment(t *testing.T) {
+	t.Parallel()
+
+	f, err := os.Create(filepath.Join(t.TempDir(), "report.txt"))
+	if err != nil {
+		t.Fatalf("os.Create() error = %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+
+	if got := ColorProfileFor(f); got != termenv.Ascii {
+		t.Errorf("ColorProfileFor(file) = %v, want %v", got, termenv.Ascii)
+	}
+}
+
+// TestUseColorProfileFor cannot run in parallel: the styles are package level,
+// so the profile they render with is process wide.
+func TestUseColorProfileFor(t *testing.T) {
+	// Stand in for the reproduction condition: under a pty, lipgloss resolves a
+	// color profile from os.Stdout at init and every style binds to it.
+	original := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(original) })
+
+	if !strings.Contains(StyleHeader.Render("Scan Results:"), "\x1b") {
+		t.Fatal("precondition failed: styles are not colored, cannot detect a leak")
+	}
+
+	f, err := os.Create(filepath.Join(t.TempDir(), "report.txt"))
+	if err != nil {
+		t.Fatalf("os.Create() error = %v", err)
+	}
+	defer f.Close()
+
+	restore := UseColorProfileFor(f)
+
+	if got := StyleHeader.Render("Scan Results:"); strings.Contains(got, "\x1b") {
+		t.Errorf("styles still emit escapes for a file destination: %q", got)
+	}
+	if got := lipgloss.ColorProfile(); got != termenv.Ascii {
+		t.Errorf("lipgloss.ColorProfile() = %v, want %v", got, termenv.Ascii)
+	}
+
+	restore()
+
+	if got := lipgloss.ColorProfile(); got != termenv.TrueColor {
+		t.Errorf("after restore lipgloss.ColorProfile() = %v, want %v", got, termenv.TrueColor)
+	}
+	if got := StyleHeader.Render("Scan Results:"); !strings.Contains(got, "\x1b") {
+		t.Errorf("restore did not bring color back for the terminal: %q", got)
+	}
+}


### PR DESCRIPTION
Fixes #285.

`deputy scan --output vulnerabilities.txt --format text` wrote ANSI escapes into the file. The styles in `internal/ui` are package level, so they bind to lipgloss's default renderer, which probes `os.Stdout` once at init. The color profile therefore answered "is my terminal a terminal" and `--output` inherited that answer for a file.

## Reviewer notes, in order

**1. This was never scan-specific, which is why the fix is not either.** Eight commands take `--output` and every one of them inherited the same process-wide decision. Measured under a pty, before and after:

| command | before | after |
| --- | --- | --- |
| `scan . --format text -o f` | 1166 escape bytes | 0 |
| `list . --format text -o f` | 10 | 0 |
| `pin check . -o f` | 24 | 0 |
| `diff main <branch> -o f` | present | 0 |

Fixing only `scan` would have left the identical defect in seven siblings, so the change routes every `--output` destination through one opener and decides the profile from the destination. Seven copies of the same eight-line open-and-close block collapsed into `openOutputWriter`.

**2. The tests could not have caught this and still cannot, unless written a specific way.** With stdout redirected, lipgloss disables color globally, so the file comes out clean on broken code and a naive test passes. The tests that actually discriminate first force `lipgloss.SetColorProfile(termenv.TrueColor)` to stand in for a terminal. Non-vacuity was proven twice, by removing the wiring and separately by restoring the old process-wide decision, and one table case still passed under the second mutation for exactly the reason the bug shipped. That case is documented rather than deleted.

**3. Process-wide profile state, and why it is safe here.** The profile is mutated for the lifetime of an open destination and restored on close. `internal/ui` is reachable from `internal/server` transitively via `internal/cache`, so the styles do exist in the server binary, but the only mutation site is `openOutputWriter`, which is reachable only from CLI command paths, never from a goroutine, and never from the server command. Nothing renders concurrently to two destinations.

The measured cost: for `diff`, the destination opens before analysis, so the progress spinner runs monochrome for that invocation. File bytes are correct everywhere. That is the reason `restore` exists rather than a one-way switch, and it is the argument for per-writer style sets later if it starts to matter.

**4. Description and docs.** The `text` format description promised color unconditionally; it now says color depends on the destination. No sibling command made the same claim. Since this is now a cross-command rule, it is documented once in `docs/commands/README.md`.

## Not included, deliberately

No `--color=auto|always|never` flag. Overrides today are environment-only (`NO_COLOR`, `CLICOLOR_FORCE`, both honored and verified), and a flag name is a permanent decision worth making separately.

#252 is untouched: the log handler still sets color unconditionally with no TTY or `NO_COLOR` check. `ui.ColorProfileFor` is the piece it should reuse, and a fix that covered only logs would have left this one, which is why they are separate.

`termenv` moves from indirect to direct in `go.mod`. It was already in the graph via lipgloss, so this adds no dependency.
