### PR TITLE
Make an unloadable config file fatal instead of silent

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -41,6 +41,8 @@ Having no config file is normal: Deputy runs on built-in defaults without commen
 
 Dropping them is not a safe fallback. `advisory_sources` is the one with real security weight: a deployment that pinned its vulnerability data to an internal mirror would silently query the public defaults instead. The `otel` block goes the same way, so a deployment that believes it is exporting traces exports nothing. The `egress` block is a list of relaxations (hosts and CIDRs permitted to resolve to private addresses), so losing it does not loosen anything, it makes allowlisted internal hosts unreachable and breaks the deployment in a way that is hard to trace back to the config file.
 
+Precedence still applies to this check: a value is only invalid if nothing higher in the order replaces it, so `--log-level=debug` corrects an invalid `DEPUTY_LOG_LEVEL` rather than being rejected by it.
+
 The command exits non-zero and names the file:
 
 ```console

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -35,6 +35,19 @@ Deputy searches these locations (in order):
 
 Override with `DEPUTY_CONFIG=/path/to/config.yaml`.
 
+## Invalid Configuration
+
+Having no config file is normal: Deputy runs on built-in defaults without comment. A config file that *is* found but cannot be read, parsed, or validated is a different situation, and Deputy refuses to run rather than falling back to defaults, because settings such as `egress` allowlists and `advisory_sources` would otherwise be silently dropped. The command exits non-zero and names the file:
+
+```console
+$ deputy list
+Failed to load config from .deputy.yaml: validation failed for logging.level: must be one of: debug, info, warn, error.
+
+Suggestion: Fix the file, or run 'deputy config validate .deputy.yaml' for details
+```
+
+The `deputy config` commands (`validate`, `show`, `path`) keep working in this state so you can diagnose the file.
+
 ## Starter Config
 
 See [`.deputy.yaml.example`](../../.deputy.yaml.example) for an annotated template. Copy to `.deputy.yaml` and customize.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -41,7 +41,7 @@ Having no config file is normal: Deputy runs on built-in defaults without commen
 
 Dropping them is not a safe fallback. `advisory_sources` is the one with real security weight: a deployment that pinned its vulnerability data to an internal mirror would silently query the public defaults instead. The `otel` block goes the same way, so a deployment that believes it is exporting traces exports nothing. The `egress` block is a list of relaxations (hosts and CIDRs permitted to resolve to private addresses), so losing it does not loosen anything, it makes allowlisted internal hosts unreachable and breaks the deployment in a way that is hard to trace back to the config file.
 
-Precedence still applies to this check: a value is only invalid if nothing higher in the order replaces it, so `--log-level=debug` corrects an invalid `DEPUTY_LOG_LEVEL` rather than being rejected by it.
+Precedence still applies to this check: a value is only invalid if nothing higher in the order replaces it, so `--log-level=debug` corrects an invalid `DEPUTY_LOG_LEVEL` rather than being rejected by it. The rule covers a command's own flags too, because the check runs after the command line is parsed: `deputy server --egress-allow-cidr 10.0.0.0/8` starts on a config file whose `server.egress.allowed_cidrs` the flag replaces.
 
 The command exits non-zero, and the diagnostic points at the source that can actually be at fault. A file that cannot be read or parsed is the file's problem:
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -43,13 +43,22 @@ Dropping them is not a safe fallback. `advisory_sources` is the one with real se
 
 Precedence still applies to this check: a value is only invalid if nothing higher in the order replaces it, so `--log-level=debug` corrects an invalid `DEPUTY_LOG_LEVEL` rather than being rejected by it.
 
-The command exits non-zero and names the file:
+The command exits non-zero, and the diagnostic points at the source that can actually be at fault. A file that cannot be read or parsed is the file's problem:
 
 ```console
 $ deputy list
-Failed to load config from .deputy.yaml: validation failed for logging.level: must be one of: debug, info, warn, error.
+Failed to load config: config error in .deputy.yaml: failed to parse config file.
 
 Suggestion: Fix the file, or run 'deputy config validate .deputy.yaml' for details
+```
+
+A value that fails validation is attributed more carefully, because validation runs on the merged result of file, environment, and flags:
+
+```console
+$ DEPUTY_LOG_LEVEL=shouty deputy list
+Invalid configuration: validation failed for logging.level: must be one of: debug, info, warn, error.
+
+Suggestion: The value can come from .deputy.yaml or from a DEPUTY_* environment variable, which overrides the file; check both
 ```
 
 Commands that do not act on configuration keep working in this state: `deputy config` (`validate`, `show`, `path`) so you can diagnose the file, plus `deputy version`, `deputy help`, `deputy completion`, and shell tab completion. Everything else refuses to run until the file is fixed.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -37,7 +37,11 @@ Override with `DEPUTY_CONFIG=/path/to/config.yaml`.
 
 ## Invalid Configuration
 
-Having no config file is normal: Deputy runs on built-in defaults without comment. A config file that *is* found but cannot be read, parsed, or validated is a different situation, and Deputy refuses to run rather than falling back to defaults, because settings such as `egress` allowlists and `advisory_sources` would otherwise be silently dropped. The command exits non-zero and names the file:
+Having no config file is normal: Deputy runs on built-in defaults without comment. A config file that *is* found but cannot be read, parsed, or validated is a different situation, and Deputy refuses to run rather than falling back to defaults, because every setting the file carries would otherwise be silently dropped.
+
+Dropping them is not a safe fallback. `advisory_sources` is the one with real security weight: a deployment that pinned its vulnerability data to an internal mirror would silently query the public defaults instead. The `otel` block goes the same way, so a deployment that believes it is exporting traces exports nothing. The `egress` block is a list of relaxations (hosts and CIDRs permitted to resolve to private addresses), so losing it does not loosen anything, it makes allowlisted internal hosts unreachable and breaks the deployment in a way that is hard to trace back to the config file.
+
+The command exits non-zero and names the file:
 
 ```console
 $ deputy list
