### PR TITLE
fix(explain): compare timestamps by instant

### DIFF
--- a/internal/explain/renderer.go
+++ b/internal/explain/renderer.go
@@ -372,7 +372,7 @@ func (r *Renderer) renderTimeline(out io.Writer, data *VulnData) {
 	}
 
 	// Modified (only if different from published)
-	if !temporal.Modified.IsZero() && temporal.Modified != temporal.Published {
+	if !temporal.Modified.IsZero() && !temporal.Modified.Equal(temporal.Published) {
 		age := FormatAge(temporal.TimeSinceModified())
 		fmt.Fprintf(out, "  %s  %s  %s\n",
 			styleLabel.Render("updated"),

--- a/internal/explain/renderer_test.go
+++ b/internal/explain/renderer_test.go
@@ -312,6 +312,30 @@ func TestRender_AbsentDatesRenderAsAbsent(t *testing.T) {
 	}
 }
 
+func TestRenderTimeline_SameInstantDoesNotRenderUpdated(t *testing.T) {
+	published := time.Now().Add(-24 * time.Hour).UTC()
+	modified := published.In(time.FixedZone("UTC+01:00", 60*60))
+	if !published.Equal(modified) {
+		t.Fatal("test times must represent the same instant")
+	}
+
+	var buf bytes.Buffer
+	NewRenderer(Config{}).renderTimeline(&buf, &VulnData{
+		Temporal: TemporalInfo{
+			Published: published,
+			Modified:  modified,
+		},
+	})
+
+	out := buf.String()
+	if !strings.Contains(out, "disclosed") {
+		t.Fatalf("timeline did not render the disclosure date:\n%s", out)
+	}
+	if strings.Contains(out, "updated") {
+		t.Errorf("timeline rendered equivalent instants as different dates:\n%s", out)
+	}
+}
+
 // TestRenderJSON_AbsentDatesOmitTimeline is [TestRender_AbsentDatesRenderAsAbsent]
 // for the JSON surface: an absent date must not produce a timeline key at all,
 // because a consumer cannot tell an epoch date from a missing one.


### PR DESCRIPTION
## Summary

* compare `Published` and `Modified` timestamps using `time.Time.Equal`
* avoid rendering an `updated` timeline entry when both timestamps represent the same instant in different locations
* add a regression test covering equivalent UTC and UTC+01 timestamps

## Why

Direct `time.Time` comparison also considers representation details such as location. As a result, equivalent instants could be treated as different and produce a misleading `updated` timeline entry.

## Testing

* `go test -run '^TestRenderTimeline_SameInstantDoesNotRenderUpdated$' -count=1 ./internal/explain`
* `go test -count=1 ./internal/explain`
* `go test -race -count=1 ./internal/explain`
* `go vet ./internal/explain`
* `go build ./...`
* `TZ=UTC DEPUTY_TEST_BINARY=/tmp/deputy-test-binary go test -race -count=1 -coverprofile=/tmp/deputy-coverage.out ./...`

Fixes #293 