### PR TITLE
Run CI and security on pull requests to any base branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,12 @@ name: CI
 on:
   push:
     branches: [main]
+  # No branch filter. A stacked pull request targets its parent branch rather
+  # than main, and a filter of [main] gives those pull requests no checks at
+  # all, silently: the workflow does not appear as pending or skipped, it
+  # simply never exists. Reviewing an unverified stack is worse than reviewing
+  # one large verified branch, so this stays unfiltered.
   pull_request:
-    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,8 +8,10 @@ name: Security
 on:
   push:
     branches: [main]
+  # No branch filter, matching ci.yml: a stacked pull request targets its
+  # parent branch, so filtering on main leaves every layer of a stack
+  # unscanned.
   pull_request:
-    branches: [main]
   schedule:
     # Weekly scan on Mondays at 9am UTC
     - cron: '0 9 * * 1'


### PR DESCRIPTION
Fixes #275.

`ci.yml` and `security.yml` filtered their `pull_request` trigger to `branches: [main]`. A stacked pull request targets its parent branch, so it matched neither workflow and ran no checks at all.

The failure mode is silent, which is what makes it costly. The workflows did not show as pending or skipped on those pull requests, they simply never existed, so a reviewer saw a stack with no checks and nothing indicating any were missing.

That inverted the point of stacking. Splitting a large change into layers is meant to make review tractable, and instead it traded away the verification that made review meaningful: an unverified four-layer stack asks more of a reviewer than one large branch with green CI.

## Verified end to end, not just read

Opened a throwaway pull request based on this branch rather than on `main`, and the checks appeared:

```
base: fix/275-ci-on-stacked-prs
  Build                      SUCCESS
  Test                       IN_PROGRESS
  Scan / Security Scan       IN_PROGRESS
  PR Gate / Security Scan    IN_PROGRESS
  PR Gate / Dependency Diff  SUCCESS
```

Before this change that pull request would have carried zero checks. The probe branch and its pull request are deleted.

## Scope

The `push` trigger keeps its `[main]` filter, since pull requests already cover branch pushes and dropping it would run the full suite on every push to every branch. Only `pull_request` loses the filter, so pull requests are now checked wherever they are aimed.

`actionlint` is clean on both files.