@@ -46,7 +50,7 @@ Failed to load config from .deputy.yaml: validation failed for logging.level: mu
 Suggestion: Fix the file, or run 'deputy config validate .deputy.yaml' for details
 ```
 
-The `deputy config` commands (`validate`, `show`, `path`) keep working in this state so you can diagnose the file.
+Commands that do not act on configuration keep working in this state: `deputy config` (`validate`, `show`, `path`) so you can diagnose the file, plus `deputy version`, `deputy help`, `deputy completion`, and shell tab completion. Everything else refuses to run until the file is fixed.
 
 ## Starter Config
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -370,12 +370,24 @@ CONNECTION MODES:
 		// which the user asked for. A short allowlist of commands that do not
 		// act on configuration stays runnable, so the failure can be diagnosed
 		// and reported.
-		if configErr != nil && !runsWithoutConfig(c) {
+		exempt := runsWithoutConfig(c)
+		if configErr != nil && !exempt {
 			return configErr
 		}
 
 		if err := configureLogging(logLevel, logFormat); err != nil {
-			return err
+			if !exempt {
+				return err
+			}
+			// Exempt means exempt for the whole startup, not just for the
+			// check above. An invalid DEPUTY_LOG_LEVEL is a configuration
+			// fault like any other, and taking 'deputy version' or shell
+			// completion down with it defeats the point of the allowlist, so
+			// these commands fall back to the built-in logging defaults.
+			slog.Debug("ignoring invalid logging configuration for a command that runs without configuration", "error", err)
+			if err := configureLogging(fallbackLogLevel, fallbackLogFormat); err != nil {
+				return err
+			}
 		}
 
 		// Apply --no-cache flag to context if set
@@ -473,6 +485,15 @@ func isInGitRepo() bool {
 	return err == nil
 }
 
+const (
+	// fallbackLogLevel and fallbackLogFormat are the built-in logging settings.
+	// Warn keeps interactive output clean; they are also what a command that
+	// runs without configuration falls back to when the requested values do
+	// not parse.
+	fallbackLogLevel  = "warn"
+	fallbackLogFormat = "text"
+)
+
 // defaultLogLevel returns the default log level from the environment or "warn".
 // Default is warn to keep CLI output clean for interactive use. Users who want
 // verbose observability logs can set DEPUTY_LOG_LEVEL=info or --log-level=info.
@@ -480,7 +501,7 @@ func defaultLogLevel() string {
 	if v := strings.TrimSpace(os.Getenv("DEPUTY_LOG_LEVEL")); v != "" {
 		return v
 	}
-	return "warn"
+	return fallbackLogLevel
 }
 
 // defaultLogFormat returns the default log format from the environment or "text".
@@ -488,7 +509,7 @@ func defaultLogFormat() string {
 	if v := strings.TrimSpace(os.Getenv("DEPUTY_LOG_FORMAT")); v != "" {
 		return v
 	}
-	return "text"
+	return fallbackLogFormat
 }
 
 // configureLogging sets up the global slog logger based on the provided level and format.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -31,11 +31,14 @@ import (
 func Run(ctx context.Context) error {
 	// Load configuration for runtime defaults (OTel, egress allowlists). A
 	// config file that exists but cannot be loaded is fatal, not ignorable:
-	// every control it configures would otherwise revert to its default with
-	// nothing said. The failure is carried into the root command instead of
-	// being returned here, because main only maps a Run error to an exit code;
-	// reporting it from PersistentPreRunE routes it through fang so the user
-	// sees the same diagnostic 'deputy config show' prints.
+	// every setting it carries would otherwise revert to its default with
+	// nothing said, and a configured advisory mirror quietly becoming the
+	// public default sources is a security problem, not a degraded mode.
+	//
+	// The failure is carried into the root command instead of being returned
+	// here, because main only maps a Run error to an exit code; reporting it
+	// from PersistentPreRunE routes it through fang so the user sees the same
+	// diagnostic 'deputy config show' prints.
 	cfg, cfgErr := loadRuntimeConfig()
 
 	// Apply local egress allowlists before services are initialized.
@@ -67,10 +70,12 @@ func Run(ctx context.Context) error {
 // loadRuntimeConfig loads configuration from the environment and the
 // auto-discovered config file. A non-nil error means a configuration source was
 // present but unusable (unreadable or malformed file, or a value that fails
-// validation), which callers must treat as fatal: continuing would silently run
-// with default egress allowlists, advisory sources, and OTel settings instead of
-// the configured ones. Finding no config file at all is not an error, it yields
-// the defaults with a nil error.
+// validation), which callers must treat as fatal: continuing would silently
+// substitute defaults for whatever the file configured. That means querying the
+// public advisory sources in place of a pinned internal mirror, exporting no
+// telemetry, and dropping the egress relaxations that let allowlisted internal
+// hosts resolve to private addresses. Finding no config file at all is not an
+// error, it yields the defaults with a nil error.
 func loadRuntimeConfig() (*config.Config, error) {
 	configPath := config.FindConfigFile()
 	cfg, err := config.NewLoader(configPath).Load()
@@ -181,8 +186,9 @@ func silentErrorHandler(w io.Writer, styles fang.Styles, err error) {
 
 // newRoot returns the root command with all subcommands attached. configErr
 // carries a configuration failure detected before command construction; when it
-// is non-nil every command except the config diagnostics refuses to run, so a
-// config file that cannot be honored never masquerades as an absent one.
+// is non-nil every command outside commandsRunnableWithoutConfig refuses to
+// run, so a config file that cannot be honored never masquerades as an absent
+// one.
 func newRoot(configErr error) *cobra.Command {
 	logLevel := defaultLogLevel()
 	logFormat := defaultLogFormat()
@@ -299,12 +305,13 @@ CONNECTION MODES:
 
 	rootCmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
 		// Refuse to run on a configuration that could not be loaded. This is
-		// checked first: a command that proceeds here would enforce default
-		// egress allowlists, query default advisory sources, and export no
-		// telemetry, none of which the user asked for. The config subtree is
-		// exempt because those commands exist to diagnose exactly this failure
-		// and report it themselves.
-		if configErr != nil && !inConfigCommandTree(c) {
+		// checked first: a command that proceeds here would query the default
+		// advisory sources instead of the configured ones, export no
+		// telemetry, and lose the egress relaxations the file granted, none of
+		// which the user asked for. A short allowlist of commands that do not
+		// act on configuration stays runnable, so the failure can be diagnosed
+		// and reported.
+		if configErr != nil && !runsWithoutConfig(c) {
 			return configErr
 		}
 
@@ -345,23 +352,59 @@ CONNECTION MODES:
 	return rootCmd
 }
 
-// inConfigCommandTree reports whether cmd is 'deputy config' or one of its
-// subcommands. Those commands read and report on configuration rather than
-// acting on it, so they stay available when the discovered config file is the
-// thing that is broken: refusing to run them would take away the tools that
-// explain the failure.
-// The exemption is deliberately narrow: only the top-level "config" command
-// qualifies, so a future subcommand that happens to be named "config" under some
-// other command (say 'deputy proxy config') cannot inherit it and quietly become
-// runnable on a config file that failed to load.
-func inConfigCommandTree(cmd *cobra.Command) bool {
+// commandsRunnableWithoutConfig is the allowlist of top-level commands that
+// still run when the discovered config file cannot be loaded. Membership is
+// earned by not acting on configuration at all:
+//
+//   - config, because its subcommands exist to diagnose exactly this failure,
+//     and refusing to run them would take away the tools that explain it.
+//   - version, because it is the first thing a user runs when filing a bug
+//     report, and because 'deputy --version' answers with the version whether
+//     or not a config file loads; the subcommand must not disagree with it.
+//   - completion and cobra's hidden completion helpers, because their output is
+//     sourced at shell startup and requested on every tab press, so gating them
+//     would inject errors into an interactive shell rather than into a command
+//     the user chose to run.
+//   - help, because the help command (unlike the --help flag, which cobra
+//     resolves before this check) is dispatched like any other command.
+var commandsRunnableWithoutConfig = map[string]bool{
+	"config":                        true,
+	"version":                       true,
+	"completion":                    true,
+	"help":                          true,
+	cobra.ShellCompRequestCmd:       true,
+	cobra.ShellCompNoDescRequestCmd: true,
+}
+
+// runsWithoutConfig reports whether cmd belongs to a top-level command that is
+// allowed to run when configuration could not be loaded. The allowlist is keyed
+// on the top-level command rather than on cmd's own name, so a future
+// subcommand that happens to share an exempt name (say 'deputy proxy config')
+// cannot inherit the exemption and quietly become runnable on a config file
+// that failed to load.
+func runsWithoutConfig(cmd *cobra.Command) bool {
+	top := topLevelCommand(cmd)
+	if top == nil {
+		// The root command itself, which runs diff when invoked bare, so it
+		// acts on configuration and is not exempt.
+		return false
+	}
+	return commandsRunnableWithoutConfig[top.Name()]
+}
+
+// topLevelCommand returns the ancestor of cmd that is a direct child of the
+// root command, or nil when cmd is the root itself.
+func topLevelCommand(cmd *cobra.Command) *cobra.Command {
 	for c := cmd; c != nil; c = c.Parent() {
 		parent := c.Parent()
-		if c.Name() == "config" && parent != nil && !parent.HasParent() {
-			return true
+		if parent == nil {
+			return nil
+		}
+		if !parent.HasParent() {
+			return c
 		}
 	}
-	return false
+	return nil
 }
 
 // isInGitRepo checks if the current working directory is inside a git repository.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -88,7 +88,7 @@ func loadRuntimeConfig() (*config.Config, error) {
 			"Point DEPUTY_CONFIG at a readable config file, or unset it to use auto-discovery",
 		)
 	}
-	cfg, err := config.NewLoader(configPath).Load()
+	cfg, err := config.NewLoader(configPath).LoadWithOverrides(loggingFlagOverrides(os.Args[1:]))
 	if err != nil {
 		if configPath != "" {
 			// Name the file: an offending config can be in the home directory,
@@ -107,6 +107,42 @@ func loadRuntimeConfig() (*config.Config, error) {
 		)
 	}
 	return cfg, nil
+}
+
+// loggingFlagOverrides scrapes the logging flags out of the raw arguments,
+// before cobra has parsed anything. Configuration has to be loaded this early
+// (egress allowlists and advisory sources must be applied before any client is
+// built), but flags outrank the environment, so validating the merged config
+// without them would reject a value the user already corrected on the command
+// line, contradicting the documented precedence.
+//
+// Only explicitly set flags are returned. Unknown flags are tolerated rather
+// than treated as errors, since the real parse happens later and reports them;
+// arguments after "--" are left alone, so a passthrough command such as
+// 'deputy proxy npm -- npm install --log-level=silly' cannot be mistaken for a
+// Deputy flag. A flag this pre-parse fails to spot simply leaves the
+// environment value standing, which fails closed.
+func loggingFlagOverrides(args []string) map[string]string {
+	fs := pflag.NewFlagSet("logging-precedence", pflag.ContinueOnError)
+	fs.ParseErrorsWhitelist.UnknownFlags = true
+	fs.SetOutput(io.Discard)
+	fs.Usage = func() {}
+
+	var level, format string
+	fs.StringVar(&level, "log-level", "", "")
+	fs.StringVar(&format, "log-format", "", "")
+	// A parse failure here is not actionable: cobra parses these arguments
+	// again, properly, and reports anything wrong with them.
+	_ = fs.Parse(args)
+
+	overrides := make(map[string]string, 2)
+	if fs.Changed("log-level") {
+		overrides["log-level"] = level
+	}
+	if fs.Changed("log-format") {
+		overrides["log-format"] = format
+	}
+	return overrides
 }
 
 // applyAdvisorySourceConfig hands the config file's advisory_sources entries to

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -77,7 +77,17 @@ func Run(ctx context.Context) error {
 // hosts resolve to private addresses. Finding no config file at all is not an
 // error, it yields the defaults with a nil error.
 func loadRuntimeConfig() (*config.Config, error) {
-	configPath := config.FindConfigFile()
+	configPath, err := config.ResolveConfigFile()
+	if err != nil {
+		// An explicitly requested file that is not there is the same downgrade
+		// this function exists to prevent: without this, discovery would fall
+		// back to some other file, or to none, and the command would run on
+		// settings the operator did not ask for.
+		return nil, deputyerrors.Suggest(
+			fmt.Errorf("failed to load config: %w", err),
+			"Point DEPUTY_CONFIG at a readable config file, or unset it to use auto-discovery",
+		)
+	}
 	cfg, err := config.NewLoader(configPath).Load()
 	if err != nil {
 		if configPath != "" {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -64,7 +64,7 @@ func Run(ctx context.Context) error {
 		}
 	}()
 
-	return fang.Execute(ctx, newRoot(cfgErr), fang.WithErrorHandler(silentErrorHandler), fang.WithVersion(version.Value))
+	return fang.Execute(ctx, newRoot(cfg, cfgErr), fang.WithErrorHandler(silentErrorHandler), fang.WithVersion(version.Value))
 }
 
 // loadRuntimeConfig loads configuration from the environment and the
@@ -243,12 +243,14 @@ func silentErrorHandler(w io.Writer, styles fang.Styles, err error) {
 	}
 }
 
-// newRoot returns the root command with all subcommands attached. configErr
-// carries a configuration failure detected before command construction; when it
+// newRoot returns the root command with all subcommands attached. cfg is the
+// configuration merged before command construction, handed to the commands that
+// need it so none of them loads its own and reaches a different answer.
+// configErr carries a configuration failure detected during that load; when it
 // is non-nil every command outside commandsRunnableWithoutConfig refuses to
 // run, so a config file that cannot be honored never masquerades as an absent
 // one.
-func newRoot(configErr error) *cobra.Command {
+func newRoot(cfg *config.Config, configErr error) *cobra.Command {
 	logLevel := defaultLogLevel()
 	logFormat := defaultLogFormat()
 	var serverAddr string
@@ -359,7 +361,7 @@ CONNECTION MODES:
 	// Commands are registered before cobra parses the persistent flags, so the
 	// connection settings resolve from the environment here and are re-resolved
 	// in PersistentPreRunE once the flag values are known.
-	deps := &cmd.Dependencies{}
+	deps := &cmd.Dependencies{Config: cfg}
 	cmd.RegisterCommands(rootCmd, deps)
 
 	rootCmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -38,19 +38,30 @@ func Run(ctx context.Context) error {
 	// The failure is carried into the root command instead of being returned
 	// here, because main only maps a Run error to an exit code; reporting it
 	// from PersistentPreRunE routes it through fang so the user sees the same
-	// diagnostic 'deputy config show' prints.
-	cfg, cfgErr := loadRuntimeConfig()
+	// diagnostic 'deputy config show' prints. The merged settings travel with
+	// it, so the commands that need configuration read this one rather than
+	// loading their own and reaching a different answer.
+	rc := loadRuntimeConfig()
 
 	// Apply local egress allowlists before services are initialized.
-	applyLocalEgressConfig(cfg)
+	//
+	// These three consumers run on the merged settings, before validation,
+	// which cannot happen until the command line is parsed. So a config file
+	// with one bad field now wires up whatever else it carries, where before it
+	// would have wired up nothing: the egress relaxations get installed and an
+	// OTel exporter gets built, and only then is the command refused. That is
+	// deliberate. Each consumer already rejects what it cannot use on its own
+	// (egress skips an unparseable CIDR, OTel falls back to its defaults), the
+	// refusal follows immediately, and no command body runs in between.
+	applyLocalEgressConfig(rc.Config)
 
 	// Declare configured advisory sources; they are materialized lazily when a
 	// scan builds its source registry, so non-scanning commands pay nothing.
-	applyAdvisorySourceConfig(cfg)
+	applyAdvisorySourceConfig(rc.Config)
 
 	otelCfg := otel.DefaultConfig()
-	if cfg != nil {
-		otelCfg = cfg.OTel
+	if rc.Config != nil {
+		otelCfg = rc.Config.OTel
 	}
 
 	// Initialize OpenTelemetry (graceful no-op if disabled)
@@ -64,35 +75,106 @@ func Run(ctx context.Context) error {
 		}
 	}()
 
-	return fang.Execute(ctx, newRoot(cfg, cfgErr), fang.WithErrorHandler(silentErrorHandler), fang.WithVersion(version.Value))
+	return fang.Execute(ctx, newRoot(rc), fang.WithErrorHandler(silentErrorHandler), fang.WithVersion(version.Value))
 }
 
-// loadRuntimeConfig loads configuration from the environment and the
-// auto-discovered config file. A non-nil error means a configuration source was
-// present but unusable (unreadable or malformed file, or a value that fails
-// validation), which callers must treat as fatal: continuing would silently
+// runtimeConfig is what the CLI knows about configuration before cobra has
+// parsed anything: the file and environment settings merged together, the file
+// they came from, and any failure to get that far.
+//
+// Validation is deliberately not part of it. The merged value is not the
+// effective one until the command line is parsed, because flags outrank both
+// sources, so the gate in newRoot validates instead, once, with the flags
+// applied.
+type runtimeConfig struct {
+	// Config is the merged file and environment settings. It is nil only when
+	// Err is non-nil.
+	Config *config.Config
+
+	// Path is the config file the settings were read from, empty when no file
+	// was found. It is what the diagnostic names.
+	Path string
+
+	// Err reports a configuration source that was named but could not be read
+	// or parsed. No flag corrects that, so it is fatal on its own.
+	Err error
+}
+
+// loadRuntimeConfig merges configuration from the environment and the
+// auto-discovered config file. A non-nil Err means a configuration source was
+// present but unusable (missing when named explicitly, or unreadable or
+// malformed), which callers must treat as fatal: continuing would silently
 // substitute defaults for whatever the file configured. That means querying the
 // public advisory sources in place of a pinned internal mirror, exporting no
 // telemetry, and dropping the egress relaxations that let allowlisted internal
 // hosts resolve to private addresses. Finding no config file at all is not an
-// error, it yields the defaults with a nil error.
-func loadRuntimeConfig() (*config.Config, error) {
+// error, it yields the defaults with a nil Err.
+func loadRuntimeConfig() runtimeConfig {
 	configPath, err := config.ResolveConfigFile()
 	if err != nil {
 		// An explicitly requested file that is not there is the same downgrade
 		// this function exists to prevent: without this, discovery would fall
 		// back to some other file, or to none, and the command would run on
 		// settings the operator did not ask for.
-		return nil, deputyerrors.Suggest(
+		return runtimeConfig{Err: deputyerrors.Suggest(
 			fmt.Errorf("failed to load config: %w", err),
 			"Point DEPUTY_CONFIG at a readable config file, or unset it to use auto-discovery",
-		)
+		)}
 	}
-	cfg, err := config.NewLoader(configPath).LoadWithOverrides(loggingFlagOverrides(os.Args[1:]))
+	cfg, err := config.NewLoader(configPath).LoadMerged()
 	if err != nil {
-		return nil, configLoadError(configPath, err)
+		return runtimeConfig{Path: configPath, Err: configLoadError(configPath, err)}
 	}
-	return cfg, nil
+	return runtimeConfig{Config: cfg, Path: configPath}
+}
+
+// configGateError reports the configuration failure that must stop cmd, or nil
+// when the invocation is usable. It runs from PersistentPreRunE rather than
+// from the load, because that is the first moment the effective configuration
+// exists: cobra has parsed the command line by then, so a flag the user set can
+// correct a value the environment or the file got wrong, which is the
+// precedence the reference documents. Validating earlier rejected values the
+// invocation had already replaced, and it did so for every override-capable
+// flag, one finding at a time.
+//
+// The overrides land on the shared configuration rather than on a copy, so the
+// commands handed that configuration see the corrected values too.
+func configGateError(rc runtimeConfig, cmd *cobra.Command) error {
+	if rc.Err != nil {
+		return rc.Err
+	}
+	if rc.Config == nil {
+		return nil
+	}
+	config.ApplyOverrides(rc.Config, flagOverrides(cmd))
+	if err := rc.Config.Validate(); err != nil {
+		return configLoadError(rc.Path, err)
+	}
+	return nil
+}
+
+// flagOverrides collects the flags the invocation set explicitly, keyed by flag
+// name, for config.ApplyOverrides to pick from. It reports every changed flag
+// rather than a chosen few: which flags configuration cares about is the
+// config package's business, and a list kept here would have to be extended
+// for each new override-capable flag, which is how command-specific flags came
+// to be missing from the validated merge in the first place.
+//
+// cmd is the command cobra resolved, so its flag set already carries the
+// persistent flags inherited from the root alongside its own. Arguments after
+// "--" are not flags to pflag, so a passthrough such as
+// 'deputy proxy npm -- npm install --log-level=silly' cannot contribute one.
+func flagOverrides(cmd *cobra.Command) config.Overrides {
+	flags := cmd.Flags()
+	overrides := make(config.Overrides, flags.NFlag())
+	flags.Visit(func(f *pflag.Flag) {
+		if slice, ok := f.Value.(pflag.SliceValue); ok {
+			overrides[f.Name] = slice.GetSlice()
+			return
+		}
+		overrides[f.Name] = []string{f.Value.String()}
+	})
+	return overrides
 }
 
 // configLoadError turns a load failure into a diagnostic that points at a
@@ -120,42 +202,6 @@ func configLoadError(configPath string, err error) error {
 		fmt.Errorf("invalid configuration: %w", err),
 		fmt.Sprintf("The value can come from %s or from a DEPUTY_* environment variable, which overrides the file; check both", configPath),
 	)
-}
-
-// loggingFlagOverrides scrapes the logging flags out of the raw arguments,
-// before cobra has parsed anything. Configuration has to be loaded this early
-// (egress allowlists and advisory sources must be applied before any client is
-// built), but flags outrank the environment, so validating the merged config
-// without them would reject a value the user already corrected on the command
-// line, contradicting the documented precedence.
-//
-// Only explicitly set flags are returned. Unknown flags are tolerated rather
-// than treated as errors, since the real parse happens later and reports them;
-// arguments after "--" are left alone, so a passthrough command such as
-// 'deputy proxy npm -- npm install --log-level=silly' cannot be mistaken for a
-// Deputy flag. A flag this pre-parse fails to spot simply leaves the
-// environment value standing, which fails closed.
-func loggingFlagOverrides(args []string) map[string]string {
-	fs := pflag.NewFlagSet("logging-precedence", pflag.ContinueOnError)
-	fs.ParseErrorsWhitelist.UnknownFlags = true
-	fs.SetOutput(io.Discard)
-	fs.Usage = func() {}
-
-	var level, format string
-	fs.StringVar(&level, "log-level", "", "")
-	fs.StringVar(&format, "log-format", "", "")
-	// A parse failure here is not actionable: cobra parses these arguments
-	// again, properly, and reports anything wrong with them.
-	_ = fs.Parse(args)
-
-	overrides := make(map[string]string, 2)
-	if fs.Changed("log-level") {
-		overrides["log-level"] = level
-	}
-	if fs.Changed("log-format") {
-		overrides["log-format"] = format
-	}
-	return overrides
 }
 
 // applyAdvisorySourceConfig hands the config file's advisory_sources entries to
@@ -243,14 +289,14 @@ func silentErrorHandler(w io.Writer, styles fang.Styles, err error) {
 	}
 }
 
-// newRoot returns the root command with all subcommands attached. cfg is the
-// configuration merged before command construction, handed to the commands that
-// need it so none of them loads its own and reaches a different answer.
-// configErr carries a configuration failure detected during that load; when it
-// is non-nil every command outside commandsRunnableWithoutConfig refuses to
-// run, so a config file that cannot be honored never masquerades as an absent
-// one.
-func newRoot(cfg *config.Config, configErr error) *cobra.Command {
+// newRoot returns the root command with all subcommands attached. rc carries
+// the configuration merged before command construction, handed to the commands
+// that need it so none of them loads its own and reaches a different answer.
+// Whatever cannot be honored in it, either because the file would not load or
+// because the merged result fails validation once the flags are in, stops every
+// command outside commandsRunnableWithoutConfig, so a config file that cannot
+// be honored never masquerades as an absent one.
+func newRoot(rc runtimeConfig) *cobra.Command {
 	logLevel := defaultLogLevel()
 	logFormat := defaultLogFormat()
 	var serverAddr string
@@ -361,11 +407,11 @@ CONNECTION MODES:
 	// Commands are registered before cobra parses the persistent flags, so the
 	// connection settings resolve from the environment here and are re-resolved
 	// in PersistentPreRunE once the flag values are known.
-	deps := &cmd.Dependencies{Config: cfg}
+	deps := &cmd.Dependencies{Config: rc.Config}
 	cmd.RegisterCommands(rootCmd, deps)
 
 	rootCmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
-		// Refuse to run on a configuration that could not be loaded. This is
+		// Refuse to run on a configuration that cannot be honored. This is
 		// checked first: a command that proceeds here would query the default
 		// advisory sources instead of the configured ones, export no
 		// telemetry, and lose the egress relaxations the file granted, none of
@@ -373,7 +419,7 @@ CONNECTION MODES:
 		// act on configuration stays runnable, so the failure can be diagnosed
 		// and reported.
 		exempt := runsWithoutConfig(c)
-		if configErr != nil && !exempt {
+		if configErr := configGateError(rc, c); configErr != nil && !exempt {
 			return configErr
 		}
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -83,7 +83,13 @@ func loadRuntimeConfig() (*config.Config, error) {
 				fmt.Sprintf("Fix the file, or run 'deputy config validate %s' for details", configPath),
 			)
 		}
-		return nil, fmt.Errorf("failed to load config: %w", err)
+		// No file was found, so the offending value came from the environment.
+		// 'deputy config validate' cannot help here (it reads files), so point
+		// at the variables instead.
+		return nil, deputyerrors.Suggest(
+			fmt.Errorf("failed to load config: %w", err),
+			"Check the DEPUTY_* environment variables for an invalid value",
+		)
 	}
 	return cfg, nil
 }
@@ -344,10 +350,14 @@ CONNECTION MODES:
 // acting on it, so they stay available when the discovered config file is the
 // thing that is broken: refusing to run them would take away the tools that
 // explain the failure.
+// The exemption is deliberately narrow: only the top-level "config" command
+// qualifies, so a future subcommand that happens to be named "config" under some
+// other command (say 'deputy proxy config') cannot inherit it and quietly become
+// runnable on a config file that failed to load.
 func inConfigCommandTree(cmd *cobra.Command) bool {
 	for c := cmd; c != nil; c = c.Parent() {
-		// The root command is "deputy", so this cannot match the whole CLI.
-		if c.Name() == "config" && c.Parent() != nil {
+		parent := c.Parent()
+		if c.Name() == "config" && parent != nil && !parent.HasParent() {
 			return true
 		}
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -90,23 +90,36 @@ func loadRuntimeConfig() (*config.Config, error) {
 	}
 	cfg, err := config.NewLoader(configPath).LoadWithOverrides(loggingFlagOverrides(os.Args[1:]))
 	if err != nil {
-		if configPath != "" {
-			// Name the file: an offending config can be in the home directory,
-			// far from the directory the command was run in.
-			return nil, deputyerrors.Suggest(
-				fmt.Errorf("failed to load config from %s: %w", configPath, err),
-				fmt.Sprintf("Fix the file, or run 'deputy config validate %s' for details", configPath),
-			)
-		}
-		// No file was found, so the offending value came from the environment.
-		// 'deputy config validate' cannot help here (it reads files), so point
-		// at the variables instead.
-		return nil, deputyerrors.Suggest(
-			fmt.Errorf("failed to load config: %w", err),
-			"Check the DEPUTY_* environment variables for an invalid value",
-		)
+		return nil, configLoadError(configPath, err)
 	}
 	return cfg, nil
+}
+
+// configLoadError turns a load failure into a diagnostic that points at a
+// source which can actually be at fault. Read and parse failures are the file's
+// by construction, since the loader only raises them with a file in hand.
+// Validation is different: it runs on the merged result of file, environment,
+// and flags, so blaming the file for it sends the operator to
+// 'deputy config validate', which passes, and teaches them nothing. Where the
+// provenance is genuinely unknown, the message says so rather than guessing.
+func configLoadError(configPath string, err error) error {
+	if _, ok := errors.AsType[*deputyerrors.ConfigError](err); ok {
+		// ConfigError already names the path it failed to read or parse.
+		return deputyerrors.Suggest(
+			fmt.Errorf("failed to load config: %w", err),
+			fmt.Sprintf("Fix the file, or run 'deputy config validate %s' for details", configPath),
+		)
+	}
+	if configPath == "" {
+		return deputyerrors.Suggest(
+			fmt.Errorf("invalid configuration: %w", err),
+			"No config file was loaded, so check the DEPUTY_* environment variables for an invalid value",
+		)
+	}
+	return deputyerrors.Suggest(
+		fmt.Errorf("invalid configuration: %w", err),
+		fmt.Sprintf("The value can come from %s or from a DEPUTY_* environment variable, which overrides the file; check both", configPath),
+	)
 }
 
 // loggingFlagOverrides scrapes the logging flags out of the raw arguments,

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -29,8 +29,14 @@ import (
 // Run constructs the root command hierarchy and executes it with all
 // subcommands registered. It is the primary entry point used by main.
 func Run(ctx context.Context) error {
-	// Load configuration for runtime defaults (OTel, egress allowlists).
-	cfg := loadRuntimeConfig()
+	// Load configuration for runtime defaults (OTel, egress allowlists). A
+	// config file that exists but cannot be loaded is fatal, not ignorable:
+	// every control it configures would otherwise revert to its default with
+	// nothing said. The failure is carried into the root command instead of
+	// being returned here, because main only maps a Run error to an exit code;
+	// reporting it from PersistentPreRunE routes it through fang so the user
+	// sees the same diagnostic 'deputy config show' prints.
+	cfg, cfgErr := loadRuntimeConfig()
 
 	// Apply local egress allowlists before services are initialized.
 	applyLocalEgressConfig(cfg)
@@ -55,18 +61,31 @@ func Run(ctx context.Context) error {
 		}
 	}()
 
-	return fang.Execute(ctx, newRoot(), fang.WithErrorHandler(silentErrorHandler), fang.WithVersion(version.Value))
+	return fang.Execute(ctx, newRoot(cfgErr), fang.WithErrorHandler(silentErrorHandler), fang.WithVersion(version.Value))
 }
 
-// loadRuntimeConfig loads configuration from environment and config file.
-func loadRuntimeConfig() *config.Config {
+// loadRuntimeConfig loads configuration from the environment and the
+// auto-discovered config file. A non-nil error means a configuration source was
+// present but unusable (unreadable or malformed file, or a value that fails
+// validation), which callers must treat as fatal: continuing would silently run
+// with default egress allowlists, advisory sources, and OTel settings instead of
+// the configured ones. Finding no config file at all is not an error, it yields
+// the defaults with a nil error.
+func loadRuntimeConfig() (*config.Config, error) {
 	configPath := config.FindConfigFile()
-	loader := config.NewLoader(configPath)
-	cfg, err := loader.Load()
+	cfg, err := config.NewLoader(configPath).Load()
 	if err != nil {
-		return nil
+		if configPath != "" {
+			// Name the file: an offending config can be in the home directory,
+			// far from the directory the command was run in.
+			return nil, deputyerrors.Suggest(
+				fmt.Errorf("failed to load config from %s: %w", configPath, err),
+				fmt.Sprintf("Fix the file, or run 'deputy config validate %s' for details", configPath),
+			)
+		}
+		return nil, fmt.Errorf("failed to load config: %w", err)
 	}
-	return cfg
+	return cfg, nil
 }
 
 // applyAdvisorySourceConfig hands the config file's advisory_sources entries to
@@ -154,8 +173,11 @@ func silentErrorHandler(w io.Writer, styles fang.Styles, err error) {
 	}
 }
 
-// newRoot returns the root command with all subcommands attached.
-func newRoot() *cobra.Command {
+// newRoot returns the root command with all subcommands attached. configErr
+// carries a configuration failure detected before command construction; when it
+// is non-nil every command except the config diagnostics refuses to run, so a
+// config file that cannot be honored never masquerades as an absent one.
+func newRoot(configErr error) *cobra.Command {
 	logLevel := defaultLogLevel()
 	logFormat := defaultLogFormat()
 	var serverAddr string
@@ -270,6 +292,16 @@ CONNECTION MODES:
 	cmd.RegisterCommands(rootCmd, deps)
 
 	rootCmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
+		// Refuse to run on a configuration that could not be loaded. This is
+		// checked first: a command that proceeds here would enforce default
+		// egress allowlists, query default advisory sources, and export no
+		// telemetry, none of which the user asked for. The config subtree is
+		// exempt because those commands exist to diagnose exactly this failure
+		// and report it themselves.
+		if configErr != nil && !inConfigCommandTree(c) {
+			return configErr
+		}
+
 		if err := configureLogging(logLevel, logFormat); err != nil {
 			return err
 		}
@@ -305,6 +337,21 @@ CONNECTION MODES:
 	}
 
 	return rootCmd
+}
+
+// inConfigCommandTree reports whether cmd is 'deputy config' or one of its
+// subcommands. Those commands read and report on configuration rather than
+// acting on it, so they stay available when the discovered config file is the
+// thing that is broken: refusing to run them would take away the tools that
+// explain the failure.
+func inConfigCommandTree(cmd *cobra.Command) bool {
+	for c := cmd; c != nil; c = c.Parent() {
+		// The root command is "deputy", so this cannot match the whole CLI.
+		if c.Name() == "config" && c.Parent() != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // isInGitRepo checks if the current working directory is inside a git repository.

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -44,7 +44,7 @@ func TestParseLogLevel(t *testing.T) {
 // internal/cli/cmd/register.go fails this test instead of silently shrinking
 // the CLI surface.
 func TestNewRoot(t *testing.T) {
-	cmd := newRoot(nil)
+	cmd := newRoot(nil, nil)
 	if cmd.Use != "deputy" {
 		t.Errorf("expected Use to be 'deputy', got %q", cmd.Use)
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -44,7 +44,7 @@ func TestParseLogLevel(t *testing.T) {
 // internal/cli/cmd/register.go fails this test instead of silently shrinking
 // the CLI surface.
 func TestNewRoot(t *testing.T) {
-	cmd := newRoot(nil, nil)
+	cmd := newRoot(runtimeConfig{})
 	if cmd.Use != "deputy" {
 		t.Errorf("expected Use to be 'deputy', got %q", cmd.Use)
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -44,7 +44,7 @@ func TestParseLogLevel(t *testing.T) {
 // internal/cli/cmd/register.go fails this test instead of silently shrinking
 // the CLI surface.
 func TestNewRoot(t *testing.T) {
-	cmd := newRoot()
+	cmd := newRoot(nil)
 	if cmd.Use != "deputy" {
 		t.Errorf("expected Use to be 'deputy', got %q", cmd.Use)
 	}

--- a/internal/cli/cmd/register.go
+++ b/internal/cli/cmd/register.go
@@ -9,6 +9,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/spf13/cobra"
+	"github.com/temporalio/deputy/internal/config"
 	"github.com/temporalio/deputy/internal/services"
 
 	// Import AI providers to register them via init()
@@ -34,6 +35,14 @@ type Dependencies struct {
 	// AuthToken is the bearer token for authenticating with remote servers.
 	// Falls back to the DEPUTY_AUTH_TOKEN environment variable when empty.
 	AuthToken string
+
+	// Config is the configuration the CLI already merged from file,
+	// environment, and flags. Commands that need configuration read it here
+	// rather than loading their own: a second load answers the same question
+	// differently, because it cannot see the flag overrides the first one was
+	// given. Nil means no configuration was supplied, and commands fall back
+	// to their built-in defaults.
+	Config *config.Config
 }
 
 // ResolveConnection fills empty connection settings from the environment
@@ -143,7 +152,7 @@ func RegisterCommands(root *cobra.Command, deps *Dependencies) {
 	AddMCPCommand(root)
 
 	// Server command
-	AddServerCommand(root)
+	AddServerCommand(root, deps)
 }
 
 // authInterceptor returns a Connect interceptor that adds Bearer authentication.

--- a/internal/cli/cmd/scan_flags.go
+++ b/internal/cli/cmd/scan_flags.go
@@ -194,9 +194,12 @@ func excludePathsFromCmd(cmd *cobra.Command) []string {
 }
 
 // discoverConfigExcludePaths returns scan.exclude_paths from an auto-discovered
-// .deputy.yaml (relative to the current working directory, then home). It is
-// best-effort: a missing or unparseable config yields no patterns rather than a
-// hard error, so a malformed config never blocks a scan.
+// .deputy.yaml (relative to the current working directory, then home). A missing
+// config yields no patterns. An unparseable one also yields none, which is safe
+// only because the CLI refuses to run any command whose config file failed to
+// load (see internal/cli.loadRuntimeConfig): by the time a scan reaches here the
+// config is known to be loadable, so this returns nothing only when the setting
+// is genuinely absent.
 func discoverConfigExcludePaths() []string {
 	path := config.FindConfigFile()
 	if path == "" {

--- a/internal/cli/cmd/server.go
+++ b/internal/cli/cmd/server.go
@@ -245,15 +245,22 @@ func parseTLSClientAuth(auth string) tls.ClientAuthType {
 
 // loadServerConfig builds a server.Config with proper precedence:
 // CLI flags > environment variables > config file > defaults.
-func loadServerConfig(flags *serverFlags, cmd *cobra.Command) server.Config {
+// A config file that cannot be loaded is an error rather than a fall back to
+// defaults: silently ignoring it would start the server on a different address,
+// without the configured TLS settings, and with different egress allowlists
+// than the operator asked for. The CLI already refuses to run any command in
+// this state (see internal/cli.loadRuntimeConfig), so this is a second line of
+// defense for callers that construct the command directly.
+func loadServerConfig(flags *serverFlags, cmd *cobra.Command) (server.Config, error) {
 	// Load config file + env vars (config.Loader handles file + env precedence)
 	configPath := config.FindConfigFile()
 	loader := config.NewLoader(configPath)
 	fileCfg, err := loader.Load()
 	if err != nil {
-		// Log but continue with defaults - config file is optional
-		logs.Debug(context.Background(), "config file load failed, using defaults", "error", err)
-		fileCfg = &config.Config{}
+		if configPath != "" {
+			return server.Config{}, fmt.Errorf("failed to load config from %s: %w", configPath, err)
+		}
+		return server.Config{}, fmt.Errorf("failed to load config: %w", err)
 	}
 
 	// Start with defaults, then apply config file values
@@ -535,12 +542,15 @@ func loadServerConfig(flags *serverFlags, cmd *cobra.Command) server.Config {
 		}
 	}
 
-	return cfg
+	return cfg, nil
 }
 
 func runServer(ctx context.Context, flags *serverFlags, cmd *cobra.Command) error {
 	// Load configuration with proper precedence: flags > env > config file > defaults
-	cfg := loadServerConfig(flags, cmd)
+	cfg, err := loadServerConfig(flags, cmd)
+	if err != nil {
+		return err
+	}
 
 	srv, err := server.New(cfg)
 	if err != nil {

--- a/internal/cli/cmd/server.go
+++ b/internal/cli/cmd/server.go
@@ -72,7 +72,16 @@ type serverFlags struct {
 }
 
 // AddServerCommand adds the server command to the root command.
-func AddServerCommand(root *cobra.Command) {
+func AddServerCommand(root *cobra.Command, deps *Dependencies) {
+	cmd, _ := newServerCommand(deps)
+	root.AddCommand(cmd)
+}
+
+// newServerCommand builds the server command and returns it alongside the
+// struct its flags bind to. Callers that need the parsed flag values, which is
+// the precedence tests, get them from the declarations the CLI actually ships
+// rather than from a second copy that can drift.
+func newServerCommand(deps *Dependencies) (*cobra.Command, *serverFlags) {
 	flags := &serverFlags{}
 
 	cmd := &cobra.Command{
@@ -153,7 +162,7 @@ Examples (curl):
     -H "Content-Type: application/json" \
     -d '{"target": "github.com/example/repo"}'`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runServer(cmd.Context(), flags, cmd)
