### PR TITLE
Fail secrets baselines on unreadable files or scan errors

### DIFF
--- a/internal/cli/cmd/secrets_baseline.go
+++ b/internal/cli/cmd/secrets_baseline.go
@@ -368,6 +368,9 @@ func generateBaselineWithExcludes(ctx context.Context, scanner secrets.Scanner, 
 			}
 			return nil
 		}
+		if d.Type()&fs.ModeType != 0 {
+			return nil
+		}
 
 		// Get relative path
 		relPath := filepath.FromSlash(path)
@@ -418,6 +421,9 @@ func scanDirectoryForBaseline(ctx context.Context, scanner secrets.Scanner, dir 
 			if base == ".git" || base == "node_modules" || base == "vendor" || base == ".venv" {
 				return fs.SkipDir
 			}
+			return nil
+		}
+		if d.Type()&fs.ModeType != 0 {
 			return nil
 		}
 

--- a/internal/cli/cmd/secrets_baseline.go
+++ b/internal/cli/cmd/secrets_baseline.go
@@ -382,14 +382,9 @@ func generateBaselineWithExcludes(ctx context.Context, scanner secrets.Scanner, 
 			return nil
 		}
 
-		content, err := fs.ReadFile(rootFS, path)
+		findings, err := scanBaselineFile(ctx, rootFS, scanner, path)
 		if err != nil {
-			return nil
-		}
-
-		findings, err := scanner.ScanFile(ctx, relPath, content)
-		if err != nil {
-			return nil
+			return err
 		}
 
 		baseline.AddFindings(findings, reason)
@@ -431,16 +426,9 @@ func scanDirectoryForBaseline(ctx context.Context, scanner secrets.Scanner, dir 
 			return nil
 		}
 
-		content, err := fs.ReadFile(rootFS, path)
+		findings, err := scanBaselineFile(ctx, rootFS, scanner, path)
 		if err != nil {
-			return nil
-		}
-
-		relPath := filepath.FromSlash(path)
-
-		findings, err := scanner.ScanFile(ctx, relPath, content)
-		if err != nil {
-			return nil
+			return err
 		}
 
 		allFindings = append(allFindings, findings...)
@@ -448,6 +436,21 @@ func scanDirectoryForBaseline(ctx context.Context, scanner secrets.Scanner, dir 
 	})
 
 	return allFindings, err
+}
+
+func scanBaselineFile(ctx context.Context, rootFS fs.FS, scanner secrets.Scanner, path string) ([]secrets.Finding, error) {
+	content, err := fs.ReadFile(rootFS, path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	relPath := filepath.FromSlash(path)
+	findings, err := scanner.ScanFile(ctx, relPath, content)
+	if err != nil {
+		return nil, fmt.Errorf("scanning %s: %w", relPath, err)
+	}
+
+	return findings, nil
 }
 
 // isBinaryFileByExtension checks if a file is binary by extension.

--- a/internal/cli/cmd/secrets_baseline_test.go
+++ b/internal/cli/cmd/secrets_baseline_test.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/temporalio/deputy/internal/secrets"
+)
+
+type failingBaselineScanner struct {
+	err error
+}
+
+func TestScanBaselineFileReturnsReadErrors(t *testing.T) {
+	_, err := scanBaselineFile(t.Context(), fstest.MapFS{}, failingBaselineScanner{}, "missing.txt")
+	if !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("error = %v, want not-exist error", err)
+	}
+	if !strings.Contains(err.Error(), "reading missing.txt") {
+		t.Fatalf("error = %q, want file context", err)
+	}
+}
+
+func (s failingBaselineScanner) Scan(context.Context, []byte) ([]secrets.Finding, error) {
+	return nil, s.err
+}
+
+func (s failingBaselineScanner) ScanFile(context.Context, string, []byte) ([]secrets.Finding, error) {
+	return nil, s.err
+}
+
+func TestBaselineWalksReturnScanErrors(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "credentials.txt"), []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	scanErr := errors.New("scanner unavailable")
+	scanner := failingBaselineScanner{err: scanErr}
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "create",
+			run: func() error {
+				_, err := generateBaselineWithExcludes(t.Context(), scanner, dir, "test", nil)
+				return err
+			},
+		},
+		{
+			name: "update",
+			run: func() error {
+				_, err := scanDirectoryForBaseline(t.Context(), scanner, dir)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.run()
+			if !errors.Is(err, scanErr) {
+				t.Fatalf("error = %v, want scanner error", err)
+			}
+			if !strings.Contains(err.Error(), "scanning credentials.txt") {
+				t.Fatalf("error = %q, want file context", err)
+			}
+		})
+	}
+}

--- a/internal/cli/cmd/secrets_baseline_test.go
+++ b/internal/cli/cmd/secrets_baseline_test.go
@@ -35,6 +35,46 @@ func (s failingBaselineScanner) ScanFile(context.Context, string, []byte) ([]sec
 	return nil, s.err
 }
 
+func TestBaselineWalksSkipDirectorySymlinks(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target")
+	if err := os.Mkdir(target, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink("target", filepath.Join(dir, "target-link")); err != nil {
+		t.Skipf("creating directory symlink: %v", err)
+	}
+
+	scanner := failingBaselineScanner{err: errors.New("scanner should not be called")}
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{
+			name: "create",
+			run: func() error {
+				_, err := generateBaselineWithExcludes(t.Context(), scanner, dir, "test", nil)
+				return err
+			},
+		},
+		{
+			name: "update",
+			run: func() error {
+				_, err := scanDirectoryForBaseline(t.Context(), scanner, dir)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.run(); err != nil {
+				t.Fatalf("directory symlink caused baseline failure: %v", err)
+			}
+		})
+	}
+}
+
 func TestBaselineWalksReturnScanErrors(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "credentials.txt"), []byte("secret"), 0o600); err != nil {


### PR DESCRIPTION
## Summary

- stop both secrets-baseline walks when a file cannot be read or scanned
- preserve the underlying error while adding the affected file path
- cover create/update scan failures and read failures with regression tests

Previously, either failure was returned as `nil` from the walk callback, so the command could persist a baseline built from an unknown subset of files and still report success.

Fixes #309.

## Verification

- `go test ./internal/cli/cmd -count=1`
- `go test -race ./internal/cli/cmd -run 'TestBaselineWalksReturnScanErrors|TestScanBaselineFileReturnsReadErrors' -count=1`
- `go vet ./internal/cli/cmd`
- `go build -o /private/tmp/v36-deputy-bin .`
- `go test ./... -count=1`: all packages passed except `internal/ignore`; its two date-dependent failures reproduce unchanged at base commit `65f6eb9`

Implementation and regression tests were prepared with Codex and reviewed against the final diff.