+			return runServer(cmd.Context(), flags, cmd, deps.Config)
 		},
 	}
 
@@ -208,7 +217,7 @@ Examples (curl):
 	cmd.Flags().BoolVar(&flags.egressAllowLoopback, "egress-allow-loopback", false, "Allow loopback targets in remote server mode")
 	cmd.Flags().BoolVar(&flags.egressAllowLinkLocal, "egress-allow-link-local", false, "Allow link-local targets in remote server mode")
 
-	root.AddCommand(cmd)
+	return cmd, flags
 }
 
 // parseTLSVersion converts a version string to a tls.Version constant.
@@ -245,22 +254,16 @@ func parseTLSClientAuth(auth string) tls.ClientAuthType {
 
 // loadServerConfig builds a server.Config with proper precedence:
 // CLI flags > environment variables > config file > defaults.
-// A config file that cannot be loaded is an error rather than a fall back to
-// defaults: silently ignoring it would start the server on a different address,
-// without the configured TLS settings, and with different egress allowlists
-// than the operator asked for. The CLI already refuses to run any command in
-// this state (see internal/cli.loadRuntimeConfig), so this is a second line of
-// defense for callers that construct the command directly.
-func loadServerConfig(flags *serverFlags, cmd *cobra.Command) (server.Config, error) {
-	// Load config file + env vars (config.Loader handles file + env precedence)
-	configPath := config.FindConfigFile()
-	loader := config.NewLoader(configPath)
-	fileCfg, err := loader.Load()
-	if err != nil {
-		if configPath != "" {
-			return server.Config{}, fmt.Errorf("failed to load config from %s: %w", configPath, err)
-		}
-		return server.Config{}, fmt.Errorf("failed to load config: %w", err)
+//
+// fileCfg is the configuration the CLI already merged from file, environment,
+// and root flags. It is passed in rather than loaded again here: a second load
+// cannot see the overrides the first one was given, so it answers the same
+// question differently, which is how a valid --log-level came to be rejected by
+// the server command alone. A nil fileCfg means no configuration was supplied,
+// and the built-in defaults below stand.
+func loadServerConfig(flags *serverFlags, cmd *cobra.Command, fileCfg *config.Config) (server.Config, error) {
+	if fileCfg == nil {
+		fileCfg = &config.Config{}
 	}
 
 	// Start with defaults, then apply config file values
@@ -545,9 +548,10 @@ func loadServerConfig(flags *serverFlags, cmd *cobra.Command) (server.Config, er
 	return cfg, nil
 }
 
-func runServer(ctx context.Context, flags *serverFlags, cmd *cobra.Command) error {
-	// Load configuration with proper precedence: flags > env > config file > defaults
-	cfg, err := loadServerConfig(flags, cmd)
+func runServer(ctx context.Context, flags *serverFlags, cmd *cobra.Command, fileCfg *config.Config) error {
+	// Build the server settings with proper precedence: server flags on top of
+	// the configuration the CLI already merged.
+	cfg, err := loadServerConfig(flags, cmd, fileCfg)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/cmd/server_config_test.go
+++ b/internal/cli/cmd/server_config_test.go
@@ -2,90 +2,144 @@ package cmd
 
 import (
 	"os"
-	"strings"
+	"slices"
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/temporalio/deputy/internal/config"
 )
 
-// TestLoadServerConfig pins that a config file which cannot be loaded stops the
-// server instead of downgrading it to defaults. Silently ignoring the file would
-// bind a different address and drop the configured TLS settings, which is the
-// opposite of what an operator who wrote the file expects.
+// TestLoadServerConfig pins how the server settles its settings: on the
+// configuration the CLI already merged, with its own flags on top.
+//
+// It used to load the config file a second time here. That second load could
+// not see the overrides the first one was given, so it answered the same
+// question differently, and 'deputy server --log-level=debug' was rejected by
+// an invalid DEPUTY_LOG_LEVEL that the flag had already corrected. The
+// "not re-read" cases below are what stops that coming back.
 func TestLoadServerConfig(t *testing.T) {
 	tests := []struct {
-		name       string
-		writeFile  bool
-		contents   string
-		wantErr    bool
-		wantErrHas string
-		wantAddr   string
+		name string
+		// onDiskFile is a .deputy.yaml planted in the working directory. It is
+		// never the source of the answer; it is there to fail the test if
+		// something reads it.
+		onDiskFile string
+		// supplied is the configuration the CLI merged and handed over.
+		supplied *config.Config
+		args     []string
+		wantAddr string
+		// wantCIDRs is checked only when non-nil.
+		wantCIDRs []string
 	}{
 		{
-			name:      "no config file uses defaults",
-			writeFile: false,
+			name:     "no configuration uses the built-in defaults",
+			wantAddr: "127.0.0.1:8090",
+		},
+		{
+			name:     "the supplied address is honored",
+			supplied: &config.Config{Server: config.ServerConfig{Addr: "127.0.0.1:9999"}},
+			wantAddr: "127.0.0.1:9999",
+		},
+		{
+			name:     "a flag outranks the supplied address",
+			supplied: &config.Config{Server: config.ServerConfig{Addr: "127.0.0.1:9999"}},
+			args:     []string{"--addr", "127.0.0.1:7777"},
+			wantAddr: "127.0.0.1:7777",
+		},
+		{
+			name: "the supplied egress allowlist is honored",
+			supplied: &config.Config{Server: config.ServerConfig{
+				Egress: &config.ServerEgressConfig{AllowedCIDRs: []string{"172.16.0.0/12"}},
+			}},
 			wantAddr:  "127.0.0.1:8090",
+			wantCIDRs: []string{"172.16.0.0/12"},
 		},
 		{
-			name:      "config file address is honored",
-			writeFile: true,
-			contents:  "server:\n  addr: \"127.0.0.1:9999\"\n",
-			wantAddr:  "127.0.0.1:9999",
+			name: "an egress flag replaces the supplied allowlist",
+			supplied: &config.Config{Server: config.ServerConfig{
+				Egress: &config.ServerEgressConfig{AllowedCIDRs: []string{"172.16.0.0/12"}},
+			}},
+			args:      []string{"--egress-allow-cidr", "10.0.0.0/8"},
+			wantAddr:  "127.0.0.1:8090",
+			wantCIDRs: []string{"10.0.0.0/8"},
 		},
 		{
-			name:       "unparseable config is an error",
-			writeFile:  true,
-			contents:   "server:\n  addr: \"unclosed\n   bogus: [1, 2\n",
-			wantErr:    true,
-			wantErrHas: "failed to load config from",
+			// A second load would read this file and reject it. The supplied
+			// configuration is the answer, so the file on disk is irrelevant.
+			name:       "a broken file on disk is not re-read",
+			onDiskFile: "logging:\n  level: shouty\n",
+			supplied:   &config.Config{Server: config.ServerConfig{Addr: "127.0.0.1:9999"}},
+			wantAddr:   "127.0.0.1:9999",
 		},
 		{
-			name:       "invalid value is an error",
-			writeFile:  true,
-			contents:   "logging:\n  level: shouty\n",
-			wantErr:    true,
-			wantErrHas: "validation failed for logging.level",
+			// The same for a file that cannot be parsed at all, which is the
+			// louder half of the same mistake.
+			name:       "an unparseable file on disk is not re-read",
+			onDiskFile: "server:\n  addr: \"unclosed\n   bogus: [1, 2\n",
+			supplied:   &config.Config{Server: config.ServerConfig{Addr: "127.0.0.1:9999"}},
+			wantAddr:   "127.0.0.1:9999",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// Isolate discovery: the temp dir is both the working directory
-			// and HOME, and DEPUTY_CONFIG is cleared, so only the fixture can
-			// be found.
+			// and HOME, and DEPUTY_CONFIG is cleared, so only the fixture
+			// could be found by anything that went looking.
 			dir := t.TempDir()
 			t.Setenv("HOME", dir)
 			t.Setenv("DEPUTY_CONFIG", "")
 			t.Setenv("DEPUTY_LOG_LEVEL", "")
 			t.Chdir(dir)
 
-			if test.writeFile {
-				if err := os.WriteFile(".deputy.yaml", []byte(test.contents), 0o644); err != nil {
+			if test.onDiskFile != "" {
+				if err := os.WriteFile(".deputy.yaml", []byte(test.onDiskFile), 0o644); err != nil {
 					t.Fatalf("write .deputy.yaml: %v", err)
 				}
 			}
 
-			// A bare command is enough: loadServerConfig only asks whether
-			// flags were changed, and pflag reports false for flags that were
-			// never registered.
-			cfg, err := loadServerConfig(&serverFlags{}, &cobra.Command{})
-
-			if test.wantErr {
-				if err == nil {
-					t.Fatalf("loadServerConfig() error = nil, want an error; cfg = %+v", cfg)
-				}
-				if !strings.Contains(err.Error(), test.wantErrHas) {
-					t.Errorf("error %q does not contain %q", err.Error(), test.wantErrHas)
-				}
-				return
+			cmd, flags := newServerCommand(&Dependencies{Config: test.supplied})
+			if err := cmd.ParseFlags(test.args); err != nil {
+				t.Fatalf("ParseFlags(%v): %v", test.args, err)
 			}
 
+			cfg, err := loadServerConfig(flags, cmd, test.supplied)
 			if err != nil {
 				t.Fatalf("loadServerConfig() error = %v, want nil", err)
 			}
 			if cfg.Addr != test.wantAddr {
 				t.Errorf("Addr = %q, want %q", cfg.Addr, test.wantAddr)
 			}
+			if test.wantCIDRs != nil {
+				var got []string
+				if cfg.Egress != nil {
+					got = cfg.Egress.AllowedCIDRs
+				}
+				if !slices.Equal(got, test.wantCIDRs) {
+					t.Errorf("Egress.AllowedCIDRs = %v, want %v", got, test.wantCIDRs)
+				}
+			}
 		})
+	}
+}
+
+// TestAddServerCommand pins that the command the CLI registers is the one the
+// precedence tests build, so newServerCommand cannot drift away from the
+// shipped surface without failing here.
+func TestAddServerCommand(t *testing.T) {
+	root := &cobra.Command{Use: "deputy"}
+	AddServerCommand(root, &Dependencies{})
+
+	cmd, _, err := root.Find([]string{"server"})
+	if err != nil {
+		t.Fatalf("Find(server): %v", err)
+	}
+	if cmd.Name() != "server" {
+		t.Fatalf("Find(server) resolved to %q", cmd.Name())
+	}
+	for _, name := range []string{"addr", "egress-allow-cidr", "egress-allow-host"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("registered server command has no --%s flag", name)
+		}
 	}
 }

--- a/internal/cli/cmd/server_config_test.go
+++ b/internal/cli/cmd/server_config_test.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// TestLoadServerConfig pins that a config file which cannot be loaded stops the
+// server instead of downgrading it to defaults. Silently ignoring the file would
+// bind a different address and drop the configured TLS settings, which is the
+// opposite of what an operator who wrote the file expects.
+func TestLoadServerConfig(t *testing.T) {
+	tests := []struct {
+		name       string
+		writeFile  bool
+		contents   string
+		wantErr    bool
+		wantErrHas string
+		wantAddr   string
+	}{
+		{
+			name:      "no config file uses defaults",
+			writeFile: false,
+			wantAddr:  "127.0.0.1:8090",
+		},
+		{
+			name:      "config file address is honored",
+			writeFile: true,
+			contents:  "server:\n  addr: \"127.0.0.1:9999\"\n",
+			wantAddr:  "127.0.0.1:9999",
+		},
+		{
+			name:       "unparseable config is an error",
+			writeFile:  true,
+			contents:   "server:\n  addr: \"unclosed\n   bogus: [1, 2\n",
+			wantErr:    true,
+			wantErrHas: "failed to load config from",
+		},
+		{
+			name:       "invalid value is an error",
+			writeFile:  true,
+			contents:   "logging:\n  level: shouty\n",
+			wantErr:    true,
+			wantErrHas: "validation failed for logging.level",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Isolate discovery: the temp dir is both the working directory
+			// and HOME, and DEPUTY_CONFIG is cleared, so only the fixture can
+			// be found.
+			dir := t.TempDir()
+			t.Setenv("HOME", dir)
+			t.Setenv("DEPUTY_CONFIG", "")
+			t.Setenv("DEPUTY_LOG_LEVEL", "")
+			t.Chdir(dir)
+
+			if test.writeFile {
+				if err := os.WriteFile(".deputy.yaml", []byte(test.contents), 0o644); err != nil {
+					t.Fatalf("write .deputy.yaml: %v", err)
+				}
+			}
+
+			// A bare command is enough: loadServerConfig only asks whether
+			// flags were changed, and pflag reports false for flags that were
+			// never registered.
+			cfg, err := loadServerConfig(&serverFlags{}, &cobra.Command{})
+
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("loadServerConfig() error = nil, want an error; cfg = %+v", cfg)
+				}
+				if !strings.Contains(err.Error(), test.wantErrHas) {
+					t.Errorf("error %q does not contain %q", err.Error(), test.wantErrHas)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("loadServerConfig() error = %v, want nil", err)
+			}
+			if cfg.Addr != test.wantAddr {
+				t.Errorf("Addr = %q, want %q", cfg.Addr, test.wantAddr)
+			}
+		})
+	}
+}

--- a/internal/cli/config_load_test.go
+++ b/internal/cli/config_load_test.go
@@ -171,6 +171,80 @@ func TestLoadRuntimeConfig(t *testing.T) {
 	}
 }
 
+// TestLoadRuntimeConfigExplicitPath covers DEPUTY_CONFIG, which names one
+// specific file. Discovery treats an unusable explicit path as a cue to look
+// elsewhere, which reintroduces the exact downgrade this package guards
+// against: the operator names a file, does not get it, and is told nothing.
+func TestLoadRuntimeConfigExplicitPath(t *testing.T) {
+	const pinnedSource = "https://advisories.example.com"
+	explicit := "advisory_sources:\n  - url: \"" + pinnedSource + "\"\n"
+
+	tests := []struct {
+		name string
+		// explicitExists writes the file DEPUTY_CONFIG points at.
+		explicitExists bool
+		// discoverable writes a different .deputy.yaml in the working
+		// directory, which discovery would otherwise silently substitute.
+		discoverable bool
+		wantErr      bool
+		wantErrHas   string
+	}{
+		{
+			name:           "explicit path that exists is loaded",
+			explicitExists: true,
+		},
+		{
+			name:       "missing explicit path is an error",
+			wantErr:    true,
+			wantErrHas: "DEPUTY_CONFIG is unavailable",
+		},
+		{
+			name:         "missing explicit path is an error even when another config is discoverable",
+			discoverable: true,
+			wantErr:      true,
+			wantErrHas:   "DEPUTY_CONFIG is unavailable",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dir := isolatedConfigDir(t)
+			explicitPath := filepath.Join(dir, "explicit.yaml")
+			if test.explicitExists {
+				if err := os.WriteFile(explicitPath, []byte(explicit), 0o644); err != nil {
+					t.Fatalf("write explicit config: %v", err)
+				}
+			}
+			if test.discoverable {
+				writeConfigFile(t, "logging:\n  level: debug\n")
+			}
+			t.Setenv("DEPUTY_CONFIG", explicitPath)
+
+			cfg, err := loadRuntimeConfig()
+
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("loadRuntimeConfig() error = nil, want an error; cfg = %+v", cfg)
+				}
+				if !strings.Contains(err.Error(), test.wantErrHas) {
+					t.Errorf("error %q does not contain %q", err.Error(), test.wantErrHas)
+				}
+				if got := deputyerrors.GetSuggestion(err); !strings.Contains(got, "DEPUTY_CONFIG") {
+					t.Errorf("suggestion = %q, want it to mention DEPUTY_CONFIG", got)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("loadRuntimeConfig() error = %v, want nil", err)
+			}
+			if len(cfg.AdvisorySources) != 1 || cfg.AdvisorySources[0].URL != pinnedSource {
+				t.Errorf("AdvisorySources = %+v, want the source pinned by the explicit file", cfg.AdvisorySources)
+			}
+		})
+	}
+}
+
 // TestRootRefusesUnloadableConfig proves the load failure reaches command
 // execution rather than stopping at loadRuntimeConfig: a command must fail
 // instead of running on defaults. It drives the root command the way Run does,

--- a/internal/cli/config_load_test.go
+++ b/internal/cli/config_load_test.go
@@ -1,0 +1,291 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/temporalio/deputy/internal/config"
+	deputyerrors "github.com/temporalio/deputy/internal/errors"
+)
+
+// isolatedConfigDir puts the test in an empty working directory that also acts
+// as the home directory, so config discovery cannot pick up the developer's own
+// .deputy.yaml (FindConfigFile searches the working directory and then $HOME).
+// DEPUTY_CONFIG and DEPUTY_LOG_LEVEL are cleared for the same reason: an
+// inherited value would decide the outcome instead of the fixture.
+func isolatedConfigDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("DEPUTY_CONFIG", "")
+	t.Setenv("DEPUTY_LOG_LEVEL", "")
+	t.Chdir(dir)
+	return dir
+}
+
+// writeConfigFile writes a .deputy.yaml into the isolated working directory.
+func writeConfigFile(t *testing.T, contents string) {
+	t.Helper()
+	if err := os.WriteFile(".deputy.yaml", []byte(contents), 0o644); err != nil {
+		t.Fatalf("write .deputy.yaml: %v", err)
+	}
+}
+
+// TestLoadRuntimeConfig pins the distinction the CLI depends on: no config file
+// is normal and yields usable defaults, while a config file that exists but
+// cannot be parsed or validated is an error the caller must treat as fatal. The
+// silent-nil behavior this replaces let a broken file disable egress
+// allowlists, advisory sources, and OTel with no diagnostic at all.
+func TestLoadRuntimeConfig(t *testing.T) {
+	tests := []struct {
+		name string
+		// writeFile is false for the absent-config case.
+		writeFile   bool
+		contents    string
+		wantErr     bool
+		wantErrHas  []string
+		checkConfig func(t *testing.T, cfg *config.Config)
+	}{
+		{
+			name:      "no config file loads defaults without error",
+			writeFile: false,
+			checkConfig: func(t *testing.T, cfg *config.Config) {
+				if cfg == nil {
+					t.Fatal("cfg is nil; an absent config file must still yield defaults")
+				}
+				if cfg.Logging.Level == "" {
+					t.Error("expected default logging level to be populated")
+				}
+			},
+		},
+		{
+			name:      "unparseable yaml is an error",
+			writeFile: true,
+			contents:  "logging:\n  level: \"unclosed\n   bogus: [1, 2\n",
+			wantErr:   true,
+			// The path must be named: the offending file can live in the
+			// home directory, far from where the command was run.
+			wantErrHas: []string{"failed to load config from", ".deputy.yaml", "failed to parse config file"},
+		},
+		{
+			name:       "valid yaml with an invalid value is an error",
+			writeFile:  true,
+			contents:   "logging:\n  level: shouty\n",
+			wantErr:    true,
+			wantErrHas: []string{"failed to load config from", ".deputy.yaml", "validation failed for logging.level"},
+		},
+		{
+			name:      "valid config is loaded and honored",
+			writeFile: true,
+			contents: "logging:\n  level: debug\negress:\n  allow_loopback: true\n" +
+				"advisory_sources:\n  - url: \"https://advisories.example.com\"\n",
+			checkConfig: func(t *testing.T, cfg *config.Config) {
+				if cfg == nil {
+					t.Fatal("cfg is nil for a valid config file")
+				}
+				if cfg.Logging.Level != "debug" {
+					t.Errorf("Logging.Level = %q, want %q", cfg.Logging.Level, "debug")
+				}
+				if cfg.Egress == nil || !cfg.Egress.AllowLoopback {
+					t.Errorf("Egress.AllowLoopback not honored: %+v", cfg.Egress)
+				}
+				if len(cfg.AdvisorySources) != 1 || cfg.AdvisorySources[0].URL != "https://advisories.example.com" {
+					t.Errorf("AdvisorySources = %+v, want the single configured URL", cfg.AdvisorySources)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isolatedConfigDir(t)
+			if test.writeFile {
+				writeConfigFile(t, test.contents)
+			}
+
+			cfg, err := loadRuntimeConfig()
+
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("loadRuntimeConfig() error = nil, want an error; cfg = %+v", cfg)
+				}
+				if cfg != nil {
+					t.Errorf("loadRuntimeConfig() returned a config alongside an error: %+v", cfg)
+				}
+				for _, want := range test.wantErrHas {
+					if !strings.Contains(err.Error(), want) {
+						t.Errorf("error %q does not contain %q", err.Error(), want)
+					}
+				}
+				if got := deputyerrors.GetSuggestion(err); !strings.Contains(got, "deputy config validate") {
+					t.Errorf("suggestion = %q, want it to point at 'deputy config validate'", got)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("loadRuntimeConfig() error = %v, want nil", err)
+			}
+			if test.checkConfig != nil {
+				test.checkConfig(t, cfg)
+			}
+		})
+	}
+}
+
+// TestRootRefusesUnloadableConfig proves the load failure reaches command
+// execution rather than stopping at loadRuntimeConfig: a command must fail
+// instead of running on defaults. It drives the root command the way Run does,
+// with the error loadRuntimeConfig produced for a real broken file.
+func TestRootRefusesUnloadableConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+	}{
+		{name: "unparseable yaml", contents: "logging:\n  level: \"unclosed\n   bogus: [1, 2\n"},
+		{name: "invalid value", contents: "logging:\n  level: shouty\n"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isolatedConfigDir(t)
+			writeConfigFile(t, test.contents)
+
+			cfg, cfgErr := loadRuntimeConfig()
+			if cfgErr == nil {
+				t.Fatalf("loadRuntimeConfig() error = nil for %q; the rest of this test is meaningless", test.contents)
+			}
+			if cfg != nil {
+				t.Errorf("cfg = %+v, want nil", cfg)
+			}
+
+			// "version" is the cheapest real command: it touches no network
+			// and no filesystem, so the only thing that can fail it is the
+			// config gate.
+			err := executeRootWithConfigErr(t, cfgErr, "version")
+			if err == nil {
+				t.Fatal("command succeeded with an unloadable config; it ran on defaults instead of failing")
+			}
+			if !errors.Is(err, cfgErr) {
+				t.Errorf("command error = %v, want the config load error %v", err, cfgErr)
+			}
+		})
+	}
+}
+
+// TestRootAllowsConfigCommandsWithUnloadableConfig pins the one exemption: the
+// commands that diagnose a broken config file must stay runnable when the file
+// is broken, otherwise the failure message has no follow-up.
+func TestRootAllowsConfigCommandsWithUnloadableConfig(t *testing.T) {
+	isolatedConfigDir(t)
+	writeConfigFile(t, "logging:\n  level: shouty\n")
+
+	_, cfgErr := loadRuntimeConfig()
+	if cfgErr == nil {
+		t.Fatal("loadRuntimeConfig() error = nil; fixture is not broken")
+	}
+
+	if err := executeRootWithConfigErr(t, cfgErr, "config", "path"); err != nil {
+		t.Errorf("'config path' failed with an unloadable config: %v", err)
+	}
+}
+
+// TestRootRunsWithValidConfig guards the other direction, so the gate cannot
+// pass by failing everything: a loadable config file leaves commands runnable.
+func TestRootRunsWithValidConfig(t *testing.T) {
+	isolatedConfigDir(t)
+	writeConfigFile(t, "logging:\n  level: debug\n")
+
+	cfg, cfgErr := loadRuntimeConfig()
+	if cfgErr != nil {
+		t.Fatalf("loadRuntimeConfig() error = %v, want nil", cfgErr)
+	}
+	if cfg == nil {
+		t.Fatal("cfg is nil for a valid config file")
+	}
+
+	if err := executeRootWithConfigErr(t, nil, "version"); err != nil {
+		t.Errorf("'version' failed with a valid config: %v", err)
+	}
+}
+
+// TestRootRunsWithoutConfigFile pins the silent-success case: with no config
+// file anywhere, commands run and nothing is written to the command's error
+// stream.
+func TestRootRunsWithoutConfigFile(t *testing.T) {
+	isolatedConfigDir(t)
+
+	cfg, cfgErr := loadRuntimeConfig()
+	if cfgErr != nil {
+		t.Fatalf("loadRuntimeConfig() error = %v, want nil for an absent config file", cfgErr)
+	}
+	if cfg == nil {
+		t.Fatal("cfg is nil for an absent config file")
+	}
+
+	var stderr bytes.Buffer
+	root := newRoot(nil)
+	root.SetArgs([]string{"version"})
+	root.SetOut(io.Discard)
+	root.SetErr(&stderr)
+	if err := root.ExecuteContext(context.Background()); err != nil {
+		t.Errorf("'version' failed with no config file: %v", err)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr = %q, want empty: an absent config file must stay silent", stderr.String())
+	}
+}
+
+// TestInConfigCommandTree covers the exemption predicate directly, including
+// the case that must not be exempt: the root command itself is named "deputy",
+// and a top-level command must never inherit the config exemption.
+func TestInConfigCommandTree(t *testing.T) {
+	root := newRoot(nil)
+
+	find := func(t *testing.T, args ...string) *cobra.Command {
+		t.Helper()
+		cmd, _, err := root.Find(args)
+		if err != nil {
+			t.Fatalf("Find(%v): %v", args, err)
+		}
+		return cmd
+	}
+
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "config parent", args: []string{"config"}, want: true},
+		{name: "config show", args: []string{"config", "show"}, want: true},
+		{name: "config validate", args: []string{"config", "validate"}, want: true},
+		{name: "root", args: nil, want: false},
+		{name: "version", args: []string{"version"}, want: false},
+		{name: "scan", args: []string{"scan"}, want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := inConfigCommandTree(find(t, test.args...)); got != test.want {
+				t.Errorf("inConfigCommandTree(%v) = %v, want %v", test.args, got, test.want)
+			}
+		})
+	}
+}
+
+// executeRootWithConfigErr builds the root command the way Run does, with a
+// pending config error, and executes args against it with output discarded.
+func executeRootWithConfigErr(t *testing.T, configErr error, args ...string) error {
+	t.Helper()
+	root := newRoot(configErr)
+	root.SetArgs(args)
+	root.SetOut(io.Discard)
+	root.SetErr(io.Discard)
+	return root.ExecuteContext(context.Background())
+}

--- a/internal/cli/config_load_test.go
+++ b/internal/cli/config_load_test.go
@@ -530,7 +530,7 @@ func TestRootRunsWithoutConfigFile(t *testing.T) {
 	}
 
 	var stderr bytes.Buffer
-	root := newRoot(nil)
+	root := newRoot(nil, nil)
 	root.SetArgs([]string{"list", "."})
 	root.SetOut(io.Discard)
 	root.SetErr(&stderr)
@@ -547,7 +547,7 @@ func TestRootRunsWithoutConfigFile(t *testing.T) {
 // ones that must not. A one-sided test would pass just as well if the predicate
 // started returning true for everything.
 func TestRunsWithoutConfig(t *testing.T) {
-	root := newRoot(nil)
+	root := newRoot(nil, nil)
 	// The help and completion commands are attached lazily at Execute time, so
 	// materialize them before looking commands up by name.
 	root.InitDefaultHelpCmd()
@@ -797,7 +797,7 @@ func TestRootConfigGateByCommand(t *testing.T) {
 // pending config error, and executes args against it with output discarded.
 func executeRootWithConfigErr(t *testing.T, ctx context.Context, configErr error, args ...string) error {
 	t.Helper()
-	root := newRoot(configErr)
+	root := newRoot(nil, configErr)
 	root.SetArgs(args)
 	root.SetOut(io.Discard)
 	root.SetErr(io.Discard)

--- a/internal/cli/config_load_test.go
+++ b/internal/cli/config_load_test.go
@@ -89,16 +89,18 @@ func TestLoadRuntimeConfig(t *testing.T) {
 			wantErr:   true,
 			// The path must be named: the offending file can live in the
 			// home directory, far from where the command was run.
-			wantErrHas:        []string{"failed to load config from", ".deputy.yaml", "failed to parse config file"},
+			wantErrHas:        []string{"failed to load config", ".deputy.yaml", "failed to parse config file"},
 			wantSuggestionHas: "deputy config validate",
 		},
 		{
-			name:              "valid yaml with an invalid value is an error",
-			writeFile:         true,
-			contents:          "logging:\n  level: shouty\n",
-			wantErr:           true,
-			wantErrHas:        []string{"failed to load config from", ".deputy.yaml", "validation failed for logging.level"},
-			wantSuggestionHas: "deputy config validate",
+			name:      "valid yaml with an invalid value is an error",
+			writeFile: true,
+			contents:  "logging:\n  level: shouty\n",
+			wantErr:   true,
+			// A merged-config validation failure must not be blamed on the
+			// file: the offending value may have come from the environment.
+			wantErrHas:        []string{"invalid configuration", "validation failed for logging.level"},
+			wantSuggestionHas: "check both",
 		},
 		{
 			// With no file to blame, the error must not point at
@@ -107,7 +109,7 @@ func TestLoadRuntimeConfig(t *testing.T) {
 			writeFile:         false,
 			env:               map[string]string{"DEPUTY_LOG_LEVEL": "shouty"},
 			wantErr:           true,
-			wantErrHas:        []string{"failed to load config", "validation failed for logging.level"},
+			wantErrHas:        []string{"invalid configuration", "validation failed for logging.level"},
 			wantSuggestionHas: "DEPUTY_* environment variables",
 		},
 		{
@@ -167,6 +169,77 @@ func TestLoadRuntimeConfig(t *testing.T) {
 			}
 			if test.checkConfig != nil {
 				test.checkConfig(t, cfg)
+			}
+		})
+	}
+}
+
+// TestConfigLoadErrorAttribution pins where the diagnostic points. A merged
+// configuration is validated after the environment and flags are folded in, so
+// a validation failure cannot be pinned on the file just because a file exists.
+// Getting this wrong is worse than saying nothing: it sends the operator to
+// 'deputy config validate', which passes on the file it names.
+func TestConfigLoadErrorAttribution(t *testing.T) {
+	parseFailure := &deputyerrors.ConfigError{
+		Path:    ".deputy.yaml",
+		Message: "failed to parse config file",
+	}
+	validationFailure := &deputyerrors.ValidationError{
+		Field:   "logging.level",
+		Value:   "shouty",
+		Message: "must be one of: debug, info, warn, error",
+	}
+
+	tests := []struct {
+		name              string
+		configPath        string
+		err               error
+		wantErrHas        string
+		wantSuggestionHas string
+		// wantSuggestionLacks catches the misattribution directly.
+		wantSuggestionLacks string
+	}{
+		{
+			name:              "unreadable file blames the file",
+			configPath:        ".deputy.yaml",
+			err:               parseFailure,
+			wantErrHas:        "failed to load config",
+			wantSuggestionHas: "deputy config validate .deputy.yaml",
+		},
+		{
+			name:                "validation with a file names both sources",
+			configPath:          ".deputy.yaml",
+			err:                 validationFailure,
+			wantErrHas:          "invalid configuration",
+			wantSuggestionHas:   "check both",
+			wantSuggestionLacks: "deputy config validate",
+		},
+		{
+			name:                "validation without a file blames the environment",
+			configPath:          "",
+			err:                 validationFailure,
+			wantErrHas:          "invalid configuration",
+			wantSuggestionHas:   "DEPUTY_* environment variables",
+			wantSuggestionLacks: "deputy config validate",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := configLoadError(test.configPath, test.err)
+
+			if !strings.Contains(got.Error(), test.wantErrHas) {
+				t.Errorf("error %q does not contain %q", got.Error(), test.wantErrHas)
+			}
+			if !errors.Is(got, test.err) {
+				t.Errorf("error %v does not wrap the cause %v", got, test.err)
+			}
+			suggestion := deputyerrors.GetSuggestion(got)
+			if !strings.Contains(suggestion, test.wantSuggestionHas) {
+				t.Errorf("suggestion %q does not contain %q", suggestion, test.wantSuggestionHas)
+			}
+			if test.wantSuggestionLacks != "" && strings.Contains(suggestion, test.wantSuggestionLacks) {
+				t.Errorf("suggestion %q must not contain %q: the named command passes and teaches nothing", suggestion, test.wantSuggestionLacks)
 			}
 		})
 	}

--- a/internal/cli/config_load_test.go
+++ b/internal/cli/config_load_test.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -52,10 +53,14 @@ func writeConfigFile(t *testing.T, contents string) {
 
 // TestLoadRuntimeConfig pins the distinction the CLI depends on: no config file
 // is normal and yields usable defaults, while a config file that exists but
-// cannot be parsed or validated is an error the caller must treat as fatal. The
+// cannot be read or parsed is an error the caller must treat as fatal. The
 // silent-nil behavior this replaces let a broken file silently swap the
 // configured advisory sources, OTel settings, and egress relaxations for the
 // defaults, with no diagnostic at all.
+//
+// A value that merges cleanly but fails validation is deliberately not an error
+// here. It cannot be judged yet, because a flag may replace it; the gate does
+// that once the command line is parsed, and TestConfigGate covers it.
 func TestLoadRuntimeConfig(t *testing.T) {
 	tests := []struct {
 		name string
@@ -74,9 +79,6 @@ func TestLoadRuntimeConfig(t *testing.T) {
 			name:      "no config file loads defaults without error",
 			writeFile: false,
 			checkConfig: func(t *testing.T, cfg *config.Config) {
-				if cfg == nil {
-					t.Fatal("cfg is nil; an absent config file must still yield defaults")
-				}
 				if cfg.Logging.Level == "" {
 					t.Error("expected default logging level to be populated")
 				}
@@ -93,24 +95,27 @@ func TestLoadRuntimeConfig(t *testing.T) {
 			wantSuggestionHas: "deputy config validate",
 		},
 		{
-			name:      "valid yaml with an invalid value is an error",
+			// The value is carried, not judged. Judging it here would judge it
+			// without the flags, which is the ordering this split exists to
+			// fix.
+			name:      "valid yaml with an invalid value merges and waits for the gate",
 			writeFile: true,
 			contents:  "logging:\n  level: shouty\n",
-			wantErr:   true,
-			// A merged-config validation failure must not be blamed on the
-			// file: the offending value may have come from the environment.
-			wantErrHas:        []string{"invalid configuration", "validation failed for logging.level"},
-			wantSuggestionHas: "check both",
+			checkConfig: func(t *testing.T, cfg *config.Config) {
+				if cfg.Logging.Level != "shouty" {
+					t.Errorf("Logging.Level = %q, want the file's value carried through", cfg.Logging.Level)
+				}
+			},
 		},
 		{
-			// With no file to blame, the error must not point at
-			// 'config validate', which only reads files.
-			name:              "invalid environment value is an error without a file",
-			writeFile:         false,
-			env:               map[string]string{"DEPUTY_LOG_LEVEL": "shouty"},
-			wantErr:           true,
-			wantErrHas:        []string{"invalid configuration", "validation failed for logging.level"},
-			wantSuggestionHas: "DEPUTY_* environment variables",
+			name:      "invalid environment value merges and waits for the gate",
+			writeFile: false,
+			env:       map[string]string{"DEPUTY_LOG_LEVEL": "shouty"},
+			checkConfig: func(t *testing.T, cfg *config.Config) {
+				if cfg.Logging.Level != "shouty" {
+					t.Errorf("Logging.Level = %q, want the environment's value carried through", cfg.Logging.Level)
+				}
+			},
 		},
 		{
 			name:      "valid config is loaded and honored",
@@ -118,9 +123,6 @@ func TestLoadRuntimeConfig(t *testing.T) {
 			contents: "logging:\n  level: debug\negress:\n  allow_loopback: true\n" +
 				"advisory_sources:\n  - url: \"https://advisories.example.com\"\n",
 			checkConfig: func(t *testing.T, cfg *config.Config) {
-				if cfg == nil {
-					t.Fatal("cfg is nil for a valid config file")
-				}
 				if cfg.Logging.Level != "debug" {
 					t.Errorf("Logging.Level = %q, want %q", cfg.Logging.Level, "debug")
 				}
@@ -144,32 +146,33 @@ func TestLoadRuntimeConfig(t *testing.T) {
 				t.Setenv(k, v)
 			}
 
-			cfg, err := loadRuntimeConfig()
+			rc := loadRuntimeConfig()
 
 			if test.wantErr {
-				if err == nil {
-					t.Fatalf("loadRuntimeConfig() error = nil, want an error; cfg = %+v", cfg)
+				if rc.Err == nil {
+					t.Fatalf("loadRuntimeConfig() Err = nil, want an error; Config = %+v", rc.Config)
 				}
-				if cfg != nil {
-					t.Errorf("loadRuntimeConfig() returned a config alongside an error: %+v", cfg)
+				if rc.Config != nil {
+					t.Errorf("loadRuntimeConfig() returned a config alongside an error: %+v", rc.Config)
 				}
 				for _, want := range test.wantErrHas {
-					if !strings.Contains(err.Error(), want) {
-						t.Errorf("error %q does not contain %q", err.Error(), want)
+					if !strings.Contains(rc.Err.Error(), want) {
+						t.Errorf("error %q does not contain %q", rc.Err.Error(), want)
 					}
 				}
-				if got := deputyerrors.GetSuggestion(err); !strings.Contains(got, test.wantSuggestionHas) {
+				if got := deputyerrors.GetSuggestion(rc.Err); !strings.Contains(got, test.wantSuggestionHas) {
 					t.Errorf("suggestion = %q, want it to contain %q", got, test.wantSuggestionHas)
 				}
 				return
 			}
 
-			if err != nil {
-				t.Fatalf("loadRuntimeConfig() error = %v, want nil", err)
+			if rc.Err != nil {
+				t.Fatalf("loadRuntimeConfig() Err = %v, want nil", rc.Err)
 			}
-			if test.checkConfig != nil {
-				test.checkConfig(t, cfg)
+			if rc.Config == nil {
+				t.Fatal("loadRuntimeConfig() returned neither a config nor an error")
 			}
+			test.checkConfig(t, rc.Config)
 		})
 	}
 }
@@ -294,158 +297,303 @@ func TestLoadRuntimeConfigExplicitPath(t *testing.T) {
 			}
 			t.Setenv("DEPUTY_CONFIG", explicitPath)
 
-			cfg, err := loadRuntimeConfig()
+			rc := loadRuntimeConfig()
 
 			if test.wantErr {
-				if err == nil {
-					t.Fatalf("loadRuntimeConfig() error = nil, want an error; cfg = %+v", cfg)
+				if rc.Err == nil {
+					t.Fatalf("loadRuntimeConfig() Err = nil, want an error; Config = %+v", rc.Config)
 				}
-				if !strings.Contains(err.Error(), test.wantErrHas) {
-					t.Errorf("error %q does not contain %q", err.Error(), test.wantErrHas)
+				if !strings.Contains(rc.Err.Error(), test.wantErrHas) {
+					t.Errorf("error %q does not contain %q", rc.Err.Error(), test.wantErrHas)
 				}
-				if got := deputyerrors.GetSuggestion(err); !strings.Contains(got, "DEPUTY_CONFIG") {
+				if got := deputyerrors.GetSuggestion(rc.Err); !strings.Contains(got, "DEPUTY_CONFIG") {
 					t.Errorf("suggestion = %q, want it to mention DEPUTY_CONFIG", got)
 				}
 				return
 			}
 
-			if err != nil {
-				t.Fatalf("loadRuntimeConfig() error = %v, want nil", err)
+			if rc.Err != nil {
+				t.Fatalf("loadRuntimeConfig() Err = %v, want nil", rc.Err)
 			}
-			if len(cfg.AdvisorySources) != 1 || cfg.AdvisorySources[0].URL != pinnedSource {
-				t.Errorf("AdvisorySources = %+v, want the source pinned by the explicit file", cfg.AdvisorySources)
+			if len(rc.Config.AdvisorySources) != 1 || rc.Config.AdvisorySources[0].URL != pinnedSource {
+				t.Errorf("AdvisorySources = %+v, want the source pinned by the explicit file", rc.Config.AdvisorySources)
 			}
 		})
 	}
 }
 
-// TestLoggingFlagOverrides pins the early scrape of the logging flags. It has
-// to find a flag in every form cobra accepts, or configuration is validated
-// against an environment value the user already overrode; it has to ignore
-// everything after "--", or a passthrough command's own flags would be read as
-// Deputy's.
-func TestLoggingFlagOverrides(t *testing.T) {
+// TestFlagOverrides pins what the gate hands to configuration: every flag the
+// invocation set, by name, and nothing it did not set. Reporting a chosen few
+// is what left command-specific flags out of the validated merge, so the test
+// covers a repeatable flag from a subcommand alongside the root's own.
+func TestFlagOverrides(t *testing.T) {
 	tests := []struct {
 		name string
 		args []string
-		want map[string]string
+		want config.Overrides
 	}{
 		{
-			name: "no logging flags",
+			name: "no flags",
 			args: []string{"list", "."},
-			want: map[string]string{},
+			want: config.Overrides{},
 		},
 		{
 			name: "equals form",
 			args: []string{"list", ".", "--log-level=debug"},
-			want: map[string]string{"log-level": "debug"},
+			want: config.Overrides{"log-level": {"debug"}},
 		},
 		{
 			name: "space form",
 			args: []string{"list", ".", "--log-level", "debug"},
-			want: map[string]string{"log-level": "debug"},
+			want: config.Overrides{"log-level": {"debug"}},
 		},
 		{
 			name: "before the subcommand",
 			args: []string{"--log-level", "debug", "list", "."},
-			want: map[string]string{"log-level": "debug"},
+			want: config.Overrides{"log-level": {"debug"}},
 		},
 		{
-			name: "alongside an unknown flag that takes a value",
-			args: []string{"--server", "https://x.example.com", "--log-level", "debug", "list"},
-			want: map[string]string{"log-level": "debug"},
-		},
-		{
-			name: "both flags",
+			name: "both logging flags",
 			args: []string{"scan", "--log-level=warn", "--log-format=json"},
-			want: map[string]string{"log-level": "warn", "log-format": "json"},
+			want: config.Overrides{"log-level": {"warn"}, "log-format": {"json"}},
+		},
+		{
+			// A repeatable flag on a subcommand: the one shape the old scrape
+			// could not see, and the one that made an invalid config file
+			// unstartable even when the command line replaced the bad value.
+			name: "repeatable subcommand flag keeps every value",
+			args: []string{"server", "--egress-allow-cidr", "10.0.0.0/8", "--egress-allow-cidr", "192.168.0.0/16"},
+			want: config.Overrides{"egress-allow-cidr": {"10.0.0.0/8", "192.168.0.0/16"}},
 		},
 		{
 			// The inner flag belongs to npm, not to Deputy. Reading it would
 			// let an unrelated argument satisfy Deputy's config validation.
-			name: "not scraped from a passthrough after the terminator",
+			name: "nothing after the terminator is a flag",
 			args: []string{"proxy", "npm", "--", "npm", "install", "--log-level=silly"},
-			want: map[string]string{},
+			want: config.Overrides{},
 		},
 		{
-			name: "explicitly empty flag is recorded but means no choice",
+			name: "an explicitly empty flag is reported as set",
 			args: []string{"list", "--log-level="},
-			want: map[string]string{"log-level": ""},
+			want: config.Overrides{"log-level": {""}},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := loggingFlagOverrides(test.args)
-			if !maps.Equal(got, test.want) {
-				t.Errorf("loggingFlagOverrides(%v) = %v, want %v", test.args, got, test.want)
+			got := flagOverrides(resolveCommand(t, runtimeConfig{}, test.args...))
+			if !maps.EqualFunc(got, test.want, slices.Equal) {
+				t.Errorf("flagOverrides(%v) = %v, want %v", test.args, got, test.want)
 			}
 		})
 	}
 }
 
-// TestLoadRuntimeConfigHonorsFlagPrecedence proves the scrape is actually wired
-// into the load, end to end: an invalid DEPUTY_LOG_LEVEL that the command line
-// overrides must not make the command fatal, because flags outrank the
-// environment. This regressed once already.
-func TestLoadRuntimeConfigHonorsFlagPrecedence(t *testing.T) {
+// TestOverrideFlagNamesAreRealFlags checks the override registry against the
+// commands the CLI actually ships. An override keyed on a flag that was renamed
+// or removed stops applying without a word, and the config file value it existed
+// to correct starts winning again, which is the defect this whole gate is about
+// arriving by a different route.
+func TestOverrideFlagNamesAreRealFlags(t *testing.T) {
+	names := config.OverrideFlagNames()
+	if len(names) == 0 {
+		t.Fatal("config.OverrideFlagNames() is empty; the checks below would pass vacuously")
+	}
+
+	root := newRoot(runtimeConfig{})
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			if !declaresFlag(root, name) {
+				t.Errorf("configuration overrides --%s, which no command declares, so the override can never apply", name)
+			}
+		})
+	}
+}
+
+// declaresFlag reports whether cmd or any command beneath it declares a flag of
+// this name, local or persistent.
+func declaresFlag(cmd *cobra.Command, name string) bool {
+	if cmd.Flags().Lookup(name) != nil || cmd.PersistentFlags().Lookup(name) != nil {
+		return true
+	}
+	return slices.ContainsFunc(cmd.Commands(), func(child *cobra.Command) bool {
+		return declaresFlag(child, name)
+	})
+}
+
+// TestConfigGate pins the ordering the three round-two findings all came from:
+// configuration is judged against the values the command will use, so a flag
+// can correct what the environment or the file got wrong, and cannot rescue
+// what it does not replace. Validating before the command line was parsed made
+// every override-capable flag a separate defect, one per flag.
+func TestConfigGate(t *testing.T) {
+	// badCIDRFile is the finding that command-specific flags exposed: only the
+	// server command can replace this value, so only the server command's flags
+	// can tell whether it is the effective one.
+	const badCIDRFile = "server:\n  egress:\n    allowed_cidrs:\n      - \"not-a-cidr\"\n"
+	const badLevelFile = "logging:\n  level: shouty\n"
+
 	tests := []struct {
-		name    string
-		argv    []string
-		wantErr bool
+		name        string
+		file        string
+		env         map[string]string
+		args        []string
+		wantRefused bool
+		wantErrHas  string
 	}{
 		{
-			name:    "flag overrides the invalid environment value",
-			argv:    []string{"deputy", "list", ".", "--log-level=debug"},
-			wantErr: false,
+			name:        "an invalid file CIDR stops the server",
+			file:        badCIDRFile,
+			args:        []string{"server"},
+			wantRefused: true,
+			wantErrHas:  "server.egress.allowed_cidrs",
 		},
 		{
-			name:    "no override leaves the invalid value fatal",
-			argv:    []string{"deputy", "list", "."},
-			wantErr: true,
+			name: "a valid egress flag corrects an invalid file CIDR",
+			file: badCIDRFile,
+			args: []string{"server", "--egress-allow-cidr", "10.0.0.0/8"},
+		},
+		{
+			name:        "an invalid egress flag is rejected on its own terms",
+			file:        badCIDRFile,
+			args:        []string{"server", "--egress-allow-cidr", "also-not-a-cidr"},
+			wantRefused: true,
+			wantErrHas:  "server.egress.allowed_cidrs",
+		},
+		{
+			name:        "an invalid environment level stops a gated command",
+			env:         map[string]string{"DEPUTY_LOG_LEVEL": "shouty"},
+			args:        []string{"list", "."},
+			wantRefused: true,
+			wantErrHas:  "logging.level",
+		},
+		{
+			name: "a logging flag corrects an invalid environment level",
+			env:  map[string]string{"DEPUTY_LOG_LEVEL": "shouty"},
+			args: []string{"list", ".", "--log-level=debug"},
+		},
+		{
+			// The server command reached its own second load here, which had
+			// none of the overrides, and rejected a flag the root accepted.
+			name: "a logging flag corrects an invalid environment level for the server too",
+			env:  map[string]string{"DEPUTY_LOG_LEVEL": "shouty"},
+			args: []string{"server", "--log-level=debug"},
+		},
+		{
+			name: "a logging flag placed before the subcommand still corrects it",
+			env:  map[string]string{"DEPUTY_LOG_LEVEL": "shouty"},
+			args: []string{"--log-level", "debug", "list", "."},
+		},
+		{
+			name: "a logging flag corrects an invalid file level",
+			file: badLevelFile,
+			args: []string{"scan", ".", "--log-level=debug"},
+		},
+		{
+			name:        "an explicitly empty flag chooses nothing and does not correct",
+			env:         map[string]string{"DEPUTY_LOG_LEVEL": "shouty"},
+			args:        []string{"list", ".", "--log-level="},
+			wantRefused: true,
+			wantErrHas:  "logging.level",
+		},
+		{
+			name:        "a flag for a different field does not correct",
+			env:         map[string]string{"DEPUTY_LOG_LEVEL": "shouty"},
+			args:        []string{"list", ".", "--log-format=json"},
+			wantRefused: true,
+			wantErrHas:  "logging.level",
+		},
+		{
+			name:        "a passthrough argument cannot pose as a correcting flag",
+			env:         map[string]string{"DEPUTY_LOG_LEVEL": "shouty"},
+			args:        []string{"proxy", "npm", "--", "npm", "install", "--log-level=debug"},
+			wantRefused: true,
+			wantErrHas:  "logging.level",
+		},
+		{
+			// No flag can correct a file the loader never read.
+			name:        "an unparseable file is refused whatever the flags say",
+			file:        "logging:\n  level: \"unclosed\n   bogus: [1, 2\n",
+			args:        []string{"list", ".", "--log-level=debug"},
+			wantRefused: true,
+			wantErrHas:  "failed to parse config file",
+		},
+		{
+			name: "a valid configuration passes",
+			file: "logging:\n  level: debug\n",
+			args: []string{"list", "."},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			isolatedConfigDir(t)
-			t.Setenv("DEPUTY_LOG_LEVEL", "shouty")
+			if test.file != "" {
+				writeConfigFile(t, test.file)
+			}
+			for k, v := range test.env {
+				t.Setenv(k, v)
+			}
 
-			// loadRuntimeConfig reads the real argv, since it runs before
-			// cobra parses anything.
-			original := os.Args
-			t.Cleanup(func() { os.Args = original })
-			os.Args = test.argv
+			rc := loadRuntimeConfig()
+			err := configGateError(rc, resolveCommand(t, rc, test.args...))
 
-			cfg, err := loadRuntimeConfig()
-
-			if test.wantErr {
+			if test.wantRefused {
 				if err == nil {
-					t.Fatalf("loadRuntimeConfig() error = nil, want an error; cfg = %+v", cfg)
+					t.Fatalf("configGateError(%v) = nil, want a refusal", test.args)
+				}
+				if !strings.Contains(err.Error(), test.wantErrHas) {
+					t.Errorf("error %q does not contain %q", err.Error(), test.wantErrHas)
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("loadRuntimeConfig() error = %v, want nil: the flag outranks DEPUTY_LOG_LEVEL", err)
-			}
-			if cfg.Logging.Level != "debug" {
-				t.Errorf("Logging.Level = %q, want %q", cfg.Logging.Level, "debug")
+				t.Errorf("configGateError(%v) = %v, want nil: the invocation replaced the offending value", test.args, err)
 			}
 		})
 	}
 }
 
+// resolveCommand builds the real root command and resolves args the way cobra
+// does before it calls PersistentPreRunE, so a test sees the command that would
+// run with the flag set it would have.
+func resolveCommand(t *testing.T, rc runtimeConfig, args ...string) *cobra.Command {
+	t.Helper()
+	root := newRoot(rc)
+	// Help and completion are attached lazily at Execute time.
+	root.InitDefaultHelpCmd()
+	root.InitDefaultCompletionCmd()
+
+	cmd, flagArgs, err := root.Find(args)
+	if err != nil {
+		t.Fatalf("Find(%v): %v", args, err)
+	}
+	if err := cmd.ParseFlags(flagArgs); err != nil {
+		t.Fatalf("ParseFlags(%v): %v", flagArgs, err)
+	}
+	return cmd
+}
+
 // TestRootRefusesUnloadableConfig proves the load failure reaches command
 // execution rather than stopping at loadRuntimeConfig: a command must fail
 // instead of running on defaults. It drives the root command the way Run does,
-// with the error loadRuntimeConfig produced for a real broken file.
+// against a real broken file.
 func TestRootRefusesUnloadableConfig(t *testing.T) {
 	tests := []struct {
-		name     string
-		contents string
+		name       string
+		contents   string
+		wantErrHas string
 	}{
-		{name: "unparseable yaml", contents: "logging:\n  level: \"unclosed\n   bogus: [1, 2\n"},
-		{name: "invalid value", contents: "logging:\n  level: shouty\n"},
+		{
+			name:       "unparseable yaml",
+			contents:   "logging:\n  level: \"unclosed\n   bogus: [1, 2\n",
+			wantErrHas: "failed to parse config file",
+		},
+		{
+			name:       "invalid value",
+			contents:   "logging:\n  level: shouty\n",
+			wantErrHas: "validation failed for logging.level",
+		},
 	}
 
 	for _, test := range tests {
@@ -453,24 +601,19 @@ func TestRootRefusesUnloadableConfig(t *testing.T) {
 			isolatedConfigDir(t)
 			writeConfigFile(t, test.contents)
 
-			cfg, cfgErr := loadRuntimeConfig()
-			if cfgErr == nil {
-				t.Fatalf("loadRuntimeConfig() error = nil for %q; the rest of this test is meaningless", test.contents)
-			}
-			if cfg != nil {
-				t.Errorf("cfg = %+v, want nil", cfg)
-			}
-
 			// "list" is gated (it honors egress and advisory sources), and
 			// it is pointed at a directory with nothing to enumerate so the
 			// only thing that can fail it is the config gate. Deliberately
 			// not "version", which the allowlist exempts.
-			err := executeRootWithConfigErr(t, context.Background(), cfgErr, "list", ".")
+			err := executeRootFromEnvironment(t, context.Background(), "list", ".")
 			if err == nil {
 				t.Fatal("command succeeded with an unloadable config; it ran on defaults instead of failing")
 			}
-			if !errors.Is(err, cfgErr) {
-				t.Errorf("command error = %v, want the config load error %v", err, cfgErr)
+			if !isConfigGateError(err) {
+				t.Errorf("command error = %v, want the config gate refusal; an incidental error would hide a gate that stopped firing", err)
+			}
+			if !strings.Contains(err.Error(), test.wantErrHas) {
+				t.Errorf("error %q does not contain %q", err.Error(), test.wantErrHas)
 			}
 		})
 	}
@@ -483,12 +626,7 @@ func TestRootAllowsConfigCommandsWithUnloadableConfig(t *testing.T) {
 	isolatedConfigDir(t)
 	writeConfigFile(t, "logging:\n  level: shouty\n")
 
-	_, cfgErr := loadRuntimeConfig()
-	if cfgErr == nil {
-		t.Fatal("loadRuntimeConfig() error = nil; fixture is not broken")
-	}
-
-	if err := executeRootWithConfigErr(t, context.Background(), cfgErr, "config", "path"); err != nil {
+	if err := executeRootFromEnvironment(t, context.Background(), "config", "path"); err != nil {
 		t.Errorf("'config path' failed with an unloadable config: %v", err)
 	}
 }
@@ -501,15 +639,7 @@ func TestRootRunsWithValidConfig(t *testing.T) {
 	writeGoModFixture(t, dir)
 	writeConfigFile(t, "logging:\n  level: debug\n")
 
-	cfg, cfgErr := loadRuntimeConfig()
-	if cfgErr != nil {
-		t.Fatalf("loadRuntimeConfig() error = %v, want nil", cfgErr)
-	}
-	if cfg == nil {
-		t.Fatal("cfg is nil for a valid config file")
-	}
-
-	if err := executeRootWithConfigErr(t, context.Background(), nil, "list", "."); err != nil {
+	if err := executeRootFromEnvironment(t, context.Background(), "list", "."); err != nil {
 		t.Errorf("'list' failed with a valid config: %v", err)
 	}
 }
@@ -521,16 +651,16 @@ func TestRootRunsWithoutConfigFile(t *testing.T) {
 	dir := isolatedConfigDir(t)
 	writeGoModFixture(t, dir)
 
-	cfg, cfgErr := loadRuntimeConfig()
-	if cfgErr != nil {
-		t.Fatalf("loadRuntimeConfig() error = %v, want nil for an absent config file", cfgErr)
+	rc := loadRuntimeConfig()
+	if rc.Err != nil {
+		t.Fatalf("loadRuntimeConfig() Err = %v, want nil for an absent config file", rc.Err)
 	}
-	if cfg == nil {
-		t.Fatal("cfg is nil for an absent config file")
+	if rc.Config == nil {
+		t.Fatal("Config is nil for an absent config file")
 	}
 
 	var stderr bytes.Buffer
-	root := newRoot(nil, nil)
+	root := newRoot(rc)
 	root.SetArgs([]string{"list", "."})
 	root.SetOut(io.Discard)
 	root.SetErr(&stderr)
@@ -547,7 +677,7 @@ func TestRootRunsWithoutConfigFile(t *testing.T) {
 // ones that must not. A one-sided test would pass just as well if the predicate
 // started returning true for everything.
 func TestRunsWithoutConfig(t *testing.T) {
-	root := newRoot(nil, nil)
+	root := newRoot(runtimeConfig{})
 	// The help and completion commands are attached lazily at Execute time, so
 	// materialize them before looking commands up by name.
 	root.InitDefaultHelpCmd()
@@ -713,18 +843,13 @@ func TestRootConfigGateBySource(t *testing.T) {
 				isolatedConfigDir(t)
 				source.apply(t)
 
-				cfg, cfgErr := loadRuntimeConfig()
-				if cfgErr == nil && cfg == nil {
-					t.Fatal("loadRuntimeConfig returned neither a config nor an error")
-				}
-
 				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 				defer cancel()
-				err := executeRootWithConfigErr(t, ctx, cfgErr, command.args...)
+				err := executeRootFromEnvironment(t, ctx, command.args...)
 
 				if command.wantRefused {
-					if err == nil {
-						t.Errorf("%v succeeded with a broken configuration; it ran on defaults instead of being refused", command.args)
+					if !isConfigGateError(err) {
+						t.Errorf("%v error = %v, want the config gate refusal; it ran on defaults instead of being refused", command.args, err)
 					}
 					return
 				}
@@ -744,11 +869,6 @@ func TestRootConfigGateBySource(t *testing.T) {
 func TestRootConfigGateByCommand(t *testing.T) {
 	isolatedConfigDir(t)
 	writeConfigFile(t, "logging:\n  level: shouty\n")
-
-	_, cfgErr := loadRuntimeConfig()
-	if cfgErr == nil {
-		t.Fatal("loadRuntimeConfig() error = nil; fixture is not broken")
-	}
 
 	tests := []struct {
 		name string
@@ -778,11 +898,11 @@ func TestRootConfigGateByCommand(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
 
-			err := executeRootWithConfigErr(t, ctx, cfgErr, test.args...)
+			err := executeRootFromEnvironment(t, ctx, test.args...)
 
 			if test.wantRefused {
-				if !errors.Is(err, cfgErr) {
-					t.Errorf("%v error = %v, want the config load error; the command ran on defaults instead of being refused", test.args, err)
+				if !isConfigGateError(err) {
+					t.Errorf("%v error = %v, want the config gate refusal; the command ran on defaults instead of being refused", test.args, err)
 				}
 				return
 			}
@@ -793,13 +913,34 @@ func TestRootConfigGateByCommand(t *testing.T) {
 	}
 }
 
-// executeRootWithConfigErr builds the root command the way Run does, with a
-// pending config error, and executes args against it with output discarded.
-func executeRootWithConfigErr(t *testing.T, ctx context.Context, configErr error, args ...string) error {
+// executeRootFromEnvironment builds the root command the way Run does, from
+// whatever configuration the surrounding test fixture provides, and executes
+// args against it with output discarded.
+//
+// It loads for real rather than being handed a prepared error, because the
+// configuration a command is judged against is not settled until that command's
+// flags are parsed. A test that supplied its own error would decide the outcome
+// it was meant to observe.
+func executeRootFromEnvironment(t *testing.T, ctx context.Context, args ...string) error {
 	t.Helper()
-	root := newRoot(nil, configErr)
+	root := newRoot(loadRuntimeConfig())
 	root.SetArgs(args)
 	root.SetOut(io.Discard)
 	root.SetErr(io.Discard)
 	return root.ExecuteContext(ctx)
+}
+
+// isConfigGateError reports whether err is the configuration gate refusing to
+// run, rather than an incidental failure from a command that was wrongly let
+// through. The gate always wraps the configuration fault it found, so the
+// wrapped type is what distinguishes the two.
+func isConfigGateError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if _, ok := errors.AsType[*deputyerrors.ConfigError](err); ok {
+		return true
+	}
+	_, ok := errors.AsType[*deputyerrors.ValidationError](err)
+	return ok
 }

--- a/internal/cli/config_load_test.go
+++ b/internal/cli/config_load_test.go
@@ -6,8 +6,10 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/temporalio/deputy/internal/config"
@@ -29,6 +31,16 @@ func isolatedConfigDir(t *testing.T) string {
 	return dir
 }
 
+// writeGoModFixture gives the isolated directory a minimal Go module, so a
+// gated command such as "list" has something real to enumerate and can only
+// fail for reasons the test is actually about.
+func writeGoModFixture(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/fixture\n\ngo 1.22\n"), 0o644); err != nil {
+		t.Fatalf("write go.mod fixture: %v", err)
+	}
+}
+
 // writeConfigFile writes a .deputy.yaml into the isolated working directory.
 func writeConfigFile(t *testing.T, contents string) {
 	t.Helper()
@@ -40,8 +52,9 @@ func writeConfigFile(t *testing.T, contents string) {
 // TestLoadRuntimeConfig pins the distinction the CLI depends on: no config file
 // is normal and yields usable defaults, while a config file that exists but
 // cannot be parsed or validated is an error the caller must treat as fatal. The
-// silent-nil behavior this replaces let a broken file disable egress
-// allowlists, advisory sources, and OTel with no diagnostic at all.
+// silent-nil behavior this replaces let a broken file silently swap the
+// configured advisory sources, OTel settings, and egress relaxations for the
+// defaults, with no diagnostic at all.
 func TestLoadRuntimeConfig(t *testing.T) {
 	tests := []struct {
 		name string
@@ -184,10 +197,11 @@ func TestRootRefusesUnloadableConfig(t *testing.T) {
 				t.Errorf("cfg = %+v, want nil", cfg)
 			}
 
-			// "version" is the cheapest real command: it touches no network
-			// and no filesystem, so the only thing that can fail it is the
-			// config gate.
-			err := executeRootWithConfigErr(t, cfgErr, "version")
+			// "list" is gated (it honors egress and advisory sources), and
+			// it is pointed at a directory with nothing to enumerate so the
+			// only thing that can fail it is the config gate. Deliberately
+			// not "version", which the allowlist exempts.
+			err := executeRootWithConfigErr(t, context.Background(), cfgErr, "list", ".")
 			if err == nil {
 				t.Fatal("command succeeded with an unloadable config; it ran on defaults instead of failing")
 			}
@@ -198,9 +212,9 @@ func TestRootRefusesUnloadableConfig(t *testing.T) {
 	}
 }
 
-// TestRootAllowsConfigCommandsWithUnloadableConfig pins the one exemption: the
-// commands that diagnose a broken config file must stay runnable when the file
-// is broken, otherwise the failure message has no follow-up.
+// TestRootAllowsConfigCommandsWithUnloadableConfig pins the diagnostic
+// exemption: the commands that explain a broken config file must stay runnable
+// when the file is broken, otherwise the failure message has no follow-up.
 func TestRootAllowsConfigCommandsWithUnloadableConfig(t *testing.T) {
 	isolatedConfigDir(t)
 	writeConfigFile(t, "logging:\n  level: shouty\n")
@@ -210,15 +224,17 @@ func TestRootAllowsConfigCommandsWithUnloadableConfig(t *testing.T) {
 		t.Fatal("loadRuntimeConfig() error = nil; fixture is not broken")
 	}
 
-	if err := executeRootWithConfigErr(t, cfgErr, "config", "path"); err != nil {
+	if err := executeRootWithConfigErr(t, context.Background(), cfgErr, "config", "path"); err != nil {
 		t.Errorf("'config path' failed with an unloadable config: %v", err)
 	}
 }
 
 // TestRootRunsWithValidConfig guards the other direction, so the gate cannot
-// pass by failing everything: a loadable config file leaves commands runnable.
+// pass by failing everything: a loadable config file leaves a gated command
+// runnable. It uses "list", not an exempt command, or it would prove nothing.
 func TestRootRunsWithValidConfig(t *testing.T) {
-	isolatedConfigDir(t)
+	dir := isolatedConfigDir(t)
+	writeGoModFixture(t, dir)
 	writeConfigFile(t, "logging:\n  level: debug\n")
 
 	cfg, cfgErr := loadRuntimeConfig()
@@ -229,8 +245,8 @@ func TestRootRunsWithValidConfig(t *testing.T) {
 		t.Fatal("cfg is nil for a valid config file")
 	}
 
-	if err := executeRootWithConfigErr(t, nil, "version"); err != nil {
-		t.Errorf("'version' failed with a valid config: %v", err)
+	if err := executeRootWithConfigErr(t, context.Background(), nil, "list", "."); err != nil {
+		t.Errorf("'list' failed with a valid config: %v", err)
 	}
 }
 
@@ -238,7 +254,8 @@ func TestRootRunsWithValidConfig(t *testing.T) {
 // file anywhere, commands run and nothing is written to the command's error
 // stream.
 func TestRootRunsWithoutConfigFile(t *testing.T) {
-	isolatedConfigDir(t)
+	dir := isolatedConfigDir(t)
+	writeGoModFixture(t, dir)
 
 	cfg, cfgErr := loadRuntimeConfig()
 	if cfgErr != nil {
@@ -250,28 +267,36 @@ func TestRootRunsWithoutConfigFile(t *testing.T) {
 
 	var stderr bytes.Buffer
 	root := newRoot(nil)
-	root.SetArgs([]string{"version"})
+	root.SetArgs([]string{"list", "."})
 	root.SetOut(io.Discard)
 	root.SetErr(&stderr)
 	if err := root.ExecuteContext(context.Background()); err != nil {
-		t.Errorf("'version' failed with no config file: %v", err)
+		t.Errorf("'list' failed with no config file: %v", err)
 	}
 	if stderr.Len() != 0 {
 		t.Errorf("stderr = %q, want empty: an absent config file must stay silent", stderr.String())
 	}
 }
 
-// TestInConfigCommandTree covers the exemption predicate directly, including
-// the case that must not be exempt: the root command itself is named "deputy",
-// and a top-level command must never inherit the config exemption.
-func TestInConfigCommandTree(t *testing.T) {
+// TestRunsWithoutConfig pins the exemption allowlist in both directions: the
+// commands that must survive an unloadable config and, just as importantly, the
+// ones that must not. A one-sided test would pass just as well if the predicate
+// started returning true for everything.
+func TestRunsWithoutConfig(t *testing.T) {
 	root := newRoot(nil)
+	// The help and completion commands are attached lazily at Execute time, so
+	// materialize them before looking commands up by name.
+	root.InitDefaultHelpCmd()
+	root.InitDefaultCompletionCmd()
 
 	find := func(t *testing.T, args ...string) *cobra.Command {
 		t.Helper()
 		cmd, _, err := root.Find(args)
 		if err != nil {
 			t.Fatalf("Find(%v): %v", args, err)
+		}
+		if len(args) > 0 && cmd.Name() != args[len(args)-1] {
+			t.Fatalf("Find(%v) resolved to %q, not the command under test", args, cmd.Name())
 		}
 		return cmd
 	}
@@ -281,45 +306,145 @@ func TestInConfigCommandTree(t *testing.T) {
 		args []string
 		want bool
 	}{
-		{name: "config parent", args: []string{"config"}, want: true},
+		// Exempt: these do not act on configuration.
+		{name: "config", args: []string{"config"}, want: true},
 		{name: "config show", args: []string{"config", "show"}, want: true},
 		{name: "config validate", args: []string{"config", "validate"}, want: true},
-		{name: "root", args: nil, want: false},
-		{name: "version", args: []string{"version"}, want: false},
+		{name: "version", args: []string{"version"}, want: true},
+		{name: "completion", args: []string{"completion"}, want: true},
+		{name: "completion zsh", args: []string{"completion", "zsh"}, want: true},
+		{name: "help", args: []string{"help"}, want: true},
+
+		// Gated: each of these honors egress, advisory sources, or otel.
+		{name: "root runs diff when bare", args: nil, want: false},
+		{name: "list", args: []string{"list"}, want: false},
 		{name: "scan", args: []string{"scan"}, want: false},
+		{name: "server", args: []string{"server"}, want: false},
+		{name: "diff", args: []string{"diff"}, want: false},
+		{name: "fix", args: []string{"fix"}, want: false},
+		{name: "proxy", args: []string{"proxy"}, want: false},
+		{name: "init", args: []string{"init"}, want: false},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if got := inConfigCommandTree(find(t, test.args...)); got != test.want {
-				t.Errorf("inConfigCommandTree(%v) = %v, want %v", test.args, got, test.want)
+			if got := runsWithoutConfig(find(t, test.args...)); got != test.want {
+				t.Errorf("runsWithoutConfig(%v) = %v, want %v", test.args, got, test.want)
 			}
 		})
 	}
 
-	// The exemption keys on the top-level config command, not on the name
-	// alone, so a command named "config" nested under something else must not
-	// pick it up and become runnable on a config file that failed to load.
-	t.Run("nested command named config is not exempt", func(t *testing.T) {
-		fake := &cobra.Command{Use: "deputy"}
-		proxy := &cobra.Command{Use: "proxy"}
-		nested := &cobra.Command{Use: "config"}
-		proxy.AddCommand(nested)
-		fake.AddCommand(proxy)
+	// Cobra's hidden completion commands are what a shell actually invokes on
+	// every tab press, so they matter more than the visible "completion"
+	// command and are looked up by their cobra constants.
+	// Cobra attaches them to the root at Execute time, which is too late to
+	// look up here, so they are reproduced as direct children of a throwaway
+	// root exactly as cobra attaches them.
+	for _, name := range []string{cobra.ShellCompRequestCmd, cobra.ShellCompNoDescRequestCmd} {
+		t.Run(name, func(t *testing.T) {
+			fakeRoot := &cobra.Command{Use: "deputy"}
+			hidden := &cobra.Command{Use: name}
+			fakeRoot.AddCommand(hidden)
+			if !runsWithoutConfig(hidden) {
+				t.Errorf("runsWithoutConfig(%s) = false, want true; shell tab completion would error on a broken config", name)
+			}
+		})
+	}
 
-		if inConfigCommandTree(nested) {
-			t.Error("inConfigCommandTree(deputy proxy config) = true, want false")
+	// The allowlist keys on the top-level command, not on the name alone, so a
+	// command that shares an exempt name but hangs off something else must not
+	// pick up the exemption.
+	t.Run("nested command named config is not exempt", func(t *testing.T) {
+		nested := nestedCommand(t, "proxy", "config")
+		if runsWithoutConfig(nested) {
+			t.Error("runsWithoutConfig(deputy proxy config) = true, want false")
+		}
+	})
+	t.Run("nested command named version is not exempt", func(t *testing.T) {
+		nested := nestedCommand(t, "policy", "version")
+		if runsWithoutConfig(nested) {
+			t.Error("runsWithoutConfig(deputy policy version) = true, want false")
 		}
 	})
 }
 
+// nestedCommand builds a throwaway root -> parent -> child tree and returns the
+// child, for checking that an exempt name does not confer the exemption when it
+// appears below the top level.
+func nestedCommand(t *testing.T, parentName, childName string) *cobra.Command {
+	t.Helper()
+	root := &cobra.Command{Use: "deputy"}
+	parent := &cobra.Command{Use: parentName}
+	child := &cobra.Command{Use: childName}
+	parent.AddCommand(child)
+	root.AddCommand(parent)
+	return child
+}
+
+// TestRootConfigGateByCommand runs the real commands against a real broken
+// config file, so the allowlist is pinned where it actually takes effect rather
+// than only at the predicate. Exempt commands must succeed; gated commands must
+// fail with the config error itself, not with some incidental error that would
+// mask a gate that stopped firing.
+func TestRootConfigGateByCommand(t *testing.T) {
+	isolatedConfigDir(t)
+	writeConfigFile(t, "logging:\n  level: shouty\n")
+
+	_, cfgErr := loadRuntimeConfig()
+	if cfgErr == nil {
+		t.Fatal("loadRuntimeConfig() error = nil; fixture is not broken")
+	}
+
+	tests := []struct {
+		name string
+		args []string
+		// wantRefused is true for commands the config gate must stop.
+		wantRefused bool
+	}{
+		{name: "version", args: []string{"version"}},
+		{name: "completion zsh", args: []string{"completion", "zsh"}},
+		{name: "completion bash", args: []string{"completion", "bash"}},
+		{name: "help", args: []string{"help"}},
+		{name: "help for a gated command", args: []string{"help", "list"}},
+		{name: "config path", args: []string{"config", "path"}},
+		{name: "hidden completion", args: []string{cobra.ShellCompRequestCmd, "list", ""}},
+
+		{name: "list", args: []string{"list", "."}, wantRefused: true},
+		{name: "scan", args: []string{"scan", "."}, wantRefused: true},
+		{name: "server", args: []string{"server", "--addr", "127.0.0.1:0"}, wantRefused: true},
+		{name: "diff", args: []string{"diff"}, wantRefused: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// A gated command that is wrongly allowed through would otherwise
+			// run for real (server blocks forever, scan reaches the network),
+			// so bound every case rather than trusting the gate under test.
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			err := executeRootWithConfigErr(t, ctx, cfgErr, test.args...)
+
+			if test.wantRefused {
+				if !errors.Is(err, cfgErr) {
+					t.Errorf("%v error = %v, want the config load error; the command ran on defaults instead of being refused", test.args, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("%v failed with an unloadable config: %v; this command must keep working so the failure can be diagnosed", test.args, err)
+			}
+		})
+	}
+}
+
 // executeRootWithConfigErr builds the root command the way Run does, with a
 // pending config error, and executes args against it with output discarded.
-func executeRootWithConfigErr(t *testing.T, configErr error, args ...string) error {
+func executeRootWithConfigErr(t *testing.T, ctx context.Context, configErr error, args ...string) error {
 	t.Helper()
 	root := newRoot(configErr)
 	root.SetArgs(args)
 	root.SetOut(io.Discard)
 	root.SetErr(io.Discard)
-	return root.ExecuteContext(context.Background())
+	return root.ExecuteContext(ctx)
 }

--- a/internal/cli/config_load_test.go
+++ b/internal/cli/config_load_test.go
@@ -46,11 +46,15 @@ func TestLoadRuntimeConfig(t *testing.T) {
 	tests := []struct {
 		name string
 		// writeFile is false for the absent-config case.
-		writeFile   bool
-		contents    string
-		wantErr     bool
-		wantErrHas  []string
-		checkConfig func(t *testing.T, cfg *config.Config)
+		writeFile bool
+		contents  string
+		// env is applied after the isolating setup, for the case where the
+		// environment rather than a file carries the bad value.
+		env               map[string]string
+		wantErr           bool
+		wantErrHas        []string
+		wantSuggestionHas string
+		checkConfig       func(t *testing.T, cfg *config.Config)
 	}{
 		{
 			name:      "no config file loads defaults without error",
@@ -71,14 +75,26 @@ func TestLoadRuntimeConfig(t *testing.T) {
 			wantErr:   true,
 			// The path must be named: the offending file can live in the
 			// home directory, far from where the command was run.
-			wantErrHas: []string{"failed to load config from", ".deputy.yaml", "failed to parse config file"},
+			wantErrHas:        []string{"failed to load config from", ".deputy.yaml", "failed to parse config file"},
+			wantSuggestionHas: "deputy config validate",
 		},
 		{
-			name:       "valid yaml with an invalid value is an error",
-			writeFile:  true,
-			contents:   "logging:\n  level: shouty\n",
-			wantErr:    true,
-			wantErrHas: []string{"failed to load config from", ".deputy.yaml", "validation failed for logging.level"},
+			name:              "valid yaml with an invalid value is an error",
+			writeFile:         true,
+			contents:          "logging:\n  level: shouty\n",
+			wantErr:           true,
+			wantErrHas:        []string{"failed to load config from", ".deputy.yaml", "validation failed for logging.level"},
+			wantSuggestionHas: "deputy config validate",
+		},
+		{
+			// With no file to blame, the error must not point at
+			// 'config validate', which only reads files.
+			name:              "invalid environment value is an error without a file",
+			writeFile:         false,
+			env:               map[string]string{"DEPUTY_LOG_LEVEL": "shouty"},
+			wantErr:           true,
+			wantErrHas:        []string{"failed to load config", "validation failed for logging.level"},
+			wantSuggestionHas: "DEPUTY_* environment variables",
 		},
 		{
 			name:      "valid config is loaded and honored",
@@ -108,6 +124,9 @@ func TestLoadRuntimeConfig(t *testing.T) {
 			if test.writeFile {
 				writeConfigFile(t, test.contents)
 			}
+			for k, v := range test.env {
+				t.Setenv(k, v)
+			}
 
 			cfg, err := loadRuntimeConfig()
 
@@ -123,8 +142,8 @@ func TestLoadRuntimeConfig(t *testing.T) {
 						t.Errorf("error %q does not contain %q", err.Error(), want)
 					}
 				}
-				if got := deputyerrors.GetSuggestion(err); !strings.Contains(got, "deputy config validate") {
-					t.Errorf("suggestion = %q, want it to point at 'deputy config validate'", got)
+				if got := deputyerrors.GetSuggestion(err); !strings.Contains(got, test.wantSuggestionHas) {
+					t.Errorf("suggestion = %q, want it to contain %q", got, test.wantSuggestionHas)
 				}
 				return
 			}
@@ -277,6 +296,21 @@ func TestInConfigCommandTree(t *testing.T) {
 			}
 		})
 	}
+
+	// The exemption keys on the top-level config command, not on the name
+	// alone, so a command named "config" nested under something else must not
+	// pick it up and become runnable on a config file that failed to load.
+	t.Run("nested command named config is not exempt", func(t *testing.T) {
+		fake := &cobra.Command{Use: "deputy"}
+		proxy := &cobra.Command{Use: "proxy"}
+		nested := &cobra.Command{Use: "config"}
+		proxy.AddCommand(nested)
+		fake.AddCommand(proxy)
+
+		if inConfigCommandTree(nested) {
+			t.Error("inConfigCommandTree(deputy proxy config) = true, want false")
+		}
+	})
 }
 
 // executeRootWithConfigErr builds the root command the way Run does, with a

--- a/internal/cli/config_load_test.go
+++ b/internal/cli/config_load_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -240,6 +241,122 @@ func TestLoadRuntimeConfigExplicitPath(t *testing.T) {
 			}
 			if len(cfg.AdvisorySources) != 1 || cfg.AdvisorySources[0].URL != pinnedSource {
 				t.Errorf("AdvisorySources = %+v, want the source pinned by the explicit file", cfg.AdvisorySources)
+			}
+		})
+	}
+}
+
+// TestLoggingFlagOverrides pins the early scrape of the logging flags. It has
+// to find a flag in every form cobra accepts, or configuration is validated
+// against an environment value the user already overrode; it has to ignore
+// everything after "--", or a passthrough command's own flags would be read as
+// Deputy's.
+func TestLoggingFlagOverrides(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want map[string]string
+	}{
+		{
+			name: "no logging flags",
+			args: []string{"list", "."},
+			want: map[string]string{},
+		},
+		{
+			name: "equals form",
+			args: []string{"list", ".", "--log-level=debug"},
+			want: map[string]string{"log-level": "debug"},
+		},
+		{
+			name: "space form",
+			args: []string{"list", ".", "--log-level", "debug"},
+			want: map[string]string{"log-level": "debug"},
+		},
+		{
+			name: "before the subcommand",
+			args: []string{"--log-level", "debug", "list", "."},
+			want: map[string]string{"log-level": "debug"},
+		},
+		{
+			name: "alongside an unknown flag that takes a value",
+			args: []string{"--server", "https://x.example.com", "--log-level", "debug", "list"},
+			want: map[string]string{"log-level": "debug"},
+		},
+		{
+			name: "both flags",
+			args: []string{"scan", "--log-level=warn", "--log-format=json"},
+			want: map[string]string{"log-level": "warn", "log-format": "json"},
+		},
+		{
+			// The inner flag belongs to npm, not to Deputy. Reading it would
+			// let an unrelated argument satisfy Deputy's config validation.
+			name: "not scraped from a passthrough after the terminator",
+			args: []string{"proxy", "npm", "--", "npm", "install", "--log-level=silly"},
+			want: map[string]string{},
+		},
+		{
+			name: "explicitly empty flag is recorded but means no choice",
+			args: []string{"list", "--log-level="},
+			want: map[string]string{"log-level": ""},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := loggingFlagOverrides(test.args)
+			if !maps.Equal(got, test.want) {
+				t.Errorf("loggingFlagOverrides(%v) = %v, want %v", test.args, got, test.want)
+			}
+		})
+	}
+}
+
+// TestLoadRuntimeConfigHonorsFlagPrecedence proves the scrape is actually wired
+// into the load, end to end: an invalid DEPUTY_LOG_LEVEL that the command line
+// overrides must not make the command fatal, because flags outrank the
+// environment. This regressed once already.
+func TestLoadRuntimeConfigHonorsFlagPrecedence(t *testing.T) {
+	tests := []struct {
+		name    string
+		argv    []string
+		wantErr bool
+	}{
+		{
+			name:    "flag overrides the invalid environment value",
+			argv:    []string{"deputy", "list", ".", "--log-level=debug"},
+			wantErr: false,
+		},
+		{
+			name:    "no override leaves the invalid value fatal",
+			argv:    []string{"deputy", "list", "."},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			isolatedConfigDir(t)
+			t.Setenv("DEPUTY_LOG_LEVEL", "shouty")
+
+			// loadRuntimeConfig reads the real argv, since it runs before
+			// cobra parses anything.
+			original := os.Args
+			t.Cleanup(func() { os.Args = original })
+			os.Args = test.argv
+
+			cfg, err := loadRuntimeConfig()
+
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("loadRuntimeConfig() error = nil, want an error; cfg = %+v", cfg)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("loadRuntimeConfig() error = %v, want nil: the flag outranks DEPUTY_LOG_LEVEL", err)
+			}
+			if cfg.Logging.Level != "debug" {
+				t.Errorf("Logging.Level = %q, want %q", cfg.Logging.Level, "debug")
 			}
 		})
 	}

--- a/internal/cli/config_load_test.go
+++ b/internal/cli/config_load_test.go
@@ -645,6 +645,97 @@ func nestedCommand(t *testing.T, parentName, childName string) *cobra.Command {
 	return child
 }
 
+// TestRootConfigGateBySource pins exemption as a property that holds across
+// every way configuration can be broken, not just the one the gate happens to
+// check. An invalid logging value in the environment used to take down the
+// exempt commands anyway, because the gate skipped its own error and then
+// logging setup failed on the same value: exempt in one branch and not in the
+// next is not exempt.
+func TestRootConfigGateBySource(t *testing.T) {
+	sources := []struct {
+		name string
+		// apply breaks the configuration in one specific way.
+		apply func(t *testing.T)
+	}{
+		{
+			name: "unparseable file",
+			apply: func(t *testing.T) {
+				writeConfigFile(t, "logging:\n  level: \"unclosed\n   bogus: [1, 2\n")
+			},
+		},
+		{
+			name: "invalid value in file",
+			apply: func(t *testing.T) {
+				writeConfigFile(t, "logging:\n  level: shouty\n")
+			},
+		},
+		{
+			name: "invalid value in environment",
+			apply: func(t *testing.T) {
+				t.Setenv("DEPUTY_LOG_LEVEL", "shouty")
+			},
+		},
+		{
+			name: "invalid format in environment",
+			apply: func(t *testing.T) {
+				t.Setenv("DEPUTY_LOG_FORMAT", "bogus")
+			},
+		},
+		{
+			name: "both file and environment broken",
+			apply: func(t *testing.T) {
+				writeConfigFile(t, "logging:\n  level: shouty\n")
+				t.Setenv("DEPUTY_LOG_LEVEL", "alsoshouty")
+			},
+		},
+	}
+
+	commands := []struct {
+		name string
+		args []string
+		// wantRefused is true for commands the gate must stop whatever the
+		// source of the breakage.
+		wantRefused bool
+	}{
+		{name: "version", args: []string{"version"}},
+		{name: "help", args: []string{"help"}},
+		{name: "completion zsh", args: []string{"completion", "zsh"}},
+		{name: "config path", args: []string{"config", "path"}},
+		{name: "hidden completion", args: []string{cobra.ShellCompRequestCmd, "list", ""}},
+
+		{name: "list", args: []string{"list", "."}, wantRefused: true},
+		{name: "diff", args: []string{"diff"}, wantRefused: true},
+	}
+
+	for _, source := range sources {
+		for _, command := range commands {
+			t.Run(source.name+"/"+command.name, func(t *testing.T) {
+				isolatedConfigDir(t)
+				source.apply(t)
+
+				cfg, cfgErr := loadRuntimeConfig()
+				if cfgErr == nil && cfg == nil {
+					t.Fatal("loadRuntimeConfig returned neither a config nor an error")
+				}
+
+				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+				defer cancel()
+				err := executeRootWithConfigErr(t, ctx, cfgErr, command.args...)
+
+				if command.wantRefused {
+					if err == nil {
+						t.Errorf("%v succeeded with a broken configuration; it ran on defaults instead of being refused", command.args)
+					}
+					return
+				}
+				if err != nil {
+					t.Errorf("%v failed with a broken configuration: %v; exempt commands must work in exactly this state", command.args, err)
+				}
+			})
+		}
+	}
+}
+
 // TestRootConfigGateByCommand runs the real commands against a real broken
 // config file, so the allowlist is pinned where it actually takes effect rather
 // than only at the predicate. Exempt commands must succeed; gated commands must

--- a/internal/cli/root_flags_test.go
+++ b/internal/cli/root_flags_test.go
@@ -60,7 +60,7 @@ func chdirToGoModFixture(t *testing.T) {
 // ignore: they assert on where the RPC landed, not on the RPC succeeding.
 func executeRoot(t *testing.T, args ...string) error {
 	t.Helper()
-	root := newRoot()
+	root := newRoot(nil)
 	root.SetArgs(args)
 	root.SetOut(io.Discard)
 	root.SetErr(io.Discard)

--- a/internal/cli/root_flags_test.go
+++ b/internal/cli/root_flags_test.go
@@ -60,7 +60,7 @@ func chdirToGoModFixture(t *testing.T) {
 // ignore: they assert on where the RPC landed, not on the RPC succeeding.
 func executeRoot(t *testing.T, args ...string) error {
 	t.Helper()
-	root := newRoot(nil)
+	root := newRoot(nil, nil)
 	root.SetArgs(args)
 	root.SetOut(io.Discard)
 	root.SetErr(io.Discard)

--- a/internal/cli/root_flags_test.go
+++ b/internal/cli/root_flags_test.go
@@ -60,7 +60,7 @@ func chdirToGoModFixture(t *testing.T) {
 // ignore: they assert on where the RPC landed, not on the RPC succeeding.
 func executeRoot(t *testing.T, args ...string) error {
 	t.Helper()
-	root := newRoot(nil, nil)
+	root := newRoot(runtimeConfig{})
 	root.SetArgs(args)
 	root.SetOut(io.Discard)
 	root.SetErr(io.Discard)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -610,6 +610,15 @@ func NewLoader(configPath string) *Loader {
 // Load reads configuration from all sources and applies precedence rules.
 // Precedence: explicit flags > environment variables > config file > defaults.
 func (l *Loader) Load() (*Config, error) {
+	return l.LoadWithOverrides(nil)
+}
+
+// LoadWithOverrides loads config and applies explicit flag overrides.
+// Overrides are applied before validation, not after, because they sit at the
+// top of the precedence order: a flag the user passed has to be able to correct
+// an invalid value coming from the environment or the file, rather than being
+// rejected by the value it replaces.
+func (l *Loader) LoadWithOverrides(overrides map[string]string) (*Config, error) {
 	cfg := defaultConfig()
 
 	// 1. Load from config file if provided
@@ -622,7 +631,10 @@ func (l *Loader) Load() (*Config, error) {
 	// 2. Override with environment variables
 	l.loadFromEnv(cfg)
 
-	// 3. Validate the final configuration
+	// 3. Apply explicit flag overrides (highest precedence)
+	applyOverrides(cfg, overrides)
+
+	// 4. Validate the fully merged configuration
 	if err := cfg.Validate(); err != nil {
 		return nil, err
 	}
@@ -630,14 +642,13 @@ func (l *Loader) Load() (*Config, error) {
 	return cfg, nil
 }
 
-// LoadWithOverrides loads config and applies explicit flag overrides.
-func (l *Loader) LoadWithOverrides(overrides map[string]string) (*Config, error) {
-	cfg, err := l.Load()
-	if err != nil {
-		return nil, err
+// applyOverrides copies explicit flag values over the merged configuration. An
+// override that is present but empty is ignored: an empty flag value means the
+// user did not choose a setting, so the lower-precedence source stands.
+func applyOverrides(cfg *Config, overrides map[string]string) {
+	if len(overrides) == 0 {
+		return
 	}
-
-	// Apply explicit flag overrides (highest precedence)
 	if level, ok := overrides["log-level"]; ok && level != "" {
 		cfg.Logging.Level = level
 	}
@@ -647,8 +658,6 @@ func (l *Loader) LoadWithOverrides(overrides map[string]string) (*Config, error)
 	if color, ok := overrides["log-color"]; ok {
 		cfg.Logging.Color = color == "true" || color == "1"
 	}
-
-	return cfg, nil
 }
 
 // loadFromFile reads configuration from a YAML file.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ package config
 import (
 	"fmt"
 	"log/slog"
+	"maps"
 	"net/netip"
 	"os"
 	"path/filepath"
@@ -607,18 +608,28 @@ func NewLoader(configPath string) *Loader {
 	}
 }
 
-// Load reads configuration from all sources and applies precedence rules.
-// Precedence: explicit flags > environment variables > config file > defaults.
+// Load reads configuration from all sources and validates the merged result.
+// It is for callers that have no flags to contribute; a caller that does must
+// use LoadMerged, apply its overrides, and validate, so that a flag can correct
+// a value the environment or the file got wrong.
 func (l *Loader) Load() (*Config, error) {
-	return l.LoadWithOverrides(nil)
+	cfg, err := l.LoadMerged()
+	if err != nil {
+		return nil, err
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return cfg, nil
 }
 
-// LoadWithOverrides loads config and applies explicit flag overrides.
-// Overrides are applied before validation, not after, because they sit at the
-// top of the precedence order: a flag the user passed has to be able to correct
-// an invalid value coming from the environment or the file, rather than being
-// rejected by the value it replaces.
-func (l *Loader) LoadWithOverrides(overrides map[string]string) (*Config, error) {
+// LoadMerged reads the config file and the environment and returns the merged
+// result without validating it. Validation is left to the caller because the
+// merged value is not yet the effective one: flags outrank both sources, and
+// validating before they are known rejects values the invocation has already
+// replaced. The error it does return covers the sources it can judge on its
+// own, a file that cannot be read or parsed, which no flag can correct.
+func (l *Loader) LoadMerged() (*Config, error) {
 	cfg := defaultConfig()
 
 	// 1. Load from config file if provided
@@ -631,33 +642,101 @@ func (l *Loader) LoadWithOverrides(overrides map[string]string) (*Config, error)
 	// 2. Override with environment variables
 	l.loadFromEnv(cfg)
 
-	// 3. Apply explicit flag overrides (highest precedence)
-	applyOverrides(cfg, overrides)
-
-	// 4. Validate the fully merged configuration
-	if err := cfg.Validate(); err != nil {
-		return nil, err
-	}
-
 	return cfg, nil
 }
 
-// applyOverrides copies explicit flag values over the merged configuration. An
-// override that is present but empty is ignored: an empty flag value means the
-// user did not choose a setting, so the lower-precedence source stands.
-func applyOverrides(cfg *Config, overrides map[string]string) {
-	if len(overrides) == 0 {
+// Overrides carries the values an invocation set explicitly on the command
+// line, keyed by the flag name the CLI declares. Values are slices because a
+// repeatable flag such as --egress-allow-cidr carries several; a scalar flag
+// contributes a single element.
+//
+// The map is deliberately untyped and open: the CLI hands over every flag the
+// user changed without knowing which ones configuration cares about, and
+// ApplyOverrides picks out the ones it understands. That keeps the list of
+// override-capable flags in one place, next to the fields it writes, instead of
+// spread across the command tree where it drifts.
+type Overrides map[string][]string
+
+// overrideAppliers maps a CLI flag name to the configuration it replaces. It is
+// the one list of override-capable flags, and it lives next to the fields it
+// writes rather than in the command tree, so it can be checked in one place.
+//
+// A field that Config.Validate can reject and a flag can replace has to appear
+// here. Leaving one out means validation judges a value the invocation already
+// corrected, which is how a valid --egress-allow-cidr came to be rejected by
+// the config file it was replacing.
+//
+// Each applier writes a different field, so the order they run in does not
+// matter.
+var overrideAppliers = map[string]func(cfg *Config, values []string){
+	"log-level": func(cfg *Config, values []string) {
+		if level := scalar(values); level != "" {
+			cfg.Logging.Level = level
+		}
+	},
+	"log-format": func(cfg *Config, values []string) {
+		if format := scalar(values); format != "" {
+			cfg.Logging.Format = format
+		}
+	},
+	// The server command replaces the configured egress allowlists wholesale
+	// rather than adding to them, so the flag decides whether the merged value
+	// is valid.
+	"egress-allow-cidr": func(cfg *Config, values []string) {
+		serverEgress(cfg).AllowedCIDRs = values
+	},
+	"egress-allow-host": func(cfg *Config, values []string) {
+		serverEgress(cfg).AllowedHosts = values
+	},
+}
+
+// scalar returns the value of a scalar flag override, empty when it carried
+// none.
+func scalar(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	return values[0]
+}
+
+// ApplyOverrides copies explicit flag values over the merged configuration, so
+// that validation and every later reader see what the invocation actually asked
+// for. It must run before Config.Validate: an override sits at the top of the
+// precedence order, so a flag the user passed has to be able to correct an
+// invalid value coming from the environment or the file rather than being
+// rejected by the value it replaces.
+//
+// A scalar override that is present but empty is ignored: an empty flag value
+// means the user did not choose a setting, so the lower-precedence source
+// stands. Flag names with no applier are ignored, since most flags configure a
+// command rather than the configuration.
+func ApplyOverrides(cfg *Config, overrides Overrides) {
+	if cfg == nil || len(overrides) == 0 {
 		return
 	}
-	if level, ok := overrides["log-level"]; ok && level != "" {
-		cfg.Logging.Level = level
+	for name, apply := range overrideAppliers {
+		if values, ok := overrides[name]; ok {
+			apply(cfg, values)
+		}
 	}
-	if format, ok := overrides["log-format"]; ok && format != "" {
-		cfg.Logging.Format = format
+}
+
+// OverrideFlagNames returns the flag names ApplyOverrides acts on, sorted. It
+// exists so a test can check each one against the flags the CLI declares: an
+// override keyed on a flag that was renamed or removed stops applying without a
+// word, and the lower-precedence value it existed to correct starts winning
+// again.
+func OverrideFlagNames() []string {
+	return slices.Sorted(maps.Keys(overrideAppliers))
+}
+
+// serverEgress returns the server egress block, allocating it when the merged
+// configuration did not carry one, so an override has somewhere to land.
+func serverEgress(cfg *Config) *ServerEgressConfig {
+	if cfg.Server.Egress == nil {
+		cfg.Server.Egress = &ServerEgressConfig{}
 	}
-	if color, ok := overrides["log-color"]; ok {
-		cfg.Logging.Color = color == "true" || color == "1"
-	}
+	return cfg.Server.Egress
 }
 
 // loadFromFile reads configuration from a YAML file.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1393,8 +1393,33 @@ func (lc LogConfig) ToSlogLevel() slog.Level {
 	}
 }
 
+// ResolveConfigFile reports which config file to load, and fails when one was
+// explicitly requested but cannot be used. DEPUTY_CONFIG names a specific file,
+// so a path that cannot be stated is an error rather than a cue to look
+// elsewhere: discarding it silently hands the caller an auto-discovered file,
+// or no configuration at all, in place of the one it asked for. An empty path
+// with a nil error means no config file was requested and none was discovered,
+// which is normal.
+//
+// FindConfigFile keeps the lenient behavior for callers that are reporting on
+// configuration rather than acting on it.
+func ResolveConfigFile() (string, error) {
+	if path := os.Getenv("DEPUTY_CONFIG"); path != "" {
+		if _, err := os.Stat(path); err != nil {
+			return "", &errors.ConfigError{
+				Path:    path,
+				Message: "config file named by DEPUTY_CONFIG is unavailable",
+				Cause:   err,
+			}
+		}
+		return path, nil
+	}
+	return FindConfigFile(), nil
+}
+
 // FindConfigFile searches for a config file in standard locations.
-// Returns the path if found, empty string otherwise.
+// Returns the path if found, empty string otherwise. An unusable DEPUTY_CONFIG
+// is ignored here; use [ResolveConfigFile] when that must be an error.
 func FindConfigFile() string {
 	// Check explicit DEPUTY_CONFIG env var first
 	if path := os.Getenv("DEPUTY_CONFIG"); path != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 )
@@ -234,17 +235,17 @@ policy:
 	}
 }
 
-func TestLoadWithOverrides(t *testing.T) {
-	loader := NewLoader("")
-	overrides := map[string]string{
-		"log-level":  "error",
-		"log-format": "json",
-		"log-color":  "false",
-	}
-
-	cfg, err := loader.LoadWithOverrides(overrides)
+func TestApplyOverrides(t *testing.T) {
+	cfg, err := NewLoader("").LoadMerged()
 	if err != nil {
-		t.Fatalf("LoadWithOverrides failed: %v", err)
+		t.Fatalf("LoadMerged failed: %v", err)
+	}
+	ApplyOverrides(cfg, Overrides{
+		"log-level":  {"error"},
+		"log-format": {"json"},
+	})
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate failed: %v", err)
 	}
 
 	if cfg.Logging.Level != "error" {
@@ -252,9 +253,6 @@ func TestLoadWithOverrides(t *testing.T) {
 	}
 	if cfg.Logging.Format != "json" {
 		t.Errorf("expected log format 'json', got %q", cfg.Logging.Format)
-	}
-	if cfg.Logging.Color != false {
-		t.Errorf("expected log color false, got true")
 	}
 }
 
@@ -286,10 +284,13 @@ logging:
 	}
 
 	// Test flag overrides env
-	overrides := map[string]string{"log-level": "debug"}
-	cfg, err = loader.LoadWithOverrides(overrides)
+	cfg, err = loader.LoadMerged()
 	if err != nil {
-		t.Fatalf("LoadWithOverrides failed: %v", err)
+		t.Fatalf("LoadMerged failed: %v", err)
+	}
+	ApplyOverrides(cfg, Overrides{"log-level": {"debug"}})
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate failed: %v", err)
 	}
 	if cfg.Logging.Level != "debug" {
 		t.Errorf("expected flag to override env: got level %q", cfg.Logging.Level)
@@ -800,31 +801,38 @@ performance:
 	}
 }
 
-// TestLoadWithOverridesBeforeValidation pins the precedence the reference
-// documents: a flag outranks the environment, so an explicit flag has to be
-// able to correct an invalid environment value rather than being rejected by
-// it. Applying overrides after validation, as this used to, made the highest
-// precedence source unable to fix the one below it.
-func TestLoadWithOverridesBeforeValidation(t *testing.T) {
+// TestApplyOverridesBeforeValidation pins the precedence the reference
+// documents: a flag outranks the environment and the file, so an explicit flag
+// has to be able to correct an invalid lower-precedence value rather than being
+// rejected by it. Validating before the overrides land, as this used to, made
+// the highest precedence source unable to fix the ones below it, and it did so
+// for every override-capable flag, not just the logging ones.
+func TestApplyOverridesBeforeValidation(t *testing.T) {
+	// badCIDRFile carries a server egress allowlist the loader cannot parse,
+	// which is the shape the server command's --egress-allow-cidr replaces.
+	badCIDRFile := "server:\n  egress:\n    allowed_cidrs:\n      - \"not-a-cidr\"\n"
+
 	tests := []struct {
 		name      string
+		file      string
 		env       map[string]string
-		overrides map[string]string
+		overrides Overrides
 		wantErr   bool
 		wantLevel string
 		wantFmt   string
+		wantCIDRs []string
 	}{
 		{
 			name:      "flag corrects an invalid environment level",
 			env:       map[string]string{"DEPUTY_LOG_LEVEL": "shouty"},
-			overrides: map[string]string{"log-level": "debug"},
+			overrides: Overrides{"log-level": {"debug"}},
 			wantLevel: "debug",
 			wantFmt:   "text",
 		},
 		{
 			name:      "flag corrects an invalid environment format",
 			env:       map[string]string{"DEPUTY_LOG_FORMAT": "bogus"},
-			overrides: map[string]string{"log-format": "json"},
+			overrides: Overrides{"log-format": {"json"}},
 			wantLevel: "info",
 			wantFmt:   "json",
 		},
@@ -836,20 +844,39 @@ func TestLoadWithOverridesBeforeValidation(t *testing.T) {
 		{
 			name:      "an override for a different field does not rescue it",
 			env:       map[string]string{"DEPUTY_LOG_LEVEL": "shouty"},
-			overrides: map[string]string{"log-format": "json"},
+			overrides: Overrides{"log-format": {"json"}},
 			wantErr:   true,
 		},
 		{
 			name:      "an invalid override is itself rejected",
-			overrides: map[string]string{"log-level": "nope"},
+			overrides: Overrides{"log-level": {"nope"}},
 			wantErr:   true,
 		},
 		{
 			name:      "an empty override leaves the lower source in place",
 			env:       map[string]string{"DEPUTY_LOG_LEVEL": "error"},
-			overrides: map[string]string{"log-level": ""},
+			overrides: Overrides{"log-level": {""}},
 			wantLevel: "error",
 			wantFmt:   "text",
+		},
+		{
+			name:      "a repeatable flag corrects an invalid file CIDR",
+			file:      badCIDRFile,
+			overrides: Overrides{"egress-allow-cidr": {"10.0.0.0/8", "192.168.0.0/16"}},
+			wantLevel: "info",
+			wantFmt:   "text",
+			wantCIDRs: []string{"10.0.0.0/8", "192.168.0.0/16"},
+		},
+		{
+			name:    "an invalid file CIDR stands without the flag",
+			file:    badCIDRFile,
+			wantErr: true,
+		},
+		{
+			name:      "an invalid repeatable flag is itself rejected",
+			file:      badCIDRFile,
+			overrides: Overrides{"egress-allow-cidr": {"also-not-a-cidr"}},
+			wantErr:   true,
 		},
 	}
 
@@ -861,22 +888,41 @@ func TestLoadWithOverridesBeforeValidation(t *testing.T) {
 				t.Setenv(k, v)
 			}
 
-			cfg, err := NewLoader("").LoadWithOverrides(test.overrides)
+			path := ""
+			if test.file != "" {
+				path = filepath.Join(t.TempDir(), "deputy.yaml")
+				if err := os.WriteFile(path, []byte(test.file), 0o644); err != nil {
+					t.Fatalf("write config file: %v", err)
+				}
+			}
+
+			cfg, err := NewLoader(path).LoadMerged()
+			if err != nil {
+				t.Fatalf("LoadMerged() error = %v, want nil", err)
+			}
+			ApplyOverrides(cfg, test.overrides)
+			err = cfg.Validate()
 
 			if test.wantErr {
 				if err == nil {
-					t.Fatalf("LoadWithOverrides() error = nil, want an error; cfg = %+v", cfg)
+					t.Fatalf("Validate() error = nil, want an error; cfg = %+v", cfg)
 				}
 				return
 			}
 			if err != nil {
-				t.Fatalf("LoadWithOverrides() error = %v, want nil", err)
+				t.Fatalf("Validate() error = %v, want nil", err)
 			}
 			if cfg.Logging.Level != test.wantLevel {
 				t.Errorf("Logging.Level = %q, want %q", cfg.Logging.Level, test.wantLevel)
 			}
 			if cfg.Logging.Format != test.wantFmt {
 				t.Errorf("Logging.Format = %q, want %q", cfg.Logging.Format, test.wantFmt)
+			}
+			if test.wantCIDRs != nil {
+				got := serverEgressCIDRs(cfg.Server.Egress)
+				if !slices.Equal(got, test.wantCIDRs) {
+					t.Errorf("Server.Egress.AllowedCIDRs = %v, want %v", got, test.wantCIDRs)
+				}
 			}
 		})
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -799,3 +799,85 @@ performance:
 		t.Errorf("expected cache max size 512, got %d", cfg.Performance.Cache.MaxSize)
 	}
 }
+
+// TestLoadWithOverridesBeforeValidation pins the precedence the reference
+// documents: a flag outranks the environment, so an explicit flag has to be
+// able to correct an invalid environment value rather than being rejected by
+// it. Applying overrides after validation, as this used to, made the highest
+// precedence source unable to fix the one below it.
+func TestLoadWithOverridesBeforeValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		env       map[string]string
+		overrides map[string]string
+		wantErr   bool
+		wantLevel string
+		wantFmt   string
+	}{
+		{
+			name:      "flag corrects an invalid environment level",
+			env:       map[string]string{"DEPUTY_LOG_LEVEL": "shouty"},
+			overrides: map[string]string{"log-level": "debug"},
+			wantLevel: "debug",
+			wantFmt:   "text",
+		},
+		{
+			name:      "flag corrects an invalid environment format",
+			env:       map[string]string{"DEPUTY_LOG_FORMAT": "bogus"},
+			overrides: map[string]string{"log-format": "json"},
+			wantLevel: "info",
+			wantFmt:   "json",
+		},
+		{
+			name:    "invalid environment value stands without an override",
+			env:     map[string]string{"DEPUTY_LOG_LEVEL": "shouty"},
+			wantErr: true,
+		},
+		{
+			name:      "an override for a different field does not rescue it",
+			env:       map[string]string{"DEPUTY_LOG_LEVEL": "shouty"},
+			overrides: map[string]string{"log-format": "json"},
+			wantErr:   true,
+		},
+		{
+			name:      "an invalid override is itself rejected",
+			overrides: map[string]string{"log-level": "nope"},
+			wantErr:   true,
+		},
+		{
+			name:      "an empty override leaves the lower source in place",
+			env:       map[string]string{"DEPUTY_LOG_LEVEL": "error"},
+			overrides: map[string]string{"log-level": ""},
+			wantLevel: "error",
+			wantFmt:   "text",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("DEPUTY_LOG_LEVEL", "")
+			t.Setenv("DEPUTY_LOG_FORMAT", "")
+			for k, v := range test.env {
+				t.Setenv(k, v)
+			}
+
+			cfg, err := NewLoader("").LoadWithOverrides(test.overrides)
+
+			if test.wantErr {
+				if err == nil {
+					t.Fatalf("LoadWithOverrides() error = nil, want an error; cfg = %+v", cfg)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("LoadWithOverrides() error = %v, want nil", err)
+			}
+			if cfg.Logging.Level != test.wantLevel {
+				t.Errorf("Logging.Level = %q, want %q", cfg.Logging.Level, test.wantLevel)
+			}
+			if cfg.Logging.Format != test.wantFmt {
+				t.Errorf("Logging.Format = %q, want %q", cfg.Logging.Format, test.wantFmt)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #251.

`loadRuntimeConfig` discarded the error from loading `.deputy.yaml` and returned nil, so a malformed or invalid config file produced no diagnostic and every control it configured silently reverted to defaults. A config file that exists and cannot be honored is now fatal. A missing config file stays silent, which is the normal case.

## Reviewer notes, in order

**1. The issue's central claim was wrong and the PR does not repeat it.** I wrote that a deployment restricting egress would get unrestricted egress. That is inverted. `EgressConfig` is a list of relaxations: `internal/network/safedialer.go:88-90` documents `AllowedHosts` as "hostnames allowed to resolve to private IPs" and `isAllowedHost` returns false when the list is empty, so losing the config makes Deputy more restrictive, not less. The issue has been corrected with a dated retraction.

The consequence with real security weight is `advisory_sources`: a deployment that pinned its vulnerability data to an internal mirror silently queries the public defaults instead. Confirmed behaviorally, not just read: with a valid config the configured source was contacted, and with the same file plus one syntax error the access log was empty while `deputy scan` exited 0 and reported 52 findings from default sources. `otel` goes the same way, so a deployment that believes it exports traces exports nothing. The egress loss is a broken deployment, allowlisted internal hosts becoming unreachable, which is worth fixing but is not a weakened control.

**2. What must still work when the config cannot load.** The exemption list is `config`, `version`, `completion`, `help`, and cobra's hidden `__complete` / `__completeNoDesc`.

`__complete` is the one worth knowing about: it is what a shell invokes on **every tab press**, so gating it meant a broken `.deputy.yaml` in the working directory injected an error into the terminal on each one. Exempting only the visible `completion` command would have fixed shell setup and left interactive completion broken. `help` needed exempting too, because cobra resolves the `--help` flag before `PersistentPreRunE` but dispatches the `help` command like any other, so `deputy help` was exit 1 while `deputy --help` was exit 0.

The allowlist keys on the top-level command, so `deputy proxy config` cannot inherit an exemption by name. `init` stays gated deliberately: it cannot repair a broken file since it refuses to overwrite, so exempting it would widen the hole and buy nothing.

**3. A second swallower, fixed in the same pass.** `internal/cli/cmd/server.go` substituted an empty `config.Config` on load failure, which is worse than defaults: it silently changed the bind address and dropped configured TLS and egress. It now returns the error. It is unreachable via the root gate and kept as a second line of defense, and the tests assert error *identity* so that backstop cannot mask a missing gate.

## Verification

Observed with the built binary under a broken `.deputy.yaml`. Exempt commands exit 0 with zero bytes on stderr. `list` and `scan` exit 1 with a diagnostic naming the file, the failing key, the valid values, and a suggestion. With no config file present, `list` exits 0 with zero bytes on stderr.

Non-vacuity was proven in both directions, which mattered: shrinking the allowlist back to `config` fails the exempt rows, and widening it to everything fails the gated rows. A one-sided test would have missed the second.

`go test ./...` is green, 105 packages, and was green on the baseline.

## Reported, not fixed

`internal/cli/cmd/secrets_baseline.go:386,435` silently skip files whose read or scan fails inside a `WalkDir` callback, so a secrets baseline can quietly miss files. Different shape from this bug, worth its own issue.
