### PR TITLE
Recover superseded OSV advisories instead of aborting the scan

### DIFF
--- a/docs/commands/scan.md
+++ b/docs/commands/scan.md
@@ -166,10 +166,13 @@ result is never mistaken for complete coverage:
   record between the batch query that reports it and the lookup that expands it,
   so an advisory a source named can stop resolving mid-scan. Deputy first
   retries the aliases the not-found response names, which recovers a record that
-  merely moved. An advisory that still does not resolve is named here and its
-  finding is absent from the report: the scan keeps every other package's
+  merely moved. An advisory that still does not resolve is named here, and that
+  source contributes no finding for it: the scan keeps every other package's
   findings rather than failing outright, and the warning is what stops the
-  incomplete result from reading as clean. Transport and server failures stay
+  incomplete result from reading as clean. Each warning names the source that
+  came back short rather than claiming the report is missing the finding,
+  because with several sources configured another one may have reported the
+  same advisory; `findings[].sources` says which ones did. Transport and server failures stay
   fatal on the two paths that decide whether a finding exists at all: fetching
   a record the batch query named, and the alias recovery that follows a
   not-found. Unlike a withdrawn record those will not reproduce, so a result

--- a/docs/commands/scan.md
+++ b/docs/commands/scan.md
@@ -161,6 +161,16 @@ result is never mistaken for complete coverage:
   (e.g. `["osv"]`). Multiple entries mean independent corroboration.
 - **`advisories[].kind`**: distinguishes `FINDING_KIND_MALWARE` (e.g. OSV
   `MAL-` records) from ordinary vulnerabilities.
+- **`warnings`** (JSON/API, printed as `Warning:` lines in text output): gaps
+  that opened while the sources answered. OSV can withdraw, rename, or merge a
+  record between the batch query that reports it and the lookup that expands it,
+  so an advisory a source named can stop resolving mid-scan. Deputy first
+  retries the aliases the not-found response names, which recovers a record that
+  merely moved. An advisory that still does not resolve is named here and its
+  finding is absent from the report: the scan keeps every other package's
+  findings rather than failing outright, and the warning is what stops the
+  incomplete result from reading as clean. Transport and server failures remain
+  fatal, because unlike a withdrawn record they will not reproduce.
 
 ```console
 $ deputy scan --format json | jq '.coverage'

--- a/docs/commands/scan.md
+++ b/docs/commands/scan.md
@@ -172,14 +172,14 @@ result is never mistaken for complete coverage:
   incomplete result from reading as clean. Each warning names the source that
   came back short rather than claiming the report is missing the finding,
   because with several sources configured another one may have reported the
-  same advisory; `findings[].sources` says which ones did. Transport and server failures stay
-  fatal on the two paths that decide whether a finding exists at all: fetching
-  a record the batch query named, and the alias recovery that follows a
-  not-found. Unlike a withdrawn record those will not reproduce, so a result
-  missing findings because of one is never served. The further alias lookups
-  that enrich a record already fetched are best-effort, and their failures are
-  silent, so a scan can report an advisory with thinner severity, fix, or
-  alias data than a later run would show.
+  same advisory; `findings[].sources` says which ones did. Transport and
+  server failures stay fatal on the two paths that decide whether a finding
+  exists at all: fetching a record the batch query named, and the alias
+  recovery that follows a not-found. Unlike a withdrawn record those will not
+  reproduce, so a result missing findings because of one is never served. The
+  further alias lookups that enrich a record already fetched are best-effort,
+  and their failures are silent, so a scan can report an advisory with thinner
+  severity, fix, or alias data than a later run would show.
 
 ```console
 $ deputy scan --format json | jq '.coverage'

--- a/docs/commands/scan.md
+++ b/docs/commands/scan.md
@@ -169,8 +169,14 @@ result is never mistaken for complete coverage:
   merely moved. An advisory that still does not resolve is named here and its
   finding is absent from the report: the scan keeps every other package's
   findings rather than failing outright, and the warning is what stops the
-  incomplete result from reading as clean. Transport and server failures remain
-  fatal, because unlike a withdrawn record they will not reproduce.
+  incomplete result from reading as clean. Transport and server failures stay
+  fatal on the two paths that decide whether a finding exists at all: fetching
+  a record the batch query named, and the alias recovery that follows a
+  not-found. Unlike a withdrawn record those will not reproduce, so a result
+  missing findings because of one is never served. The further alias lookups
+  that enrich a record already fetched are best-effort, and their failures are
+  silent, so a scan can report an advisory with thinner severity, fix, or
+  alias data than a later run would show.
 
 ```console
 $ deputy scan --format json | jq '.coverage'

--- a/internal/analysis/advisorysource/advisorysource_test.go
+++ b/internal/analysis/advisorysource/advisorysource_test.go
@@ -18,6 +18,7 @@ type fakeSource struct {
 	artifacts  []vulnerabilityv1.ArtifactKind
 	findings   []*vulnerabilityv1.Finding
 	advisories map[string]*vulnerabilityv1.Advisory
+	warnings   []string
 }
 
 func (f *fakeSource) Info() *pluginv1.AdvisorySourceInfo {
@@ -31,7 +32,7 @@ func (f *fakeSource) Info() *pluginv1.AdvisorySourceInfo {
 }
 
 func (f *fakeSource) Query(_ context.Context, _ []*dependencyv1.Package) (*Result, error) {
-	return &Result{Findings: f.findings, Advisories: f.advisories}, nil
+	return &Result{Findings: f.findings, Advisories: f.advisories, Warnings: f.warnings}, nil
 }
 
 func goPkg(name, version string) *dependencyv1.Package {

--- a/internal/analysis/advisorysource/osv.go
+++ b/internal/analysis/advisorysource/osv.go
@@ -74,8 +74,12 @@ func (s *osvSource) Info() *pluginv1.AdvisorySourceInfo {
 // Query runs the OSV lookup and tags each result with OSV provenance and the
 // advisory's finding kind (malware vs vulnerability). It consumes and returns
 // proto types directly (osv.QueryProto), so there is no conversion at this seam.
+//
+// Advisories OSV reported but would not serve records for are reported as
+// warnings rather than errors, so one withdrawn record cannot cost the caller
+// every other package's findings.
 func (s *osvSource) Query(ctx context.Context, pkgs []*dependencyv1.Package) (*Result, error) {
-	findings, advisories, err := osv.QueryProto(ctx, s.client, pkgs)
+	findings, advisories, unresolved, err := osv.QueryProto(ctx, s.client, pkgs)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +94,7 @@ func (s *osvSource) Query(ctx context.Context, pkgs []*dependencyv1.Package) (*R
 		}
 		adv.Kind = AdvisoryKind(adv)
 	}
-	return &Result{Findings: findings, Advisories: advisories}, nil
+	return &Result{Findings: findings, Advisories: advisories, Warnings: osv.AdvisoryWarnings(unresolved)}, nil
 }
 
 // AdvisoryKind classifies an advisory as malware or vulnerability. OSV publishes

--- a/internal/analysis/advisorysource/registry.go
+++ b/internal/analysis/advisorysource/registry.go
@@ -56,6 +56,10 @@ type AggregateResult struct {
 	Findings   []*vulnerabilityv1.Finding
 	Advisories map[string]*vulnerabilityv1.Advisory
 	Coverage   *vulnerabilityv1.ScanCoverage
+	// Warnings collects the per-source warnings, in source order. Coverage says
+	// which combinations a source claimed; these say where a source that
+	// claimed one still came back incomplete.
+	Warnings []string
 }
 
 // Query routes pkgs to covering sources, runs them concurrently, and merges.
@@ -113,25 +117,29 @@ func (r *Registry) Query(ctx context.Context, pkgs []*dependencyv1.Package) (*Ag
 		return nil, err
 	}
 
-	findings, advisories := mergeResults(results)
+	findings, advisories, warnings := mergeResults(results)
 	return &AggregateResult{
 		Findings:   findings,
 		Advisories: advisories,
 		Coverage:   buildCoverage(coverageAcc),
+		Warnings:   warnings,
 	}, nil
 }
 
 // mergeResults unions findings across sources, accumulating provenance in
-// Finding.Sources, and merges advisory records by ID.
-func mergeResults(results []*Result) ([]*vulnerabilityv1.Finding, map[string]*vulnerabilityv1.Advisory) {
+// Finding.Sources, and merges advisory records by ID. Warnings union in source
+// order, so two sources reporting the same gap say it once.
+func mergeResults(results []*Result) ([]*vulnerabilityv1.Finding, map[string]*vulnerabilityv1.Advisory, []string) {
 	advisories := map[string]*vulnerabilityv1.Advisory{}
 	byKey := map[string]*vulnerabilityv1.Finding{}
 	var findings []*vulnerabilityv1.Finding
+	var warnings []string
 
 	for _, res := range results {
 		if res == nil {
 			continue
 		}
+		warnings = unionStrings(warnings, res.Warnings)
 		for id, adv := range res.Advisories {
 			if _, ok := advisories[id]; !ok && adv != nil {
 				advisories[id] = adv
@@ -150,7 +158,7 @@ func mergeResults(results []*Result) ([]*vulnerabilityv1.Finding, map[string]*vu
 			findings = append(findings, f)
 		}
 	}
-	return findings, advisories
+	return findings, advisories, warnings
 }
 
 // findingKey identifies a finding for dedup: advisory ID + package identity.

--- a/internal/analysis/advisorysource/source.go
+++ b/internal/analysis/advisorysource/source.go
@@ -28,4 +28,10 @@ type Source interface {
 type Result struct {
 	Findings   []*vulnerabilityv1.Finding
 	Advisories map[string]*vulnerabilityv1.Advisory
+	// Warnings names what the source could not answer for, one line each, for
+	// the scan report. A source that knows an advisory affects a package but
+	// cannot retrieve the record has to say so here: an incomplete answer that
+	// returns no warning is indistinguishable from a clean one, which is the
+	// failure mode that hides risk.
+	Warnings []string
 }

--- a/internal/analysis/advisorysource/unresolved_test.go
+++ b/internal/analysis/advisorysource/unresolved_test.go
@@ -1,0 +1,165 @@
+package advisorysource
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ossf/osv-schema/bindings/go/osvschema"
+	"osv.dev/bindings/go/api"
+
+	dependencyv1 "github.com/temporalio/deputy/gen/deputy/dependency/v1"
+	vulnerabilityv1 "github.com/temporalio/deputy/gen/deputy/vulnerability/v1"
+	"github.com/temporalio/deputy/internal/cache/disk"
+)
+
+// withdrawnAdvisoryClient reports one advisory for every queried package and
+// then refuses to expand it the way OSV refuses a withdrawn record: a 404 whose
+// body names the aliases that do exist.
+type withdrawnAdvisoryClient struct {
+	// advisoryID is the ID the batch query attributes to each package.
+	advisoryID string
+	// aliases are the IDs the 404 body names, if any.
+	aliases []string
+	// records are the alias records the client will serve.
+	records map[string]*osvschema.Vulnerability
+}
+
+func (c *withdrawnAdvisoryClient) QueryBatch(_ context.Context, queries []*api.Query) (*api.BatchVulnerabilityList, error) {
+	results := make([]*api.VulnerabilityList, 0, len(queries))
+	for range queries {
+		results = append(results, &api.VulnerabilityList{
+			Vulns: []*osvschema.Vulnerability{{Id: c.advisoryID}},
+		})
+	}
+	return &api.BatchVulnerabilityList{Results: results}, nil
+}
+
+func (c *withdrawnAdvisoryClient) GetVulnByID(_ context.Context, id string) (*osvschema.Vulnerability, error) {
+	if rec, ok := c.records[id]; ok {
+		return rec, nil
+	}
+	if id != c.advisoryID || len(c.aliases) == 0 {
+		return nil, errors.New(`client error: status="404 Not Found" body={"code":5,"message":"Bug not found."}`)
+	}
+	return nil, errors.New(`client error: status="404 Not Found" body={"code":5,` +
+		`"message":"Vulnerability not found, but the following aliases were: ` + strings.Join(c.aliases, " ") + `"}`)
+}
+
+// TestOSVSourceReportsUnresolvedAdvisories checks the seam that turns a
+// per-advisory failure into something the scan report can show. Before the fix
+// the query returned an error here and the registry discarded every source's
+// results, so the scan produced no report at all.
+func TestOSVSourceReportsUnresolvedAdvisories(t *testing.T) {
+	const (
+		buildkit  = "github.com/moby/buildkit"
+		withdrawn = "GO-2026-6255"
+		ghsaAlias = "GHSA-7236-3392-c5c6"
+	)
+
+	buildkitRecord := &osvschema.Vulnerability{
+		Id: ghsaAlias,
+		Affected: []*osvschema.Affected{{
+			Package: &osvschema.Package{Name: buildkit, Ecosystem: "Go"},
+			Ranges: []*osvschema.Range{{
+				Type:   osvschema.Range_SEMVER,
+				Events: []*osvschema.Event{{Introduced: "0"}},
+			}},
+		}},
+	}
+
+	tests := []struct {
+		name         string
+		client       *withdrawnAdvisoryClient
+		wantFindings []string
+		wantWarnings []string
+	}{
+		{
+			name:   "withdrawn advisory becomes a warning, not an error",
+			client: &withdrawnAdvisoryClient{advisoryID: withdrawn},
+			wantWarnings: []string{
+				"osv: advisory GO-2026-6255 reported for github.com/moby/buildkit@v0.30.0 is missing from this report: " +
+					"OSV no longer serves the record and it could not be recovered through an alias",
+			},
+		},
+		{
+			name: "recovered advisory needs no warning",
+			client: &withdrawnAdvisoryClient{
+				advisoryID: withdrawn,
+				aliases:    []string{ghsaAlias},
+				records:    map[string]*osvschema.Vulnerability{ghsaAlias: buildkitRecord},
+			},
+			wantFindings: []string{ghsaAlias},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(disk.SetBaseDirForTest(t.TempDir()))
+
+			pkgs := []*dependencyv1.Package{{
+				Name:      buildkit,
+				Version:   "v0.30.0",
+				Ecosystem: "go",
+				Purl:      "pkg:golang/" + buildkit + "@v0.30.0",
+			}}
+
+			agg, err := NewRegistry(NewOSVSource(tt.client)).Query(t.Context(), pkgs)
+			if err != nil {
+				t.Fatalf("Registry.Query() error = %v, want nil: one unexpandable advisory must not fail the scan", err)
+			}
+
+			gotFindings := make([]string, 0, len(agg.Findings))
+			for _, f := range agg.Findings {
+				gotFindings = append(gotFindings, f.GetAdvisoryId())
+			}
+			slices.Sort(gotFindings)
+			want := slices.Clone(tt.wantFindings)
+			slices.Sort(want)
+			if !slices.Equal(gotFindings, want) {
+				t.Errorf("findings = %v, want %v", gotFindings, want)
+			}
+			if !slices.Equal(agg.Warnings, tt.wantWarnings) {
+				t.Errorf("warnings = %q, want %q", agg.Warnings, tt.wantWarnings)
+			}
+		})
+	}
+}
+
+// TestRegistryCollectsSourceWarnings checks that a warning from one source
+// reaches the aggregate result even when another source answers cleanly, and
+// that two sources naming the same gap say it once.
+func TestRegistryCollectsSourceWarnings(t *testing.T) {
+	warned := &fakeSource{
+		name:       "osv",
+		ecosystems: []string{"go"},
+		artifacts:  onlyPackage(),
+		findings:   []*vulnerabilityv1.Finding{goFinding("CVE-1", "osv", "github.com/foo/bar", "1.0.0")},
+		advisories: map[string]*vulnerabilityv1.Advisory{"CVE-1": {Id: "CVE-1"}},
+		warnings:   []string{"osv: advisory GO-1 is missing"},
+	}
+	echo := &fakeSource{
+		name:       "echo",
+		ecosystems: []string{"go"},
+		artifacts:  onlyPackage(),
+		warnings:   []string{"osv: advisory GO-1 is missing"},
+	}
+	quiet := &fakeSource{
+		name:       "quiet",
+		ecosystems: []string{"go"},
+		artifacts:  onlyPackage(),
+	}
+
+	agg, err := NewRegistry(warned, echo, quiet).Query(t.Context(), []*dependencyv1.Package{goPkg("github.com/foo/bar", "1.0.0")})
+	if err != nil {
+		t.Fatalf("Registry.Query() error = %v", err)
+	}
+	if want := []string{"osv: advisory GO-1 is missing"}; !slices.Equal(agg.Warnings, want) {
+		t.Errorf("warnings = %q, want %q", agg.Warnings, want)
+	}
+	if len(agg.Findings) != 1 {
+		t.Errorf("findings = %d, want 1: a warning must not cost the findings", len(agg.Findings))
+	}
+}

--- a/internal/analysis/advisorysource/unresolved_test.go
+++ b/internal/analysis/advisorysource/unresolved_test.go
@@ -86,13 +86,17 @@ func TestOSVSourceReportsUnresolvedAdvisories(t *testing.T) {
 			},
 		},
 		{
-			name: "recovered advisory needs no warning",
+			// Recovery closes the gap, so there is nothing to warn about, and
+			// the finding keeps the ID the batch reported rather than the alias
+			// it was recovered through: a suppression naming the reported ID has
+			// to go on matching.
+			name: "recovered advisory needs no warning and keeps the reported ID",
 			client: &withdrawnAdvisoryClient{
 				advisoryID: withdrawn,
 				aliases:    []string{ghsaAlias},
 				records:    map[string]*osvschema.Vulnerability{ghsaAlias: buildkitRecord},
 			},
-			wantFindings: []string{ghsaAlias},
+			wantFindings: []string{withdrawn},
 		},
 	}
 

--- a/internal/analysis/advisorysource/unresolved_test.go
+++ b/internal/analysis/advisorysource/unresolved_test.go
@@ -81,7 +81,7 @@ func TestOSVSourceReportsUnresolvedAdvisories(t *testing.T) {
 			client: &withdrawnAdvisoryClient{advisoryID: withdrawn},
 			wantWarnings: []string{
 				"osv: advisory GO-2026-6255 reported for github.com/moby/buildkit@v0.30.0 is missing from this report: " +
-					"OSV no longer serves the record and it could not be recovered through an alias",
+					"OSV returned not found for the record, and no alias it named resolved",
 			},
 		},
 		{

--- a/internal/analysis/advisorysource/unresolved_test.go
+++ b/internal/analysis/advisorysource/unresolved_test.go
@@ -12,6 +12,7 @@ import (
 
 	dependencyv1 "github.com/temporalio/deputy/gen/deputy/dependency/v1"
 	vulnerabilityv1 "github.com/temporalio/deputy/gen/deputy/vulnerability/v1"
+	"github.com/temporalio/deputy/internal/analysis/osv"
 	"github.com/temporalio/deputy/internal/cache/disk"
 )
 
@@ -80,7 +81,7 @@ func TestOSVSourceReportsUnresolvedAdvisories(t *testing.T) {
 			name:   "withdrawn advisory becomes a warning, not an error",
 			client: &withdrawnAdvisoryClient{advisoryID: withdrawn},
 			wantWarnings: []string{
-				"osv: advisory GO-2026-6255 reported for github.com/moby/buildkit@v0.30.0 is missing from this report: " +
+				"osv: advisory GO-2026-6255 reported for github.com/moby/buildkit@v0.30.0 is absent from osv's findings: " +
 					"OSV returned not found for the record, and no alias it named resolved",
 			},
 		},
@@ -161,5 +162,67 @@ func TestRegistryCollectsSourceWarnings(t *testing.T) {
 	}
 	if len(agg.Findings) != 1 {
 		t.Errorf("findings = %d, want 1: a warning must not cost the findings", len(agg.Findings))
+	}
+}
+
+// TestRegistryWarningIsHonestWhenAnotherSourceCovers pins the multi-source case
+// the warning's wording has to survive. Warnings union across sources
+// independently of the findings merge, so OSV's warning about an advisory it
+// could not expand rides along even when another configured source reported that
+// same advisory and package. The aggregate therefore holds the finding and the
+// warning at once, which is only truthful because the warning speaks about
+// OSV's own findings rather than about the report. NewDefaultRegistry pairs OSV
+// with plugin sources, so this is the shipped configuration, not a contrivance.
+func TestRegistryWarningIsHonestWhenAnotherSourceCovers(t *testing.T) {
+	const (
+		advisoryID = "CVE-2026-61711"
+		pkgName    = "github.com/moby/buildkit"
+		pkgVersion = "v0.30.0"
+	)
+
+	// The exact sentence the OSV source emits, built by the same code that
+	// builds it in production so this test cannot drift from it.
+	osvWarning := osv.UnresolvedAdvisory{
+		ID:      advisoryID,
+		Package: pkgName + "@" + pkgVersion,
+		Reason:  "OSV returned not found for the record, and no alias it named resolved",
+	}.Warning()
+
+	// OSV named the advisory and then could not expand it, so it contributes
+	// the warning and no finding.
+	osvSource := &fakeSource{
+		name:       "osv",
+		ecosystems: []string{"go"},
+		artifacts:  onlyPackage(),
+		warnings:   []string{osvWarning},
+	}
+	// A second source has the record OSV could not serve.
+	vendor := &fakeSource{
+		name:       "vendor-feed",
+		ecosystems: []string{"go"},
+		artifacts:  onlyPackage(),
+		findings:   []*vulnerabilityv1.Finding{goFinding(advisoryID, "vendor-feed", pkgName, pkgVersion)},
+		advisories: map[string]*vulnerabilityv1.Advisory{advisoryID: {Id: advisoryID}},
+	}
+
+	agg, err := NewRegistry(osvSource, vendor).Query(t.Context(), []*dependencyv1.Package{goPkg(pkgName, pkgVersion)})
+	if err != nil {
+		t.Fatalf("Registry.Query() error = %v, want nil", err)
+	}
+
+	// The finding is in the report, supplied by the source that could serve it.
+	if len(agg.Findings) != 1 || agg.Findings[0].GetAdvisoryId() != advisoryID {
+		t.Fatalf("findings = %+v, want one for %s", agg.Findings, advisoryID)
+	}
+	if got, want := agg.Findings[0].GetSources(), []string{"vendor-feed"}; !slices.Equal(got, want) {
+		t.Errorf("finding sources = %q, want %q", got, want)
+	}
+	// And OSV's warning still rides along, which is why it must not describe
+	// the report: here the report is not missing anything.
+	if want := []string{osvWarning}; !slices.Equal(agg.Warnings, want) {
+		t.Fatalf("warnings = %q, want %q", agg.Warnings, want)
+	}
+	if !strings.Contains(osvWarning, "absent from osv's findings") {
+		t.Errorf("warning = %q, want it scoped to osv's findings rather than to the report", osvWarning)
 	}
 }

--- a/internal/analysis/osv/aws_integration_test.go
+++ b/internal/analysis/osv/aws_integration_test.go
@@ -13,7 +13,7 @@ func TestAWSV1Integration(t *testing.T) {
 	t.Skip("network access required")
 	ctx := t.Context()
 	client := osvdev.DefaultClient()
-	vulns, err := QueryRaw(ctx, client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/aws/aws-sdk-go", Version: "1.55.6", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
+	vulns, _, err := QueryRaw(ctx, client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/aws/aws-sdk-go", Version: "1.55.6", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
 	if err != nil {
 		t.Fatalf("query failed: %v", err)
 	}
@@ -21,7 +21,7 @@ func TestAWSV1Integration(t *testing.T) {
 		t.Fatalf("expected no vulns for fixed version, got %d", len(vulns))
 	}
 
-	vulns, err = QueryRaw(ctx, client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/aws/aws-sdk-go", Version: "1.33.0", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
+	vulns, _, err = QueryRaw(ctx, client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/aws/aws-sdk-go", Version: "1.33.0", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
 	if err != nil {
 		t.Fatalf("query2 failed: %v", err)
 	}

--- a/internal/analysis/osv/errors.go
+++ b/internal/analysis/osv/errors.go
@@ -1,6 +1,9 @@
 package osv
 
 import (
+	"encoding/json"
+	"regexp"
+	"slices"
 	"strings"
 )
 
@@ -16,4 +19,63 @@ func IsNotFoundError(err error) bool {
 		return true
 	}
 	return strings.Contains(msg, `"code":5`) && strings.Contains(strings.ToLower(msg), "not found")
+}
+
+// osvErrorBodyMarker precedes the response body inside the osv.dev client's
+// formatted error text ("client error: status=%q body=%s").
+const osvErrorBodyMarker = "body="
+
+// advisoryIDPattern matches an OSV advisory identifier: an uppercase database
+// prefix followed by dash-separated alphanumeric segments, as in CVE-2026-61711,
+// GHSA-7236-3392-c5c6, or GO-2026-6255. Matching on shape rather than on a list
+// of known prefixes means a database Deputy has never heard of still matches,
+// and keeps this from becoming another list to maintain.
+var advisoryIDPattern = regexp.MustCompile(`\b[A-Z][A-Z0-9]*(?:-[A-Za-z0-9]+)+\b`)
+
+// NotFoundAliases returns the advisory IDs an OSV not-found response names as
+// records that do exist. When a record is withdrawn, renamed, or merged, OSV
+// answers a lookup for it with "Vulnerability not found, but the following
+// aliases were: CVE-... GHSA-...", and that response is the only place those
+// IDs appear: the querybatch stub that named the missing ID carries just an id
+// and a modified timestamp.
+//
+// The upstream client renders the response as formatted text rather than a
+// typed status, so these IDs are read back out of the error string. They are
+// therefore a hint and not a contract: a caller must confirm that a record
+// fetched for a returned ID actually affects the package it was asking about,
+// and must treat an empty result as "no recovery available" rather than as an
+// error. IDs come back in the order OSV listed them, deduplicated
+// case-insensitively.
+func NotFoundAliases(err error) []string {
+	if !IsNotFoundError(err) {
+		return nil
+	}
+	text := err.Error()
+	// Prefer the decoded body message. Falling back to the whole error string
+	// costs nothing: the surrounding text ("client error", "404 Not Found")
+	// holds no advisory-shaped tokens.
+	if idx := strings.LastIndex(text, osvErrorBodyMarker); idx >= 0 {
+		var body struct {
+			Message string `json:"message"`
+		}
+		if err := json.Unmarshal([]byte(text[idx+len(osvErrorBodyMarker):]), &body); err == nil && body.Message != "" {
+			text = body.Message
+		}
+	}
+
+	var out []string
+	for _, candidate := range advisoryIDPattern.FindAllString(text, -1) {
+		// Every OSV database numbers its records, so a token without a digit is
+		// prose that happens to be hyphenated, not an identifier.
+		if !strings.ContainsAny(candidate, "0123456789") {
+			continue
+		}
+		if slices.ContainsFunc(out, func(existing string) bool {
+			return strings.EqualFold(existing, candidate)
+		}) {
+			continue
+		}
+		out = append(out, candidate)
+	}
+	return out
 }

--- a/internal/analysis/osv/errors_test.go
+++ b/internal/analysis/osv/errors_test.go
@@ -2,6 +2,7 @@ package osv
 
 import (
 	"errors"
+	"slices"
 	"testing"
 )
 
@@ -39,6 +40,68 @@ func TestIsNotFoundError(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := IsNotFoundError(tt.err); got != tt.want {
 				t.Fatalf("IsNotFoundError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNotFoundAliases covers the one place OSV names the records that replaced a
+// withdrawn ID: the not-found response body. The querybatch stub that reported
+// the missing ID carries only an id and a modified timestamp, so if these IDs
+// cannot be read back out of the error there is nothing to recover through.
+func TestNotFoundAliases(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want []string
+	}{
+		{
+			name: "nil error",
+		},
+		{
+			name: "not a not-found error",
+			err:  errors.New(`client error: status="400 Bad Request" body={"code":3,"message":"Invalid query."}`),
+		},
+		{
+			name: "transport failure is not a not-found",
+			err:  errors.New("max retries exceeded: attempt 4: request failed: dial tcp: i/o timeout"),
+		},
+		{
+			// The live response for GO-2026-6255, verbatim.
+			name: "withdrawn record names its aliases",
+			err:  errors.New(`client error: status="404 Not Found" body={"code":5,"message":"Vulnerability not found, but the following aliases were: CVE-2026-61711 GHSA-7236-3392-c5c6"}`),
+			want: []string{"CVE-2026-61711", "GHSA-7236-3392-c5c6"},
+		},
+		{
+			name: "deleted record names no aliases",
+			err:  errors.New(`client error: status="404 Not Found" body={"code":5,"message":"Bug not found."}`),
+		},
+		{
+			name: "wrapped error still yields aliases",
+			err:  errors.New(`expand vulnerability GO-2026-6255: client error: status="404 Not Found" body={"code":5,"message":"Vulnerability not found, but the following aliases were: GHSA-7236-3392-c5c6"}`),
+			want: []string{"GHSA-7236-3392-c5c6"},
+		},
+		{
+			name: "unparseable body falls back to scanning the text",
+			err:  errors.New(`client error: status="404 Not Found" body=Vulnerability not found, but the following aliases were: PYSEC-2026-1 RUSTSEC-2026-0001`),
+			want: []string{"PYSEC-2026-1", "RUSTSEC-2026-0001"},
+		},
+		{
+			name: "repeated alias is reported once",
+			err:  errors.New(`client error: status="404 Not Found" body={"code":5,"message":"aliases were: CVE-2026-1 cve-2026-1 CVE-2026-1"}`),
+			want: []string{"CVE-2026-1"},
+		},
+		{
+			name: "hyphenated prose is not an identifier",
+			err:  errors.New(`client error: status="404 Not Found" body={"code":5,"message":"NOT-FOUND: no such record"}`),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NotFoundAliases(tt.err)
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("NotFoundAliases() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/analysis/osv/gha_bucket_test.go
+++ b/internal/analysis/osv/gha_bucket_test.go
@@ -631,7 +631,7 @@ func TestQueryRaw_GitHubActionsPURLOnlySHAResolutionAvoidsFalsePositive(t *testi
 	}
 	t.Cleanup(func() { ghaListRemoteRefsWithHashes = origListWithHashes })
 
-	got, err := QueryRaw(t.Context(), nil, []PkgInput{
+	got, _, err := QueryRaw(t.Context(), nil, []PkgInput{
 		{QueryKey: QueryKey{PURL: "pkg:githubactions/anthropics/claude-code-action@" + sha + "#sub/action.yml"}},
 	})
 	if err != nil {

--- a/internal/analysis/osv/osv_test.go
+++ b/internal/analysis/osv/osv_test.go
@@ -96,7 +96,7 @@ func TestQueryRaw_SkipsOSVUnsupportedEcosystems(t *testing.T) {
 		{QueryKey: QueryKey{Name: "alpine", Version: "3.19", Ecosystem: "docker", PURL: "pkg:docker/library/alpine@3.19"}},
 		{QueryKey: QueryKey{Name: "node", Version: "20.0.0", Ecosystem: "mise"}},
 	}
-	if _, err := QueryRaw(t.Context(), client, pkgs); err != nil {
+	if _, _, err := QueryRaw(t.Context(), client, pkgs); err != nil {
 		t.Fatalf("QueryRaw() error = %v, want nil (unsupported ecosystems should be skipped, not fatal)", err)
 	}
 	if len(client.queries) != 1 {
@@ -110,7 +110,7 @@ func TestQueryRaw_SkipsOSVUnsupportedEcosystems(t *testing.T) {
 func Test_QueryRaw_ok(t *testing.T) {
 	resetDiskCache(t)
 	client := &fakeClient{}
-	vulns, err := QueryRaw(t.Context(), client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/example/pkg", Version: "1.2.3", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
+	vulns, _, err := QueryRaw(t.Context(), client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/example/pkg", Version: "1.2.3", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -149,7 +149,7 @@ func Test_QueryRaw_usesNameEcosystemForPURLInputs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			resetDiskCache(t)
 			client := &captureQueryClient{}
-			if _, err := QueryRaw(t.Context(), client, []PkgInput{tt.in}); err != nil {
+			if _, _, err := QueryRaw(t.Context(), client, []PkgInput{tt.in}); err != nil {
 				t.Fatalf("QueryRaw() error = %v", err)
 			}
 			if len(client.queries) != 1 {
@@ -184,7 +184,7 @@ func (f *fakeClientQueryErr) GetVulnByID(ctx context.Context, id string) (*osvsc
 func Test_QueryRaw_query_error(t *testing.T) {
 	resetDiskCache(t)
 	client := &fakeClientQueryErr{}
-	_, err := QueryRaw(t.Context(), client, []PkgInput{{QueryKey: QueryKey{Name: "n", Version: "1", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
+	_, _, err := QueryRaw(t.Context(), client, []PkgInput{{QueryKey: QueryKey{Name: "n", Version: "1", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
 	if err == nil {
 		t.Fatalf("expected error")
 	}
@@ -202,7 +202,7 @@ func (f *fakeClientGetErr) GetVulnByID(ctx context.Context, id string) (*osvsche
 func Test_QueryRaw_getvuln_error(t *testing.T) {
 	resetDiskCache(t)
 	client := &fakeClientGetErr{}
-	_, err := QueryRaw(t.Context(), client, []PkgInput{{QueryKey: QueryKey{Name: "n", Version: "1", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
+	_, _, err := QueryRaw(t.Context(), client, []PkgInput{{QueryKey: QueryKey{Name: "n", Version: "1", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
 	if err == nil {
 		t.Fatalf("expected error when GetVulnByID fails")
 	}
@@ -230,7 +230,7 @@ func (f *fakeClientFixed) GetVulnByID(ctx context.Context, id string) (*osvschem
 func Test_QueryRaw_skips_fixed_version(t *testing.T) {
 	resetDiskCache(t)
 	client := &fakeClientFixed{}
-	vulns, err := QueryRaw(t.Context(), client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/example/pkg", Version: "1.55.6", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
+	vulns, _, err := QueryRaw(t.Context(), client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/example/pkg", Version: "1.55.6", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -273,7 +273,7 @@ func (f *fakeClientAWS) GetVulnByID(ctx context.Context, id string) (*osvschema.
 func Test_QueryRaw_awssdkv1(t *testing.T) {
 	resetDiskCache(t)
 	client := &fakeClientAWS{}
-	vulns, err := QueryRaw(t.Context(), client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/aws/aws-sdk-go", Version: "1.55.6", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
+	vulns, _, err := QueryRaw(t.Context(), client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/aws/aws-sdk-go", Version: "1.55.6", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -281,7 +281,7 @@ func Test_QueryRaw_awssdkv1(t *testing.T) {
 		t.Fatalf("expected no vulns for fixed version, got %d", len(vulns))
 	}
 
-	vulns, err = QueryRaw(t.Context(), client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/aws/aws-sdk-go", Version: "1.33.0", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
+	vulns, _, err = QueryRaw(t.Context(), client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/aws/aws-sdk-go", Version: "1.33.0", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -332,7 +332,7 @@ func (f *fakeClientAlias) GetVulnByID(ctx context.Context, id string) (*osvschem
 func Test_QueryRaw_aliasWithoutRange(t *testing.T) {
 	resetDiskCache(t)
 	client := &fakeClientAlias{}
-	vulns, err := QueryRaw(t.Context(), client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/example/pkg", Version: "1.2.3", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
+	vulns, _, err := QueryRaw(t.Context(), client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/example/pkg", Version: "1.2.3", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -375,7 +375,7 @@ func (f *fakeClientAliasUnmatchedPackage) GetVulnByID(ctx context.Context, id st
 func Test_QueryRaw_ignoresAliasWithoutPackageIdentity(t *testing.T) {
 	resetDiskCache(t)
 	client := &fakeClientAliasUnmatchedPackage{}
-	vulns, err := QueryRaw(t.Context(), client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/example/pkg", Version: "1.2.3", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
+	vulns, _, err := QueryRaw(t.Context(), client, []PkgInput{{QueryKey: QueryKey{Name: "github.com/example/pkg", Version: "1.2.3", Ecosystem: "Go"}, PackageContext: PackageContext{IsDirect: true}}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -408,10 +408,10 @@ func Test_QueryRaw_cache(t *testing.T) {
 	resetDiskCache(t)
 	client := &countingClient{}
 	pkgs := []PkgInput{{QueryKey: QueryKey{Name: "github.com/example/pkg", Version: "1.0.0", Ecosystem: "Go"}}}
-	if _, err := QueryRaw(t.Context(), client, pkgs); err != nil {
+	if _, _, err := QueryRaw(t.Context(), client, pkgs); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if _, err := QueryRaw(t.Context(), client, pkgs); err != nil {
+	if _, _, err := QueryRaw(t.Context(), client, pkgs); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if client.calls != 1 {

--- a/internal/analysis/osv/query.go
+++ b/internal/analysis/osv/query.go
@@ -706,6 +706,14 @@ func queryOSVAPIBatch(ctx context.Context, client Client, pkgs []PkgInput) ([]Vu
 				base.Affected = true
 				var extras []Vulnerability
 				skip := false
+				// Enrichment, not retrieval: the record is already in hand, and
+				// these lookups only add severity, fix, alias, and import data
+				// from the records it is aliased to. Every failure here is
+				// therefore swallowed rather than fatal, matching Hydrate: a
+				// network blip must not fail a scan over data we already have,
+				// even though it can leave this advisory thinner than a later
+				// run would show it. The paths that decide whether the finding
+				// exists at all stay fatal; see [resolveAdvisory].
 				for _, alias := range full.GetAliases() {
 					// Use singleflight to deduplicate concurrent requests for the same alias
 					result, err, _ := aliasGroup.Do(alias, func() (any, error) {

--- a/internal/analysis/osv/query.go
+++ b/internal/analysis/osv/query.go
@@ -1,6 +1,7 @@
 package osv
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"maps"
@@ -100,10 +101,13 @@ func (u UnresolvedAdvisory) Warning() string {
 	return fmt.Sprintf("osv: advisory %s reported for %s is missing from this report: %s", u.ID, u.Package, u.Reason)
 }
 
-// unresolvedWithdrawnReason is the reason recorded when OSV will not serve a
-// record it told us about. OSV drops a record when it is withdrawn, renamed, or
-// merged into an alias, and none of those reverse on a retry.
-const unresolvedWithdrawnReason = "OSV no longer serves the record and it could not be recovered through an alias"
+// unresolvedNotFoundReason is the reason recorded when OSV will not serve a
+// record it told us about. The usual cause is withdrawal, renaming, or a merge
+// into an alias, none of which reverse on a retry, but the wording stays with
+// what was observed: the classification comes from response text rather than a
+// typed status (see [IsNotFoundError]), so it cannot promise the record is gone
+// for good.
+const unresolvedNotFoundReason = "OSV returned not found for the record, and no alias it named resolved"
 
 // AdvisoryWarnings renders unresolved advisories as scan warnings, in the order
 // given. It returns nil for an empty input so callers can assign the result
@@ -661,7 +665,7 @@ func queryOSVAPIBatch(ctx context.Context, client Client, pkgs []PkgInput) ([]Vu
 					localUnresolved = append(localUnresolved, UnresolvedAdvisory{
 						ID:      mv.GetId(),
 						Package: label,
-						Reason:  unresolvedWithdrawnReason,
+						Reason:  unresolvedNotFoundReason,
 					})
 					continue
 				}
@@ -788,17 +792,8 @@ func queryOSVAPIBatch(ctx context.Context, client Client, pkgs []PkgInput) ([]Vu
 // packageLabel names a package for a human-readable diagnostic, preferring
 // name@version and falling back to the PURL when the input carried no name.
 func packageLabel(pkg PkgInput, version string) string {
-	if version == "" {
-		version = pkg.Version
-	}
-	name := pkg.Name
-	if name == "" {
-		name = pkg.PURL
-	}
-	if name == "" {
-		name = "unknown package"
-	}
-	if version == "" {
+	name := cmp.Or(pkg.Name, pkg.PURL, "unknown package")
+	if version = cmp.Or(version, pkg.Version); version == "" {
 		return name
 	}
 	return name + "@" + version

--- a/internal/analysis/osv/query.go
+++ b/internal/analysis/osv/query.go
@@ -79,9 +79,50 @@ func NewPkgInput(key QueryKey, ctx PackageContext) PkgInput {
 	return PkgInput{QueryKey: key, PackageContext: ctx}
 }
 
+// UnresolvedAdvisory records an advisory that a batch query attributed to a
+// package but whose full record could not be retrieved, so the finding is
+// absent from the results. It is returned alongside those results rather than
+// as an error: a scan that lost one record must still report the rest, and must
+// not be mistaken for a scan that found nothing.
+type UnresolvedAdvisory struct {
+	// ID is the advisory identifier the batch query returned.
+	ID string
+	// Package identifies the package the advisory was attributed to.
+	Package string
+	// Reason explains in one line why the record could not be retrieved.
+	Reason string
+}
+
+// Warning renders the unresolved advisory for the scan's warning list. It leads
+// with the omission rather than the cause, because the omission is what changes
+// the reader's picture of their risk.
+func (u UnresolvedAdvisory) Warning() string {
+	return fmt.Sprintf("osv: advisory %s reported for %s is missing from this report: %s", u.ID, u.Package, u.Reason)
+}
+
+// unresolvedWithdrawnReason is the reason recorded when OSV will not serve a
+// record it told us about. OSV drops a record when it is withdrawn, renamed, or
+// merged into an alias, and none of those reverse on a retry.
+const unresolvedWithdrawnReason = "OSV no longer serves the record and it could not be recovered through an alias"
+
+// AdvisoryWarnings renders unresolved advisories as scan warnings, in the order
+// given. It returns nil for an empty input so callers can assign the result
+// straight onto a warning list without adding an empty entry.
+func AdvisoryWarnings(unresolved []UnresolvedAdvisory) []string {
+	if len(unresolved) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(unresolved))
+	for _, u := range unresolved {
+		out = append(out, u.Warning())
+	}
+	return out
+}
+
 // getCachedVuln retrieves a vulnerability by ID using the provided client,
 // consulting a local on-disk cache when available to avoid redundant network
-// requests. Successful responses are cached for future lookups.
+// requests. Successful responses are cached for future lookups; failures are
+// not, so a record that reappears upstream resolves on the next run.
 func getCachedVuln(ctx context.Context, client Client, id string) (*osvschema.Vulnerability, error) {
 	var v osvschema.Vulnerability
 	if disk.ReadProto("osv", id, osvCacheTTL, &v) {
@@ -97,6 +138,57 @@ func getCachedVuln(ctx context.Context, client Client, id string) (*osvschema.Vu
 	return res, nil
 }
 
+// resolveAdvisory retrieves the full OSV record for an advisory ID that a batch
+// query reported.
+//
+// A not-found response is permanent: OSV withdrew, renamed, or merged the
+// record, and asking again for the same ID will keep failing. That response
+// names the IDs that do still exist, so resolveAdvisory retries against each of
+// them, preferring the reviewed databases first, and returns the first record
+// that is about pkg. The record it returns may therefore carry a different ID
+// than the one requested. Requiring the recovered record to name pkg is what
+// makes the recovery safe, because the alias list is read out of the response
+// text rather than from a typed field: a misread ID resolves to a record about
+// some other package and is rejected here.
+//
+// Whether pkg's installed version falls in the recovered record's affected
+// ranges is deliberately left to the caller, so an alias that says "not
+// affected" reads as the answer it is rather than as a failed recovery.
+//
+// Any other failure, including a cancelled context and a server error the
+// client already retried, is returned unchanged so callers can keep treating it
+// as fatal. Distinguishing the two rests on [IsNotFoundError].
+func resolveAdvisory(ctx context.Context, client Client, id string, pkg PkgInput) (*osvschema.Vulnerability, error) {
+	full, err := getCachedVuln(ctx, client, id)
+	if err == nil {
+		return full, nil
+	}
+	if !IsNotFoundError(err) {
+		return nil, err
+	}
+	for _, alias := range SeverityAliasOrder(NotFoundAliases(err)) {
+		if strings.EqualFold(alias, id) {
+			continue
+		}
+		// A cancelled scan must never be reported as a withdrawn advisory, so
+		// stop recovering instead of spending more lookups on a dead context.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		aliasVuln, aliasErr := getCachedVuln(ctx, client, alias)
+		if aliasErr != nil || aliasVuln == nil {
+			continue
+		}
+		if !slices.ContainsFunc(aliasVuln.GetAffected(), func(a *osvschema.Affected) bool {
+			return matchesPackage(a.GetPackage(), pkg)
+		}) {
+			continue
+		}
+		return aliasVuln, nil
+	}
+	return nil, err
+}
+
 const osvCacheTTL = 24 * time.Hour
 
 // osvConcurrencyLimit controls the maximum number of concurrent GetVulnByID
@@ -106,18 +198,27 @@ const osvConcurrencyLimit = 10
 
 // Query performs a batched OSV vulnerability lookup and returns domain types.
 // This is the primary API for scan operations that need findings and advisories.
-func Query(ctx context.Context, client Client, pkgs []PkgInput) ([]vulnerability.Finding, map[string]*vulnerabilityv1.Advisory, error) {
-	vulns, err := QueryRaw(ctx, client, pkgs)
+// The third result lists advisories the batch query reported but whose records
+// could not be retrieved; it is not an error, but callers must surface it rather
+// than present the findings as the complete answer.
+func Query(ctx context.Context, client Client, pkgs []PkgInput) ([]vulnerability.Finding, map[string]*vulnerabilityv1.Advisory, []UnresolvedAdvisory, error) {
+	vulns, unresolved, err := QueryRaw(ctx, client, pkgs)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	return splitVulnerabilities(vulns)
+	findings, advisories, err := splitVulnerabilities(vulns)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return findings, advisories, unresolved, nil
 }
 
 // QueryRaw performs a batched OSV vulnerability lookup and returns flat Vulnerability records.
 // Use this when you need the raw OSV data format (e.g., for caching or policy evaluation maps).
 // For scan operations that need domain types, use Query instead.
-func QueryRaw(ctx context.Context, client Client, pkgs []PkgInput) ([]Vulnerability, error) {
+// The second result lists advisories whose records could not be retrieved, as
+// described on [Query].
+func QueryRaw(ctx context.Context, client Client, pkgs []PkgInput) ([]Vulnerability, []UnresolvedAdvisory, error) {
 	return queryBatch(ctx, client, pkgs)
 }
 
@@ -129,10 +230,14 @@ func QueryRaw(ctx context.Context, client Client, pkgs []PkgInput) ([]Vulnerabil
 // Returns:
 //   - findings: slice of proto Finding messages
 //   - advisories: map of advisory IDs to proto Advisory messages
+//   - unresolved: advisories the batch query reported whose records could not be
+//     retrieved, so the corresponding findings are missing from findings. Not an
+//     error, but callers must surface it rather than present the result as
+//     complete.
 //   - error: any error encountered during the query
-func QueryProto(ctx context.Context, client Client, pkgs []*dependencyv1.Package) ([]*vulnerabilityv1.Finding, map[string]*vulnerabilityv1.Advisory, error) {
+func QueryProto(ctx context.Context, client Client, pkgs []*dependencyv1.Package) ([]*vulnerabilityv1.Finding, map[string]*vulnerabilityv1.Advisory, []UnresolvedAdvisory, error) {
 	if len(pkgs) == 0 {
-		return nil, map[string]*vulnerabilityv1.Advisory{}, nil
+		return nil, map[string]*vulnerabilityv1.Advisory{}, nil, nil
 	}
 
 	// Convert proto packages to PkgInput for the existing query infrastructure.
@@ -173,13 +278,17 @@ func QueryProto(ctx context.Context, client Client, pkgs []*dependencyv1.Package
 	}
 
 	// Query using existing infrastructure
-	vulns, err := queryBatch(ctx, client, inputs)
+	vulns, unresolved, err := queryBatch(ctx, client, inputs)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	// Convert to proto types
-	return splitVulnerabilitiesToProto(vulns)
+	findings, advisories, err := splitVulnerabilitiesToProto(vulns)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return findings, advisories, unresolved, nil
 }
 
 // splitVulnerabilitiesToProto converts flat Vulnerability records to proto types.
@@ -342,9 +451,11 @@ func splitVulnerability(v Vulnerability) (*vulnerabilityv1.Advisory, vulnerabili
 // queryBatch performs a batched OSV vulnerability lookup for the provided packages,
 // returning flat Vulnerability records. For each minimal vulnerability match it
 // expands full vulnerability details via GetVulnByID to populate rich fields.
-func queryBatch(ctx context.Context, client Client, pkgs []PkgInput) ([]Vulnerability, error) {
+// Advisories whose records OSV would not serve are returned separately so the
+// caller can report them; see [Query].
+func queryBatch(ctx context.Context, client Client, pkgs []PkgInput) ([]Vulnerability, []UnresolvedAdvisory, error) {
 	if len(pkgs) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 	var ghaPkgs []PkgInput
 	var otherPkgs []PkgInput
@@ -373,27 +484,29 @@ func queryBatch(ctx context.Context, client Client, pkgs []PkgInput) ([]Vulnerab
 	}
 
 	var out []Vulnerability
+	var unresolved []UnresolvedAdvisory
 	if len(otherPkgs) > 0 {
-		vv, err := queryOSVAPIBatch(ctx, client, otherPkgs)
+		vv, uu, err := queryOSVAPIBatch(ctx, client, otherPkgs)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		out = append(out, vv...)
+		unresolved = append(unresolved, uu...)
 	}
 	if len(ghaPkgs) > 0 {
 		vv, err := queryOSVGHABucketBatch(ctx, client, ghaPkgs)
 		if err != nil {
 			if len(out) > 0 {
-				return out, err
+				return out, unresolved, err
 			}
-			return nil, err
+			return nil, unresolved, err
 		}
 		out = append(out, vv...)
 	}
 	if len(out) == 0 {
-		return nil, nil
+		return nil, unresolved, nil
 	}
-	return out, nil
+	return out, unresolved, nil
 }
 
 // osvAPIQueryable reports whether OSV's querybatch API can resolve this
@@ -435,10 +548,13 @@ func isGitHubActionsInput(p PkgInput) bool {
 	return false
 }
 
-// queryOSVAPIBatch performs the standard OSV v1/querybatch flow.
-func queryOSVAPIBatch(ctx context.Context, client Client, pkgs []PkgInput) ([]Vulnerability, error) {
+// queryOSVAPIBatch performs the standard OSV v1/querybatch flow. Advisories the
+// batch reported whose records OSV would not serve are returned as unresolved
+// rather than failing the batch; see [resolveAdvisory] for which failures stay
+// fatal.
+func queryOSVAPIBatch(ctx context.Context, client Client, pkgs []PkgInput) ([]Vulnerability, []UnresolvedAdvisory, error) {
 	if len(pkgs) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 	startTime := time.Now()
 	queries := make([]*api.Query, 0, len(pkgs))
@@ -493,13 +609,14 @@ func queryOSVAPIBatch(ctx context.Context, client Client, pkgs []PkgInput) ([]Vu
 	}
 
 	if len(queries) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 	resp, err := client.QueryBatch(ctx, queries)
 	if err != nil {
-		return nil, fmt.Errorf("failed to query OSV API: %w", err)
+		return nil, nil, fmt.Errorf("failed to query OSV API: %w", err)
 	}
 	var out []Vulnerability
+	var unresolved []UnresolvedAdvisory
 	var mu sync.Mutex
 	var aliasGroup singleflight.Group
 	g, ctx := errgroup.WithContext(ctx)
@@ -516,10 +633,40 @@ func queryOSVAPIBatch(ctx context.Context, client Client, pkgs []PkgInput) ([]Vu
 				displayVersion = ver
 			}
 			var local []Vulnerability
+			var localUnresolved []UnresolvedAdvisory
+			// Alias recovery can land on a record the batch query already named
+			// in its own right, since OSV lists a withdrawn ID alongside the
+			// live alias that replaced it. Track what this package resolved to
+			// so the same advisory is not reported against it twice.
+			resolvedIDs := collections.NewSet[string]()
 			for _, mv := range res.GetVulns() {
-				full, err := getCachedVuln(ctx, client, mv.GetId())
+				full, err := resolveAdvisory(ctx, client, mv.GetId(), pkgMeta)
 				if err != nil {
-					return fmt.Errorf("expand vulnerability %s: %w", mv.GetId(), err)
+					if !IsNotFoundError(err) {
+						// A transport failure, a server error the client already
+						// retried, or a cancelled scan means the expansion path
+						// is broken rather than one record having moved. Stay
+						// fatal: results missing advisories for a reason that
+						// will not reproduce must not be reported as complete.
+						return fmt.Errorf("expand vulnerability %s: %w", mv.GetId(), err)
+					}
+					// One withdrawn record must not cost the caller every other
+					// package's findings, so record the gap and keep going.
+					label := packageLabel(pkgMeta, displayVersion)
+					logs.Debug(ctx, "deputy.osv.advisory_unresolved",
+						"advisory", mv.GetId(),
+						"package", label,
+						"error", err,
+					)
+					localUnresolved = append(localUnresolved, UnresolvedAdvisory{
+						ID:      mv.GetId(),
+						Package: label,
+						Reason:  unresolvedWithdrawnReason,
+					})
+					continue
+				}
+				if !resolvedIDs.Add(full.GetId()) {
+					continue
 				}
 				if !isVersionAffected(full, pkgMeta) {
 					continue
@@ -601,9 +748,10 @@ func queryOSVAPIBatch(ctx context.Context, client Client, pkgs []PkgInput) ([]Vu
 				base.DatabaseSpecific = dbSpecific
 				local = append(local, base)
 			}
-			if len(local) > 0 {
+			if len(local) > 0 || len(localUnresolved) > 0 {
 				mu.Lock()
 				out = append(out, local...)
+				unresolved = append(unresolved, localUnresolved...)
 				mu.Unlock()
 			}
 			return nil
@@ -611,10 +759,49 @@ func queryOSVAPIBatch(ctx context.Context, client Client, pkgs []PkgInput) ([]Vu
 	}
 	if err := g.Wait(); err != nil {
 		otel.RecordOSVQuery(ctx, time.Since(startTime).Seconds(), "batch", false)
-		return nil, err
+		return nil, nil, err
 	}
 	otel.RecordOSVQuery(ctx, time.Since(startTime).Seconds(), "batch", true)
-	return out, nil
+	if len(unresolved) > 0 {
+		// Order by advisory then package so repeated scans of the same target
+		// produce the same warnings: expansion runs concurrently, so arrival
+		// order is not stable.
+		slices.SortFunc(unresolved, func(a, b UnresolvedAdvisory) int {
+			if c := strings.Compare(a.ID, b.ID); c != 0 {
+				return c
+			}
+			return strings.Compare(a.Package, b.Package)
+		})
+		// Debug, not warn: the caller already surfaces these in the report, and
+		// logging them again would say the same thing twice on one terminal.
+		logs.Debug(ctx, "deputy.osv.advisories_unresolved",
+			"unresolved", len(unresolved),
+			"resolved", len(out),
+		)
+		if span := otel.SpanFromContext(ctx); span != nil && span.IsRecording() {
+			span.SetAttributes(otel.AttrOSVUnresolvedAdvisories.Int(len(unresolved)))
+		}
+	}
+	return out, unresolved, nil
+}
+
+// packageLabel names a package for a human-readable diagnostic, preferring
+// name@version and falling back to the PURL when the input carried no name.
+func packageLabel(pkg PkgInput, version string) string {
+	if version == "" {
+		version = pkg.Version
+	}
+	name := pkg.Name
+	if name == "" {
+		name = pkg.PURL
+	}
+	if name == "" {
+		name = "unknown package"
+	}
+	if version == "" {
+		return name
+	}
+	return name + "@" + version
 }
 
 func normalizeQueryInput(p PkgInput) PkgInput {

--- a/internal/analysis/osv/query.go
+++ b/internal/analysis/osv/query.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/mod/semver"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/singleflight"
+	"google.golang.org/protobuf/proto"
 	"osv.dev/bindings/go/api"
 
 	containerv1 "github.com/temporalio/deputy/gen/deputy/container/v1"
@@ -163,11 +164,16 @@ func getCachedVuln(ctx context.Context, client Client, id string) (*osvschema.Vu
 // record, and asking again for the same ID will keep failing. That response
 // names the IDs that do still exist, so resolveAdvisory retries against each of
 // them, preferring the reviewed databases first, and returns the first record
-// that is about pkg. The record it returns may therefore carry a different ID
-// than the one requested. Requiring the recovered record to name pkg is what
-// makes the recovery safe, because the alias list is read out of the response
-// text rather than from a typed field: a misread ID resolves to a record about
-// some other package and is rejected here.
+// that is about pkg. The record comes back under the requested id rather than
+// the alias it was recovered from; see [supersededBy]. Requiring the recovered
+// record to name pkg is what makes the recovery safe, because the alias list is
+// read out of the response text rather than from a typed field: a misread ID
+// resolves to a record about some other package and is rejected here.
+//
+// The second result is the ID whose record actually supplied the data: id
+// itself on a direct hit, or the alias recovery went through. Callers need it to
+// tell two batch entries that resolved to one record apart from two genuinely
+// distinct advisories, which the returned identity alone no longer reveals.
 //
 // Whether pkg's installed version falls in the recovered record's affected
 // ranges is deliberately left to the caller, so an alias that says "not
@@ -182,13 +188,13 @@ func getCachedVuln(ctx context.Context, client Client, id string) (*osvschema.Vu
 // the record moved. Returning the original not-found error in that case would
 // downgrade a transient failure into a permanent verdict, so the alias error
 // wins instead.
-func resolveAdvisory(ctx context.Context, client Client, id string, pkg PkgInput) (*osvschema.Vulnerability, error) {
+func resolveAdvisory(ctx context.Context, client Client, id string, pkg PkgInput) (*osvschema.Vulnerability, string, error) {
 	full, err := getCachedVuln(ctx, client, id)
 	if err == nil {
-		return full, nil
+		return full, id, nil
 	}
 	if !IsNotFoundError(err) {
-		return nil, err
+		return nil, "", err
 	}
 	// The first alias failure that was not itself a not-found response. Kept
 	// rather than returned on the spot so a later alias can still recover the
@@ -201,7 +207,7 @@ func resolveAdvisory(ctx context.Context, client Client, id string, pkg PkgInput
 		// A cancelled scan must never be reported as a withdrawn advisory, so
 		// stop recovering instead of spending more lookups on a dead context.
 		if ctxErr := ctx.Err(); ctxErr != nil {
-			return nil, ctxErr
+			return nil, "", ctxErr
 		}
 		aliasVuln, lookupErr := getCachedVuln(ctx, client, alias)
 		if lookupErr != nil {
@@ -218,19 +224,48 @@ func resolveAdvisory(ctx context.Context, client Client, id string, pkg PkgInput
 		}) {
 			continue
 		}
-		return aliasVuln, nil
+		return supersededBy(aliasVuln, id), alias, nil
 	}
 	if aliasErr != nil {
-		return nil, aliasErr
+		return nil, "", aliasErr
 	}
 	// Cancellation can also arrive while the last alias lookup is in flight, in
 	// which case the loop's own check never sees it and the original not-found
 	// error would be handed back as a withdrawal. Recheck before that verdict is
 	// final.
 	if ctxErr := ctx.Err(); ctxErr != nil {
-		return nil, ctxErr
+		return nil, "", ctxErr
 	}
-	return nil, err
+	return nil, "", err
+}
+
+// supersededBy returns recovered's data under supersededID, the ID the batch
+// query named and could not expand, and keeps recovered's own ID among the
+// aliases so the record a reader can still look up stays discoverable.
+//
+// Identity has to follow the ID the caller asked about, because that is the ID
+// every downstream surface keys on: a suppression in .deputyignore.yaml, an
+// ignore rule, a policy that names the advisory. Handing back the recovered ID
+// instead retires all of them silently, which is worse than the gap the recovery
+// closed. This mirrors [HydrateSparseVulnerabilityAliases], which merges alias
+// records and then restores the queried identity the same way, for the same
+// reason.
+//
+// The record is cloned before anything is written to it. getCachedVuln can
+// return a pointer the Client owns and reuses across calls, resolveAdvisory runs
+// on up to osvConcurrencyLimit goroutines sharing one client, and removeEqualFold
+// rewrites its input slice in place, so mutating the argument could corrupt a
+// record another lookup in the same scan is about to read.
+func supersededBy(recovered *osvschema.Vulnerability, supersededID string) *osvschema.Vulnerability {
+	out := proto.CloneOf(recovered)
+	// OSV records are usually mutually aliased, so the recovered ID is normally
+	// already listed; mergeUniqueEqualFold adds it only when it is not, which
+	// keeps a duplicate entry from being this fix's own small defect.
+	out.Aliases = mergeUniqueEqualFold(out.GetAliases(), []string{out.GetId()})
+	// A record must not list itself as its own alias.
+	out.Aliases = removeEqualFold(out.GetAliases(), supersededID)
+	out.Id = supersededID
+	return out
 }
 
 const osvCacheTTL = 24 * time.Hour
@@ -680,11 +715,21 @@ func queryOSVAPIBatch(ctx context.Context, client Client, pkgs []PkgInput) ([]Vu
 			var localUnresolved []UnresolvedAdvisory
 			// Alias recovery can land on a record the batch query already named
 			// in its own right, since OSV lists a withdrawn ID alongside the
-			// live alias that replaced it. Track what this package resolved to
-			// so the same advisory is not reported against it twice.
+			// live alias that replaced it. Track which record each entry
+			// resolved to, keyed on the ID that supplied the data rather than
+			// the ID now reported, so the same advisory is not reported against
+			// this package twice.
 			resolvedIDs := collections.NewSet[string]()
+			// The IDs the batch named for this package. When recovery lands on
+			// one of them, that entry's own lookup will report the finding
+			// directly, so the recovered duplicate is dropped instead of
+			// racing it for which ID the finding carries.
+			batchIDs := collections.NewSet[string]()
 			for _, mv := range res.GetVulns() {
-				full, err := resolveAdvisory(ctx, client, mv.GetId(), pkgMeta)
+				batchIDs.Add(mv.GetId())
+			}
+			for _, mv := range res.GetVulns() {
+				full, sourceID, err := resolveAdvisory(ctx, client, mv.GetId(), pkgMeta)
 				if err != nil {
 					if !IsNotFoundError(err) {
 						// A transport failure, a server error the client already
@@ -709,7 +754,14 @@ func queryOSVAPIBatch(ctx context.Context, client Client, pkgs []PkgInput) ([]Vu
 					})
 					continue
 				}
-				if !resolvedIDs.Add(full.GetId()) {
+				// Recovery reached a record the batch also named on its own.
+				// That entry resolves it directly and keeps its own identity,
+				// so drop this redundant copy rather than letting response
+				// order decide which of the two IDs the finding carries.
+				if sourceID != mv.GetId() && batchIDs.Has(sourceID) {
+					continue
+				}
+				if !resolvedIDs.Add(sourceID) {
 					continue
 				}
 				if !isVersionAffected(full, pkgMeta) {

--- a/internal/analysis/osv/query.go
+++ b/internal/analysis/osv/query.go
@@ -81,10 +81,15 @@ func NewPkgInput(key QueryKey, ctx PackageContext) PkgInput {
 }
 
 // UnresolvedAdvisory records an advisory that a batch query attributed to a
-// package but whose full record could not be retrieved, so the finding is
-// absent from the results. It is returned alongside those results rather than
-// as an error: a scan that lost one record must still report the rest, and must
-// not be mistaken for a scan that found nothing.
+// package but whose full record could not be retrieved, so OSV contributes no
+// finding for it. It is returned alongside the findings that did resolve rather
+// than as an error: a scan that lost one record must still report the rest, and
+// must not be mistaken for a scan that found nothing.
+//
+// It says what OSV did and did not answer, not what the report ends up
+// containing. A deployment can configure several advisory sources, and another
+// one may report the very advisory OSV could not expand, so only the caller
+// merging the sources knows whether a finding exists.
 type UnresolvedAdvisory struct {
 	// ID is the advisory identifier the batch query returned.
 	ID string
@@ -97,8 +102,17 @@ type UnresolvedAdvisory struct {
 // Warning renders the unresolved advisory for the scan's warning list. It leads
 // with the omission rather than the cause, because the omission is what changes
 // the reader's picture of their risk.
+//
+// The omission is scoped to OSV's findings, not to the report, and that scope is
+// load-bearing. Warnings from every configured advisory source union into one
+// list, and another source may have reported the same advisory and package, in
+// which case the report does contain the finding. Claiming the report was short
+// would then be false. It names osv rather than saying "this source" for the
+// same reason: in a merged list, a deictic reference has nothing to point at.
+// Readers who want to know which sources backed a finding have
+// findings[].sources.
 func (u UnresolvedAdvisory) Warning() string {
-	return fmt.Sprintf("osv: advisory %s reported for %s is missing from this report: %s", u.ID, u.Package, u.Reason)
+	return fmt.Sprintf("osv: advisory %s reported for %s is absent from osv's findings: %s", u.ID, u.Package, u.Reason)
 }
 
 // unresolvedNotFoundReason is the reason recorded when OSV will not serve a

--- a/internal/analysis/osv/query.go
+++ b/internal/analysis/osv/query.go
@@ -161,7 +161,13 @@ func getCachedVuln(ctx context.Context, client Client, id string) (*osvschema.Vu
 //
 // Any other failure, including a cancelled context and a server error the
 // client already retried, is returned unchanged so callers can keep treating it
-// as fatal. Distinguishing the two rests on [IsNotFoundError].
+// as fatal. Distinguishing the two rests on [IsNotFoundError]. That split
+// applies to the alias lookups too: an alias that is itself not found simply
+// offers no recovery and the search moves on, but an alias that fails for any
+// other reason means the expansion path is broken and we never learned whether
+// the record moved. Returning the original not-found error in that case would
+// downgrade a transient failure into a permanent verdict, so the alias error
+// wins instead.
 func resolveAdvisory(ctx context.Context, client Client, id string, pkg PkgInput) (*osvschema.Vulnerability, error) {
 	full, err := getCachedVuln(ctx, client, id)
 	if err == nil {
@@ -170,6 +176,10 @@ func resolveAdvisory(ctx context.Context, client Client, id string, pkg PkgInput
 	if !IsNotFoundError(err) {
 		return nil, err
 	}
+	// The first alias failure that was not itself a not-found response. Kept
+	// rather than returned on the spot so a later alias can still recover the
+	// record: a working recovery is a better answer than any error.
+	var aliasErr error
 	for _, alias := range SeverityAliasOrder(NotFoundAliases(err)) {
 		if strings.EqualFold(alias, id) {
 			continue
@@ -179,8 +189,14 @@ func resolveAdvisory(ctx context.Context, client Client, id string, pkg PkgInput
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, ctxErr
 		}
-		aliasVuln, aliasErr := getCachedVuln(ctx, client, alias)
-		if aliasErr != nil || aliasVuln == nil {
+		aliasVuln, lookupErr := getCachedVuln(ctx, client, alias)
+		if lookupErr != nil {
+			if !IsNotFoundError(lookupErr) && aliasErr == nil {
+				aliasErr = fmt.Errorf("resolve alias %s of %s: %w", alias, id, lookupErr)
+			}
+			continue
+		}
+		if aliasVuln == nil {
 			continue
 		}
 		if !slices.ContainsFunc(aliasVuln.GetAffected(), func(a *osvschema.Affected) bool {
@@ -189,6 +205,16 @@ func resolveAdvisory(ctx context.Context, client Client, id string, pkg PkgInput
 			continue
 		}
 		return aliasVuln, nil
+	}
+	if aliasErr != nil {
+		return nil, aliasErr
+	}
+	// Cancellation can also arrive while the last alias lookup is in flight, in
+	// which case the loop's own check never sees it and the original not-found
+	// error would be handed back as a withdrawal. Recheck before that verdict is
+	// final.
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return nil, ctxErr
 	}
 	return nil, err
 }

--- a/internal/analysis/osv/unresolved_test.go
+++ b/internal/analysis/osv/unresolved_test.go
@@ -342,7 +342,7 @@ func TestUnresolvedAdvisoryWarning(t *testing.T) {
 				Reason:  unresolvedNotFoundReason,
 			}},
 			want: []string{
-				"osv: advisory GO-2026-6255 reported for github.com/moby/buildkit@v0.30.0 is missing from this report: " +
+				"osv: advisory GO-2026-6255 reported for github.com/moby/buildkit@v0.30.0 is absent from osv's findings: " +
 					"OSV returned not found for the record, and no alias it named resolved",
 			},
 		},

--- a/internal/analysis/osv/unresolved_test.go
+++ b/internal/analysis/osv/unresolved_test.go
@@ -102,7 +102,11 @@ func TestQueryRaw_UnresolvedAdvisories(t *testing.T) {
 		wantErrContains string
 		wantErr         bool
 		wantAdvisories  []string
-		wantUnresolved  []UnresolvedAdvisory
+		// wantAliases, when set, pins the aliases on the single reported
+		// finding. Recovery has to leave the record it recovered through
+		// discoverable here, and exactly once.
+		wantAliases    []string
+		wantUnresolved []UnresolvedAdvisory
 	}{
 		{
 			// The reported bug: one withdrawn record used to abort everything.
@@ -153,7 +157,10 @@ func TestQueryRaw_UnresolvedAdvisories(t *testing.T) {
 				},
 			},
 			// GHSA first: SeverityAliasOrder prefers the reviewed database.
-			wantAdvisories: []string{ghsaAlias},
+			// The finding keeps the ID the batch reported, so a suppression
+			// naming it still matches, with the recovered ID as an alias.
+			wantAdvisories: []string{withdrawn},
+			wantAliases:    []string{ghsaAlias},
 		},
 		{
 			name: "alias that also 404s leaves the advisory unresolved",
@@ -185,7 +192,8 @@ func TestQueryRaw_UnresolvedAdvisories(t *testing.T) {
 					cveAlias: affectedRecord(cveAlias, buildkit),
 				},
 			},
-			wantAdvisories: []string{cveAlias},
+			wantAdvisories: []string{withdrawn},
+			wantAliases:    []string{cveAlias},
 		},
 		{
 			// The defect this pins: a network blip on the alias used to be
@@ -228,7 +236,8 @@ func TestQueryRaw_UnresolvedAdvisories(t *testing.T) {
 					cveAlias: affectedRecord(cveAlias, buildkit),
 				},
 			},
-			wantAdvisories: []string{cveAlias},
+			wantAdvisories: []string{withdrawn},
+			wantAliases:    []string{cveAlias},
 		},
 		{
 			// The alias list is read out of response text, so a record about
@@ -318,6 +327,15 @@ func TestQueryRaw_UnresolvedAdvisories(t *testing.T) {
 
 			if !slices.Equal(unresolved, tt.wantUnresolved) {
 				t.Errorf("unresolved = %+v, want %+v", unresolved, tt.wantUnresolved)
+			}
+
+			if tt.wantAliases != nil {
+				if len(vulns) != 1 {
+					t.Fatalf("findings = %d, want exactly 1 to check its aliases", len(vulns))
+				}
+				if got := vulns[0].Aliases; !slices.Equal(got, tt.wantAliases) {
+					t.Errorf("finding aliases = %q, want %q (recovered ID must appear exactly once)", got, tt.wantAliases)
+				}
 			}
 		})
 	}
@@ -611,6 +629,176 @@ func TestQueryRaw_AliasEnrichmentFailuresAreSilent(t *testing.T) {
 			}
 			if gotRated := vulns[0].Severity != ""; gotRated != tt.wantRated {
 				t.Fatalf("finding carries a severity = %t (%q), want %t", gotRated, vulns[0].Severity, tt.wantRated)
+			}
+		})
+	}
+}
+
+// TestSupersededByDoesNotMutateTheRecoveredRecord guards the cache hazard in
+// re-identifying a recovered record. getCachedVuln returns whatever the Client
+// hands back, and a client with its own cache returns the same pointer to every
+// caller, so writing Id or Aliases onto that pointer would corrupt the entry for
+// the alias and serve it wrong to the next lookup in the same scan. The two
+// packages here both recover through one shared record, which is the shape that
+// turns such a mutation into a visible wrong answer rather than a latent race.
+func TestSupersededByDoesNotMutateTheRecoveredRecord(t *testing.T) {
+	const (
+		buildkit   = "github.com/moby/buildkit"
+		containerd = "github.com/containerd/containerd"
+		withdrawnA = "GO-2026-6255"
+		withdrawnB = "GO-2026-9999"
+		liveAlias  = "GHSA-7236-3392-c5c6"
+		priorCVE   = "CVE-2026-61711"
+	)
+
+	// One record, one pointer, handed to every lookup: the shape a client with
+	// an internal cache produces.
+	shared := affectedRecord(liveAlias, buildkit)
+	shared.Aliases = []string{priorCVE}
+	shared.Affected = append(shared.Affected, &osvschema.Affected{
+		Package: &osvschema.Package{Name: containerd, Ecosystem: "Go"},
+		Ranges: []*osvschema.Range{{
+			Type:   osvschema.Range_SEMVER,
+			Events: []*osvschema.Event{{Introduced: "0"}},
+		}},
+	})
+
+	resetDiskCache(t)
+	client := &scriptedClient{
+		batch: map[string][]string{
+			buildkit:   {withdrawnA},
+			containerd: {withdrawnB},
+		},
+		failures: map[string]error{
+			withdrawnA: notFoundErr(liveAlias),
+			withdrawnB: notFoundErr(liveAlias),
+		},
+		records: map[string]*osvschema.Vulnerability{liveAlias: shared},
+	}
+
+	vulns, unresolved, err := QueryRaw(t.Context(), client, []PkgInput{
+		{QueryKey: QueryKey{Name: buildkit, Version: "v0.30.0", Ecosystem: "Go"}},
+		{QueryKey: QueryKey{Name: containerd, Version: "v1.7.0", Ecosystem: "Go"}},
+	})
+	if err != nil {
+		t.Fatalf("QueryRaw() error = %v, want nil", err)
+	}
+	if len(unresolved) != 0 {
+		t.Fatalf("unresolved = %+v, want none: both recovered", unresolved)
+	}
+
+	// Each package keeps the ID its own batch entry reported, which is only
+	// possible if neither re-identification disturbed the other's record.
+	gotIDs := make([]string, 0, len(vulns))
+	for _, v := range vulns {
+		gotIDs = append(gotIDs, v.ID)
+	}
+	slices.Sort(gotIDs)
+	wantIDs := []string{withdrawnA, withdrawnB}
+	slices.Sort(wantIDs)
+	if !slices.Equal(gotIDs, wantIDs) {
+		t.Errorf("advisory IDs = %q, want %q", gotIDs, wantIDs)
+	}
+
+	// The shared record itself is untouched, so a later lookup for the alias
+	// still gets the alias.
+	if got := shared.GetId(); got != liveAlias {
+		t.Errorf("shared record Id = %q, want %q: re-identification wrote through to the cached record", got, liveAlias)
+	}
+	if got := shared.GetAliases(); !slices.Equal(got, []string{priorCVE}) {
+		t.Errorf("shared record aliases = %q, want %q: re-identification wrote through to the cached record", got, []string{priorCVE})
+	}
+
+	// And a second read of the same alias is unaffected.
+	again, err := client.GetVulnByID(t.Context(), liveAlias)
+	if err != nil {
+		t.Fatalf("second GetVulnByID(%s) error = %v", liveAlias, err)
+	}
+	if got := again.GetId(); got != liveAlias {
+		t.Errorf("second read of %s has Id = %q, want %q", liveAlias, got, liveAlias)
+	}
+	if got := again.GetAliases(); !slices.Equal(got, []string{priorCVE}) {
+		t.Errorf("second read of %s has aliases = %q, want %q", liveAlias, got, []string{priorCVE})
+	}
+}
+
+// TestSupersededByRestoresIdentity covers re-identifying a recovered record:
+// the reported ID becomes the superseded one, the recovered ID stays reachable
+// through the aliases exactly once, and the record never lists itself. It also
+// pins that the argument is untouched, because the record comes from a client
+// that may hand the same pointer to a concurrent lookup, and removeEqualFold
+// rewrites its input slice in place.
+func TestSupersededByRestoresIdentity(t *testing.T) {
+	const (
+		liveAlias    = "GHSA-7236-3392-c5c6"
+		supersededID = "GO-2026-6255"
+		priorCVE     = "CVE-2026-61711"
+	)
+
+	tests := []struct {
+		name string
+		// aliases are the recovered record's aliases before re-identification.
+		aliases     []string
+		wantAliases []string
+	}{
+		{
+			name:        "no aliases gains the recovered ID",
+			wantAliases: []string{liveAlias},
+		},
+		{
+			// The usual shape: OSV records are mutually aliased, so the
+			// recovered record already names the ID that was withdrawn. It must
+			// not survive as an alias of itself.
+			name:        "superseded ID is dropped and the recovered ID added",
+			aliases:     []string{priorCVE, supersededID},
+			wantAliases: []string{priorCVE, liveAlias},
+		},
+		{
+			// A record that already lists its own ID must not gain a second
+			// copy of it.
+			name:        "recovered ID already present is not duplicated",
+			aliases:     []string{liveAlias, supersededID},
+			wantAliases: []string{liveAlias},
+		},
+		{
+			name:        "superseded ID is dropped case-insensitively",
+			aliases:     []string{strings.ToLower(supersededID), priorCVE},
+			wantAliases: []string{priorCVE, liveAlias},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := affectedRecord(liveAlias, "github.com/moby/buildkit")
+			original.Aliases = slices.Clone(tt.aliases)
+			originalAliases := slices.Clone(tt.aliases)
+
+			out := supersededBy(original, supersededID)
+
+			if out == original {
+				t.Fatal("supersededBy returned its argument: the caller's record must not be reused")
+			}
+			if got := out.GetId(); got != supersededID {
+				t.Errorf("re-identified Id = %q, want %q", got, supersededID)
+			}
+			if got := out.GetAliases(); !slices.Equal(got, tt.wantAliases) {
+				t.Errorf("re-identified aliases = %q, want %q", got, tt.wantAliases)
+			}
+
+			// The argument is unchanged, so a concurrent lookup for the alias
+			// still sees the alias.
+			if got := original.GetId(); got != liveAlias {
+				t.Errorf("original Id = %q, want %q: supersededBy mutated its argument", got, liveAlias)
+			}
+			if got := original.GetAliases(); !slices.Equal(got, originalAliases) {
+				t.Errorf("original aliases = %q, want %q: supersededBy mutated its argument", got, originalAliases)
+			}
+			// Affected is nested structure a shallow copy would share.
+			if len(out.GetAffected()) == 0 || len(original.GetAffected()) == 0 {
+				t.Fatal("expected both records to carry affected entries")
+			}
+			if out.GetAffected()[0] == original.GetAffected()[0] {
+				t.Error("clone shares an Affected pointer with the original: the copy is not deep")
 			}
 		})
 	}

--- a/internal/analysis/osv/unresolved_test.go
+++ b/internal/analysis/osv/unresolved_test.go
@@ -530,3 +530,88 @@ func TestQueryRaw_CancelledDuringLastAliasLookupIsNotUnresolved(t *testing.T) {
 		t.Fatalf("unresolved = %+v, want none: cancellation on the last alias lookup is not a withdrawal", unresolved)
 	}
 }
+
+// TestQueryRaw_AliasEnrichmentFailuresAreSilent pins the asymmetry the scan
+// reference documents. Once a record has been fetched, the further lookups that
+// enrich it from the records it is aliased to are best-effort: a blip there must
+// not fail a scan over data already in hand, so the finding still arrives, only
+// thinner. Fatality is reserved for the paths that decide whether the finding
+// exists at all, and neither kind of failure may be filed as an unresolved
+// advisory, because the record this one is about did resolve.
+func TestQueryRaw_AliasEnrichmentFailuresAreSilent(t *testing.T) {
+	const (
+		buildkit = "github.com/moby/buildkit"
+		primary  = "GO-2026-6255"
+		cveAlias = "CVE-2026-61711"
+	)
+
+	primaryRecord := affectedRecord(primary, buildkit)
+	primaryRecord.Aliases = []string{cveAlias}
+
+	// The Go vuln DB routinely leaves severity unrated and the CVE record
+	// carries it, which is exactly what enrichment is for.
+	ratedAlias := affectedRecord(cveAlias, buildkit)
+	ratedAlias.Severity = []*osvschema.Severity{{
+		Type:  osvschema.Severity_CVSS_V3,
+		Score: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+	}}
+
+	tests := []struct {
+		name string
+		// aliasErr, when set, is what the enrichment lookup returns instead of
+		// the alias record.
+		aliasErr error
+		// wantRated is whether the finding ends up carrying the alias's rating.
+		wantRated bool
+	}{
+		{
+			// Enrichment actually working is what makes the failure cases
+			// below mean something: without this the loop could be dead code.
+			name:      "resolved alias enriches the finding's severity",
+			wantRated: true,
+		},
+		{
+			name:     "transient enrichment failure leaves the finding thinner",
+			aliasErr: errors.New("max retries exceeded: attempt 4: request failed: dial tcp: i/o timeout"),
+		},
+		{
+			name:     "exhausted enrichment retry leaves the finding thinner",
+			aliasErr: errors.New(`max retries exceeded: server error: status="503 Service Unavailable" body=busy`),
+		},
+		{
+			name:     "not-found alias leaves the finding thinner",
+			aliasErr: notFoundErr(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetDiskCache(t)
+			client := &scriptedClient{
+				batch:   map[string][]string{buildkit: {primary}},
+				records: map[string]*osvschema.Vulnerability{primary: primaryRecord},
+			}
+			if tt.aliasErr != nil {
+				client.failures = map[string]error{cveAlias: tt.aliasErr}
+			} else {
+				client.records[cveAlias] = ratedAlias
+			}
+
+			vulns, unresolved, err := QueryRaw(t.Context(), client, []PkgInput{
+				{QueryKey: QueryKey{Name: buildkit, Version: "v0.30.0", Ecosystem: "Go"}},
+			})
+			if err != nil {
+				t.Fatalf("QueryRaw() error = %v, want nil: enrichment must not fail a scan", err)
+			}
+			if len(unresolved) != 0 {
+				t.Fatalf("unresolved = %+v, want none: the advisory's own record resolved", unresolved)
+			}
+			if len(vulns) != 1 || vulns[0].ID != primary {
+				t.Fatalf("findings = %+v, want exactly one for %s", vulns, primary)
+			}
+			if gotRated := vulns[0].Severity != ""; gotRated != tt.wantRated {
+				t.Fatalf("finding carries a severity = %t (%q), want %t", gotRated, vulns[0].Severity, tt.wantRated)
+			}
+		})
+	}
+}

--- a/internal/analysis/osv/unresolved_test.go
+++ b/internal/analysis/osv/unresolved_test.go
@@ -3,6 +3,7 @@ package osv
 import (
 	"context"
 	"errors"
+	"fmt"
 	"slices"
 	"strings"
 	"testing"
@@ -120,7 +121,7 @@ func TestQueryRaw_UnresolvedAdvisories(t *testing.T) {
 			wantUnresolved: []UnresolvedAdvisory{{
 				ID:      withdrawn,
 				Package: buildkit + "@v0.30.0",
-				Reason:  unresolvedWithdrawnReason,
+				Reason:  unresolvedNotFoundReason,
 			}},
 		},
 		{
@@ -132,7 +133,7 @@ func TestQueryRaw_UnresolvedAdvisories(t *testing.T) {
 			wantUnresolved: []UnresolvedAdvisory{{
 				ID:      withdrawn,
 				Package: buildkit + "@v0.30.0",
-				Reason:  unresolvedWithdrawnReason,
+				Reason:  unresolvedNotFoundReason,
 			}},
 		},
 		{
@@ -162,7 +163,7 @@ func TestQueryRaw_UnresolvedAdvisories(t *testing.T) {
 			wantUnresolved: []UnresolvedAdvisory{{
 				ID:      withdrawn,
 				Package: buildkit + "@v0.30.0",
-				Reason:  unresolvedWithdrawnReason,
+				Reason:  unresolvedNotFoundReason,
 			}},
 		},
 		{
@@ -179,7 +180,7 @@ func TestQueryRaw_UnresolvedAdvisories(t *testing.T) {
 			wantUnresolved: []UnresolvedAdvisory{{
 				ID:      withdrawn,
 				Package: buildkit + "@v0.30.0",
-				Reason:  unresolvedWithdrawnReason,
+				Reason:  unresolvedNotFoundReason,
 			}},
 		},
 		{
@@ -268,11 +269,11 @@ func TestUnresolvedAdvisoryWarning(t *testing.T) {
 			in: []UnresolvedAdvisory{{
 				ID:      "GO-2026-6255",
 				Package: "github.com/moby/buildkit@v0.30.0",
-				Reason:  unresolvedWithdrawnReason,
+				Reason:  unresolvedNotFoundReason,
 			}},
 			want: []string{
 				"osv: advisory GO-2026-6255 reported for github.com/moby/buildkit@v0.30.0 is missing from this report: " +
-					"OSV no longer serves the record and it could not be recovered through an alias",
+					"OSV returned not found for the record, and no alias it named resolved",
 			},
 		},
 	}
@@ -290,14 +291,104 @@ func TestUnresolvedAdvisoryWarning(t *testing.T) {
 // two policies meet: cancellation surfaces through the same call as a 404, and
 // mistaking it for a withdrawn record would turn an abandoned scan into a
 // report that looks almost complete.
+//
+// The cases cover both shapes a cancellation actually arrives in. The osv.dev
+// client returns context.DeadlineExceeded bare but runs context.Canceled
+// through its retry path, which formats it into "max retries exceeded", so
+// asserting only on the bare value would leave the shape real callers see
+// untested.
 func TestQueryRaw_CancelledScanIsNotAWithdrawnAdvisory(t *testing.T) {
+	const (
+		buildkit  = "github.com/moby/buildkit"
+		withdrawn = "GO-2026-6255"
+	)
+
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "bare context error",
+			err:  context.Canceled,
+		},
+		{
+			name: "deadline exceeded",
+			err:  context.DeadlineExceeded,
+		},
+		{
+			// The shape the real client produces for a cancelled request.
+			name: "wrapped by the client's retry loop",
+			err:  fmt.Errorf(`max retries exceeded: attempt 1: request failed: Get "https://api.osv.dev/v1/vulns/%s": %w`, withdrawn, context.Canceled),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetDiskCache(t)
+			ctx, cancel := context.WithCancel(t.Context())
+			cancel()
+
+			client := &scriptedClient{
+				batch:    map[string][]string{buildkit: {withdrawn}},
+				failures: map[string]error{withdrawn: tt.err},
+			}
+			_, unresolved, err := QueryRaw(ctx, client, []PkgInput{
+				{QueryKey: QueryKey{Name: buildkit, Version: "v0.30.0", Ecosystem: "Go"}},
+			})
+			if err == nil {
+				t.Fatalf("QueryRaw() error = nil, want a cancellation error (unresolved = %+v)", unresolved)
+			}
+			if len(unresolved) != 0 {
+				t.Fatalf("unresolved = %+v, want none: a cancelled scan is not a withdrawn advisory", unresolved)
+			}
+		})
+	}
+}
+
+// cancelDuringRecoveryClient 404s the requested advisory with a live alias, then
+// cancels the scan before the alias can be fetched. This is the one ordering
+// where the not-found classification is already settled and cancellation
+// arrives afterward, so only the context check inside the recovery loop keeps
+// the advisory from being filed as withdrawn.
+type cancelDuringRecoveryClient struct {
+	advisoryID string
+	alias      string
+	cancel     context.CancelFunc
+}
+
+func (c *cancelDuringRecoveryClient) QueryBatch(_ context.Context, queries []*api.Query) (*api.BatchVulnerabilityList, error) {
+	results := make([]*api.VulnerabilityList, 0, len(queries))
+	for range queries {
+		results = append(results, &api.VulnerabilityList{
+			Vulns: []*osvschema.Vulnerability{{Id: c.advisoryID}},
+		})
+	}
+	return &api.BatchVulnerabilityList{Results: results}, nil
+}
+
+func (c *cancelDuringRecoveryClient) GetVulnByID(_ context.Context, id string) (*osvschema.Vulnerability, error) {
+	if id == c.advisoryID {
+		// The 404 lands first, then the scan is cancelled.
+		c.cancel()
+		return nil, notFoundErr(c.alias)
+	}
+	return nil, errors.New("alias lookup should not run on a cancelled scan")
+}
+
+// TestQueryRaw_CancelledDuringAliasRecoveryIsNotUnresolved pins the narrow race
+// the recovery loop's context check exists for: a 404 that names a live alias,
+// followed by cancellation. Without the check the alias fetch fails, the
+// original not-found error is returned, and an abandoned scan reports the
+// advisory as withdrawn instead of failing.
+func TestQueryRaw_CancelledDuringAliasRecoveryIsNotUnresolved(t *testing.T) {
 	resetDiskCache(t)
 	ctx, cancel := context.WithCancel(t.Context())
-	cancel()
+	t.Cleanup(cancel)
 
-	client := &scriptedClient{
-		batch:    map[string][]string{"github.com/moby/buildkit": {"GO-2026-6255"}},
-		failures: map[string]error{"GO-2026-6255": context.Canceled},
+	client := &cancelDuringRecoveryClient{
+		advisoryID: "GO-2026-6255",
+		alias:      "GHSA-7236-3392-c5c6",
+		cancel:     cancel,
 	}
 	_, unresolved, err := QueryRaw(ctx, client, []PkgInput{
 		{QueryKey: QueryKey{Name: "github.com/moby/buildkit", Version: "v0.30.0", Ecosystem: "Go"}},
@@ -306,6 +397,6 @@ func TestQueryRaw_CancelledScanIsNotAWithdrawnAdvisory(t *testing.T) {
 		t.Fatalf("QueryRaw() error = nil, want a cancellation error (unresolved = %+v)", unresolved)
 	}
 	if len(unresolved) != 0 {
-		t.Fatalf("unresolved = %+v, want none: a cancelled scan is not a withdrawn advisory", unresolved)
+		t.Fatalf("unresolved = %+v, want none: cancellation mid-recovery is not a withdrawn advisory", unresolved)
 	}
 }

--- a/internal/analysis/osv/unresolved_test.go
+++ b/internal/analysis/osv/unresolved_test.go
@@ -94,11 +94,15 @@ func TestQueryRaw_UnresolvedAdvisories(t *testing.T) {
 	tests := []struct {
 		name string
 		// pkgs defaults to buildkit alone when empty.
-		pkgs           []PkgInput
-		client         *scriptedClient
-		wantErr        bool
-		wantAdvisories []string
-		wantUnresolved []UnresolvedAdvisory
+		pkgs   []PkgInput
+		client *scriptedClient
+		// wantErrContains, when set, implies wantErr and pins the substring that
+		// identifies which lookup failed. An expansion error that only says
+		// "not found" would be the bug this asserts against.
+		wantErrContains string
+		wantErr         bool
+		wantAdvisories  []string
+		wantUnresolved  []UnresolvedAdvisory
 	}{
 		{
 			// The reported bug: one withdrawn record used to abort everything.
@@ -167,6 +171,66 @@ func TestQueryRaw_UnresolvedAdvisories(t *testing.T) {
 			}},
 		},
 		{
+			// A 404 on one alias says nothing about the next one, so the search
+			// keeps going and the finding survives under the ID that resolved.
+			name: "not-found alias is skipped and recovery continues",
+			client: &scriptedClient{
+				batch: map[string][]string{buildkit: {withdrawn}},
+				failures: map[string]error{
+					withdrawn: notFoundErr(cveAlias, ghsaAlias),
+					// Tried first, since SeverityAliasOrder prefers GHSA.
+					ghsaAlias: notFoundErr(),
+				},
+				records: map[string]*osvschema.Vulnerability{
+					cveAlias: affectedRecord(cveAlias, buildkit),
+				},
+			},
+			wantAdvisories: []string{cveAlias},
+		},
+		{
+			// The defect this pins: a network blip on the alias used to be
+			// discarded, the original 404 returned, and an expansion we never
+			// completed filed as a withdrawn record on a successful scan.
+			name: "transient alias failure stays fatal instead of reading as withdrawn",
+			client: &scriptedClient{
+				batch: map[string][]string{buildkit: {withdrawn}},
+				failures: map[string]error{
+					withdrawn: notFoundErr(ghsaAlias),
+					ghsaAlias: errors.New("max retries exceeded: attempt 4: request failed: dial tcp: i/o timeout"),
+				},
+			},
+			wantErrContains: "resolve alias " + ghsaAlias + " of " + withdrawn,
+		},
+		{
+			// An exhausted 5xx retry is the same class of ignorance as a
+			// timeout: OSV never told us whether the alias replaces the record.
+			name: "exhausted alias retry stays fatal",
+			client: &scriptedClient{
+				batch: map[string][]string{buildkit: {withdrawn}},
+				failures: map[string]error{
+					withdrawn: notFoundErr(ghsaAlias),
+					ghsaAlias: errors.New(`max retries exceeded: server error: status="503 Service Unavailable" body=busy`),
+				},
+			},
+			wantErrContains: "resolve alias " + ghsaAlias + " of " + withdrawn,
+		},
+		{
+			// A completed recovery answers the question the failed alias left
+			// open, so the kept error must not override it.
+			name: "later alias recovers despite an earlier transient failure",
+			client: &scriptedClient{
+				batch: map[string][]string{buildkit: {withdrawn}},
+				failures: map[string]error{
+					withdrawn: notFoundErr(cveAlias, ghsaAlias),
+					ghsaAlias: errors.New("max retries exceeded: attempt 4: request failed: dial tcp: i/o timeout"),
+				},
+				records: map[string]*osvschema.Vulnerability{
+					cveAlias: affectedRecord(cveAlias, buildkit),
+				},
+			},
+			wantAdvisories: []string{cveAlias},
+		},
+		{
 			// The alias list is read out of response text, so a record about
 			// some other package is a misread and must not be reported here.
 			name: "alias about a different package is not accepted",
@@ -225,9 +289,15 @@ func TestQueryRaw_UnresolvedAdvisories(t *testing.T) {
 			}
 
 			vulns, unresolved, err := QueryRaw(t.Context(), tt.client, pkgs)
-			if tt.wantErr {
+			if tt.wantErr || tt.wantErrContains != "" {
 				if err == nil {
-					t.Fatalf("QueryRaw() error = nil, want an error (findings = %d)", len(vulns))
+					t.Fatalf("QueryRaw() error = nil, want an error (findings = %d, unresolved = %+v)", len(vulns), unresolved)
+				}
+				if tt.wantErrContains != "" && !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Fatalf("QueryRaw() error = %v, want it to mention %q", err, tt.wantErrContains)
+				}
+				if len(unresolved) != 0 {
+					t.Fatalf("unresolved = %+v, want none: a failed expansion is not a withdrawn advisory", unresolved)
 				}
 				return
 			}
@@ -398,5 +468,65 @@ func TestQueryRaw_CancelledDuringAliasRecoveryIsNotUnresolved(t *testing.T) {
 	}
 	if len(unresolved) != 0 {
 		t.Fatalf("unresolved = %+v, want none: cancellation mid-recovery is not a withdrawn advisory", unresolved)
+	}
+}
+
+// cancelInsideAliasLookupClient 404s the requested advisory with an alias, then
+// cancels the scan from inside the alias lookup and answers it with a 404 of its
+// own. The recovery loop's own context check has already run by then, and a
+// not-found alias is a normal dead end rather than an error worth keeping, so
+// nothing is left holding the cancellation except the recheck that runs before
+// the advisory is classified.
+type cancelInsideAliasLookupClient struct {
+	advisoryID string
+	alias      string
+	cancel     context.CancelFunc
+}
+
+func (c *cancelInsideAliasLookupClient) QueryBatch(_ context.Context, queries []*api.Query) (*api.BatchVulnerabilityList, error) {
+	results := make([]*api.VulnerabilityList, 0, len(queries))
+	for range queries {
+		results = append(results, &api.VulnerabilityList{
+			Vulns: []*osvschema.Vulnerability{{Id: c.advisoryID}},
+		})
+	}
+	return &api.BatchVulnerabilityList{Results: results}, nil
+}
+
+func (c *cancelInsideAliasLookupClient) GetVulnByID(_ context.Context, id string) (*osvschema.Vulnerability, error) {
+	if id == c.advisoryID {
+		return nil, notFoundErr(c.alias)
+	}
+	// The scan is abandoned while this last alias lookup is in flight.
+	c.cancel()
+	return nil, notFoundErr()
+}
+
+// TestQueryRaw_CancelledDuringLastAliasLookupIsNotUnresolved covers the other
+// half of the cancellation race: the alias lookup itself is what the
+// cancellation lands on. Every alias has been tried and none resolved, so the
+// original not-found error is about to be handed back, which would report an
+// abandoned scan as a withdrawn advisory on an otherwise successful run.
+func TestQueryRaw_CancelledDuringLastAliasLookupIsNotUnresolved(t *testing.T) {
+	resetDiskCache(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	client := &cancelInsideAliasLookupClient{
+		advisoryID: "GO-2026-6255",
+		alias:      "GHSA-7236-3392-c5c6",
+		cancel:     cancel,
+	}
+	_, unresolved, err := QueryRaw(ctx, client, []PkgInput{
+		{QueryKey: QueryKey{Name: "github.com/moby/buildkit", Version: "v0.30.0", Ecosystem: "Go"}},
+	})
+	if err == nil {
+		t.Fatalf("QueryRaw() error = nil, want a cancellation error (unresolved = %+v)", unresolved)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("QueryRaw() error = %v, want a context.Canceled", err)
+	}
+	if len(unresolved) != 0 {
+		t.Fatalf("unresolved = %+v, want none: cancellation on the last alias lookup is not a withdrawal", unresolved)
 	}
 }

--- a/internal/analysis/osv/unresolved_test.go
+++ b/internal/analysis/osv/unresolved_test.go
@@ -1,0 +1,311 @@
+package osv
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ossf/osv-schema/bindings/go/osvschema"
+	"osv.dev/bindings/go/api"
+)
+
+// notFoundErr renders the error the osv.dev client returns for a withdrawn
+// record: formatted response text rather than a typed status, naming the
+// aliases that do still exist. Deputy only ever sees these IDs here, because the
+// querybatch stub that reported the missing ID carries just an id and a modified
+// timestamp.
+func notFoundErr(aliases ...string) error {
+	if len(aliases) == 0 {
+		return errors.New(`client error: status="404 Not Found" body={"code":5,"message":"Bug not found."}`)
+	}
+	return errors.New(`client error: status="404 Not Found" body={"code":5,"message":"Vulnerability not found, but the following aliases were: ` +
+		strings.Join(aliases, " ") + `"}`)
+}
+
+// affectedRecord builds an OSV record that reports pkgName as affected at every
+// version, so a test asserts on which advisory survived rather than on version
+// arithmetic.
+func affectedRecord(id, pkgName string) *osvschema.Vulnerability {
+	return &osvschema.Vulnerability{
+		Id:      id,
+		Summary: id + " summary",
+		Affected: []*osvschema.Affected{{
+			Package: &osvschema.Package{Name: pkgName, Ecosystem: "Go"},
+			Ranges: []*osvschema.Range{{
+				Type:   osvschema.Range_SEMVER,
+				Events: []*osvschema.Event{{Introduced: "0"}},
+			}},
+		}},
+	}
+}
+
+// scriptedClient answers a batch query from a per-package advisory list and
+// answers each expansion from a scripted table, so a test can make one advisory
+// fail the way OSV actually fails it while the rest keep resolving.
+type scriptedClient struct {
+	// batch maps a queried package name to the advisory IDs OSV reports for it.
+	batch map[string][]string
+	// records maps an advisory ID to the record GetVulnByID returns.
+	records map[string]*osvschema.Vulnerability
+	// failures maps an advisory ID to the error GetVulnByID returns instead.
+	failures map[string]error
+}
+
+func (c *scriptedClient) QueryBatch(_ context.Context, queries []*api.Query) (*api.BatchVulnerabilityList, error) {
+	results := make([]*api.VulnerabilityList, 0, len(queries))
+	for _, q := range queries {
+		list := &api.VulnerabilityList{}
+		for _, id := range c.batch[q.GetPackage().GetName()] {
+			list.Vulns = append(list.Vulns, &osvschema.Vulnerability{Id: id})
+		}
+		results = append(results, list)
+	}
+	return &api.BatchVulnerabilityList{Results: results}, nil
+}
+
+func (c *scriptedClient) GetVulnByID(_ context.Context, id string) (*osvschema.Vulnerability, error) {
+	if err, ok := c.failures[id]; ok {
+		return nil, err
+	}
+	if rec, ok := c.records[id]; ok {
+		return rec, nil
+	}
+	return nil, notFoundErr()
+}
+
+// TestQueryRaw_UnresolvedAdvisories covers what happens when the second OSV call
+// disagrees with the first: the batch query attributes an advisory to a package,
+// and expanding it fails. A withdrawn record must cost only its own finding, a
+// transport failure must still fail the scan, and neither may leave the caller
+// with a result that reads as clean.
+func TestQueryRaw_UnresolvedAdvisories(t *testing.T) {
+	const (
+		buildkit = "github.com/moby/buildkit"
+		other    = "github.com/example/other"
+		// The real IDs from issue #320.
+		withdrawn = "GO-2026-6255"
+		ghsaAlias = "GHSA-7236-3392-c5c6"
+		cveAlias  = "CVE-2026-61711"
+	)
+
+	tests := []struct {
+		name string
+		// pkgs defaults to buildkit alone when empty.
+		pkgs           []PkgInput
+		client         *scriptedClient
+		wantErr        bool
+		wantAdvisories []string
+		wantUnresolved []UnresolvedAdvisory
+	}{
+		{
+			// The reported bug: one withdrawn record used to abort everything.
+			name: "withdrawn advisory does not cost other packages their findings",
+			pkgs: []PkgInput{
+				{QueryKey: QueryKey{Name: buildkit, Version: "v0.30.0", Ecosystem: "Go"}},
+				{QueryKey: QueryKey{Name: other, Version: "v1.0.0", Ecosystem: "Go"}},
+			},
+			client: &scriptedClient{
+				batch: map[string][]string{
+					buildkit: {withdrawn},
+					other:    {"GHSA-live-0000-0001"},
+				},
+				failures: map[string]error{withdrawn: notFoundErr()},
+				records: map[string]*osvschema.Vulnerability{
+					"GHSA-live-0000-0001": affectedRecord("GHSA-live-0000-0001", other),
+				},
+			},
+			wantAdvisories: []string{"GHSA-live-0000-0001"},
+			wantUnresolved: []UnresolvedAdvisory{{
+				ID:      withdrawn,
+				Package: buildkit + "@v0.30.0",
+				Reason:  unresolvedWithdrawnReason,
+			}},
+		},
+		{
+			name: "unresolved advisory is reported, not dropped",
+			client: &scriptedClient{
+				batch:    map[string][]string{buildkit: {withdrawn}},
+				failures: map[string]error{withdrawn: notFoundErr()},
+			},
+			wantUnresolved: []UnresolvedAdvisory{{
+				ID:      withdrawn,
+				Package: buildkit + "@v0.30.0",
+				Reason:  unresolvedWithdrawnReason,
+			}},
+		},
+		{
+			// The 404 body names live records, so the finding is recovered
+			// under the ID a reader can actually look up.
+			name: "alias named by the 404 recovers the record",
+			client: &scriptedClient{
+				batch:    map[string][]string{buildkit: {withdrawn}},
+				failures: map[string]error{withdrawn: notFoundErr(cveAlias, ghsaAlias)},
+				records: map[string]*osvschema.Vulnerability{
+					ghsaAlias: affectedRecord(ghsaAlias, buildkit),
+					cveAlias:  affectedRecord(cveAlias, buildkit),
+				},
+			},
+			// GHSA first: SeverityAliasOrder prefers the reviewed database.
+			wantAdvisories: []string{ghsaAlias},
+		},
+		{
+			name: "alias that also 404s leaves the advisory unresolved",
+			client: &scriptedClient{
+				batch: map[string][]string{buildkit: {withdrawn}},
+				failures: map[string]error{
+					withdrawn: notFoundErr(ghsaAlias),
+					ghsaAlias: notFoundErr(),
+				},
+			},
+			wantUnresolved: []UnresolvedAdvisory{{
+				ID:      withdrawn,
+				Package: buildkit + "@v0.30.0",
+				Reason:  unresolvedWithdrawnReason,
+			}},
+		},
+		{
+			// The alias list is read out of response text, so a record about
+			// some other package is a misread and must not be reported here.
+			name: "alias about a different package is not accepted",
+			client: &scriptedClient{
+				batch:    map[string][]string{buildkit: {withdrawn}},
+				failures: map[string]error{withdrawn: notFoundErr(ghsaAlias)},
+				records: map[string]*osvschema.Vulnerability{
+					ghsaAlias: affectedRecord(ghsaAlias, other),
+				},
+			},
+			wantUnresolved: []UnresolvedAdvisory{{
+				ID:      withdrawn,
+				Package: buildkit + "@v0.30.0",
+				Reason:  unresolvedWithdrawnReason,
+			}},
+		},
+		{
+			// OSV lists a withdrawn ID next to the live alias that replaced it,
+			// so recovery can land on a record the batch already named.
+			name: "recovered record already in the batch is not reported twice",
+			client: &scriptedClient{
+				batch:    map[string][]string{buildkit: {withdrawn, ghsaAlias}},
+				failures: map[string]error{withdrawn: notFoundErr(ghsaAlias)},
+				records: map[string]*osvschema.Vulnerability{
+					ghsaAlias: affectedRecord(ghsaAlias, buildkit),
+				},
+			},
+			wantAdvisories: []string{ghsaAlias},
+		},
+		{
+			// A network blip is not a withdrawn record: it will not reproduce,
+			// so a result missing advisories because of it must not be served.
+			name: "transport failure stays fatal",
+			client: &scriptedClient{
+				batch:    map[string][]string{buildkit: {withdrawn}},
+				failures: map[string]error{withdrawn: errors.New("max retries exceeded: attempt 4: request failed: dial tcp: i/o timeout")},
+			},
+			wantErr: true,
+		},
+		{
+			name: "server error stays fatal",
+			client: &scriptedClient{
+				batch:    map[string][]string{buildkit: {withdrawn}},
+				failures: map[string]error{withdrawn: errors.New(`max retries exceeded: server error: status="503 Service Unavailable" body=busy`)},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetDiskCache(t)
+			pkgs := tt.pkgs
+			if len(pkgs) == 0 {
+				pkgs = []PkgInput{{QueryKey: QueryKey{Name: buildkit, Version: "v0.30.0", Ecosystem: "Go"}}}
+			}
+
+			vulns, unresolved, err := QueryRaw(t.Context(), tt.client, pkgs)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("QueryRaw() error = nil, want an error (findings = %d)", len(vulns))
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("QueryRaw() error = %v, want nil", err)
+			}
+
+			gotAdvisories := make([]string, 0, len(vulns))
+			for _, v := range vulns {
+				gotAdvisories = append(gotAdvisories, v.ID)
+			}
+			slices.Sort(gotAdvisories)
+			want := slices.Clone(tt.wantAdvisories)
+			slices.Sort(want)
+			if !slices.Equal(gotAdvisories, want) {
+				t.Errorf("advisories in findings = %v, want %v", gotAdvisories, want)
+			}
+
+			if !slices.Equal(unresolved, tt.wantUnresolved) {
+				t.Errorf("unresolved = %+v, want %+v", unresolved, tt.wantUnresolved)
+			}
+		})
+	}
+}
+
+// TestUnresolvedAdvisoryWarning pins the text the scan report shows, because it
+// is the only thing that stops an incomplete scan from reading as a clean one.
+func TestUnresolvedAdvisoryWarning(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []UnresolvedAdvisory
+		want []string
+	}{
+		{
+			name: "no unresolved advisories adds no warning",
+		},
+		{
+			name: "warning names the advisory, the package, and the omission",
+			in: []UnresolvedAdvisory{{
+				ID:      "GO-2026-6255",
+				Package: "github.com/moby/buildkit@v0.30.0",
+				Reason:  unresolvedWithdrawnReason,
+			}},
+			want: []string{
+				"osv: advisory GO-2026-6255 reported for github.com/moby/buildkit@v0.30.0 is missing from this report: " +
+					"OSV no longer serves the record and it could not be recovered through an alias",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := AdvisoryWarnings(tt.in); !slices.Equal(got, tt.want) {
+				t.Fatalf("AdvisoryWarnings() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestQueryRaw_CancelledScanIsNotAWithdrawnAdvisory guards the seam where the
+// two policies meet: cancellation surfaces through the same call as a 404, and
+// mistaking it for a withdrawn record would turn an abandoned scan into a
+// report that looks almost complete.
+func TestQueryRaw_CancelledScanIsNotAWithdrawnAdvisory(t *testing.T) {
+	resetDiskCache(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	client := &scriptedClient{
+		batch:    map[string][]string{"github.com/moby/buildkit": {"GO-2026-6255"}},
+		failures: map[string]error{"GO-2026-6255": context.Canceled},
+	}
+	_, unresolved, err := QueryRaw(ctx, client, []PkgInput{
+		{QueryKey: QueryKey{Name: "github.com/moby/buildkit", Version: "v0.30.0", Ecosystem: "Go"}},
+	})
+	if err == nil {
+		t.Fatalf("QueryRaw() error = nil, want a cancellation error (unresolved = %+v)", unresolved)
+	}
+	if len(unresolved) != 0 {
+		t.Fatalf("unresolved = %+v, want none: a cancelled scan is not a withdrawn advisory", unresolved)
+	}
+}

--- a/internal/cli/cmd/triage.go
+++ b/internal/cli/cmd/triage.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 
 	"connectrpc.com/connect"
@@ -152,6 +153,12 @@ func runTriage(c *services.Clients, cmd *cobra.Command, args []string) error {
 			commit = scanResp.Target.CommitHash
 		}
 		triageResp = internalproto.BuildTriageResponse(displayPath, scanResult.Stats, cons, 10)
+		// Carry the scan's warnings so triage cannot present an incomplete
+		// scan as a complete summary. The report was produced by an earlier
+		// run, possibly on another machine, so this is the first time this
+		// reader hears about them: echo them too.
+		triageResp.Warnings = slices.Clone(scanResult.Warnings)
+		echoScanWarnings(cmd.ErrOrStderr(), triageResp.Warnings)
 		// Echo the scan's resolved target as-is so ref, effectiveRef, and
 		// commit survive into triage output, matching the MCP tool.
 		triageResp.Target = scanResp.Target
@@ -209,9 +216,7 @@ func runTriage(c *services.Clients, cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("scan returned empty result")
 		}
 
-		for _, warning := range scanResult.Warnings {
-			fmt.Fprintf(cmd.ErrOrStderr(), "Warning: %s\n", warning)
-		}
+		echoScanWarnings(cmd.ErrOrStderr(), scanResult.Warnings)
 
 		repoPath = scanResult.Target.LocalPath
 		resultOut := applyTriageIgnoreRules(cmd, *scanResult, repoPath)
@@ -220,6 +225,10 @@ func runTriage(c *services.Clients, cmd *cobra.Command, args []string) error {
 		}
 		cons := vulnerability.Consolidate(resultOut.Findings, resultOut.Advisories)
 		triageResp = internalproto.BuildTriageResponse(scanResult.Target.DisplayPath, resultOut.Stats, cons, 10)
+		// Carry the scan's warnings onto the response as well as stderr: the
+		// JSON output is a report of its own, and without them it presents an
+		// incomplete scan as a complete summary.
+		triageResp.Warnings = slices.Clone(scanResult.Warnings)
 		// Echo the scan's resolved target so ref, effectiveRef, and commit
 		// survive into triage output, matching the MCP tool.
 		triageResp.Target = internalproto.InventoryTargetToProto(scanResult.Target)
@@ -261,6 +270,16 @@ func runTriage(c *services.Clients, cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// echoScanWarnings repeats a scan's non-fatal warnings for a reader of the text
+// output, which renders the summary alone and would otherwise show an
+// incomplete scan as a complete one. They go to stderr so piping stdout to a
+// parser stays safe.
+func echoScanWarnings(errW io.Writer, warnings []string) {
+	for _, warning := range warnings {
+		fmt.Fprintf(errW, "Warning: %s\n", warning)
+	}
 }
 
 // runTriagePoliciesProto evaluates policies against the proto triage response.

--- a/internal/cli/cmd/triage_test.go
+++ b/internal/cli/cmd/triage_test.go
@@ -401,7 +401,7 @@ func newMockTriageClients(t *testing.T, mock triageMockData) *services.Clients {
 func TestTriageCommandCarriesScanWarnings(t *testing.T) {
 	t.Parallel()
 
-	const unresolved = "osv: advisory GO-2026-6255 reported for github.com/moby/buildkit@v0.30.0 is missing from this report: withdrawn"
+	const unresolved = "osv: advisory GO-2026-6255 reported for github.com/moby/buildkit@v0.30.0 is absent from osv's findings: withdrawn"
 
 	vulnerable := []vulnerability.Finding{{
 		AdvisoryID: "GHSA-1234-5678-9012",

--- a/internal/cli/cmd/triage_test.go
+++ b/internal/cli/cmd/triage_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -336,6 +337,9 @@ func newTriageTestCommand(t *testing.T) *cobra.Command {
 type triageMockData struct {
 	Findings   []vulnerability.Finding
 	Advisories map[string]*vulnerabilityv1.Advisory
+	// Warnings are the scan's non-fatal warnings, such as an advisory whose
+	// record could not be expanded.
+	Warnings []string
 }
 
 // mockTriageScanHandler is a mock ScanServiceHandler for testing.
@@ -359,6 +363,7 @@ func (m *mockTriageScanHandler) Scan(ctx context.Context, req *connect.Request[s
 		Findings:   m.data.Findings,
 		Advisories: m.data.Advisories,
 		Stats:      stats,
+		Warnings:   m.data.Warnings,
 	}
 
 	// Convert to proto
@@ -385,4 +390,149 @@ func newMockTriageClients(t *testing.T, mock triageMockData) *services.Clients {
 	return &services.Clients{
 		Vulns: scanv1connect.NewScanServiceClient(httpClient, ""),
 	}
+}
+
+// TestTriageCommandCarriesScanWarnings pins the guarantee triage inherits from
+// the scan it summarizes. An advisory whose record could not be expanded is
+// absent from the findings, so the summary looks like the whole picture; the
+// warning is the only thing saying otherwise, and it has to reach both the JSON
+// output and a text reader's terminal. The zero-finding cases matter most: those
+// are the runs that read as clean.
+func TestTriageCommandCarriesScanWarnings(t *testing.T) {
+	t.Parallel()
+
+	const unresolved = "osv: advisory GO-2026-6255 reported for github.com/moby/buildkit@v0.30.0 is missing from this report: withdrawn"
+
+	vulnerable := []vulnerability.Finding{{
+		AdvisoryID: "GHSA-1234-5678-9012",
+		Dependency: dependency.ID{Name: "github.com/acme/lib", Ecosystem: "Go"},
+		Version:    "v1.0.0",
+		Affected:   true,
+	}}
+	advisories := map[string]*vulnerabilityv1.Advisory{
+		"GHSA-1234-5678-9012": {
+			Id:       "GHSA-1234-5678-9012",
+			Severity: vulnerability.NewSeverity("HIGH", "GHSA"),
+		},
+	}
+
+	tests := []struct {
+		name string
+		// fromReport routes through --report instead of a live scan.
+		fromReport bool
+		findings   []vulnerability.Finding
+		advisories map[string]*vulnerabilityv1.Advisory
+		warnings   []string
+		want       []string
+	}{
+		{
+			// The run that used to read as clean: nothing found, and no sign
+			// that a record went missing on the way.
+			name:     "live scan with no findings still reports the warning",
+			warnings: []string{unresolved},
+			want:     []string{unresolved},
+		},
+		{
+			name:       "live scan with findings reports the warning",
+			findings:   vulnerable,
+			advisories: advisories,
+			warnings:   []string{unresolved},
+			want:       []string{unresolved},
+		},
+		{
+			name:       "clean live scan reports no warning",
+			findings:   vulnerable,
+			advisories: advisories,
+		},
+		{
+			name:       "report with no findings still reports the warning",
+			fromReport: true,
+			warnings:   []string{unresolved},
+			want:       []string{unresolved},
+		},
+		{
+			name:       "report with findings reports the warning",
+			fromReport: true,
+			findings:   vulnerable,
+			advisories: advisories,
+			warnings:   []string{unresolved},
+			want:       []string{unresolved},
+		},
+		{
+			name:       "clean report reports no warning",
+			fromReport: true,
+			findings:   vulnerable,
+			advisories: advisories,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tmpDir := t.TempDir()
+			mock := triageMockData{Findings: tt.findings, Advisories: tt.advisories, Warnings: tt.warnings}
+			cmd := newTriageTestCommand(t)
+			mustSetFlag(t, cmd, "format", "json")
+			var stdout, stderr bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&stderr)
+
+			var args []string
+			if tt.fromReport {
+				mustSetFlag(t, cmd, "report", writeTriageReport(t, tmpDir, mock))
+			} else {
+				writeGoModule(t, tmpDir)
+				initGitRepo(t, tmpDir)
+				args = []string{tmpDir}
+			}
+
+			if err := runTriage(newMockTriageClients(t, mock), cmd, args); err != nil {
+				t.Fatalf("runTriage: %v", err)
+			}
+
+			var got triagev1.TriageResponse
+			if err := protojson.Unmarshal(stdout.Bytes(), &got); err != nil {
+				t.Fatalf("parse JSON output: %v (output = %s)", err, stdout.String())
+			}
+			if !slices.Equal(got.GetWarnings(), tt.want) {
+				t.Fatalf("triage response warnings = %q, want %q", got.GetWarnings(), tt.want)
+			}
+			// The text reader never sees the JSON, so the same fact has to
+			// reach stderr on every path that produces it.
+			for _, warning := range tt.want {
+				if !strings.Contains(stderr.String(), warning) {
+					t.Errorf("stderr = %q, want it to mention %q", stderr.String(), warning)
+				}
+			}
+		})
+	}
+}
+
+// writeTriageReport marshals mock scan data the way "deputy scan --format json"
+// does and returns the path, so a --report test consumes the real wire format
+// rather than a hand-built stand-in.
+func writeTriageReport(t *testing.T, dir string, mock triageMockData) string {
+	t.Helper()
+	cons := vulnerability.Consolidate(mock.Findings, mock.Advisories)
+	scanResp := internalproto.ScanningResultToProto(&scanning.Result{
+		Target: inventory.Target{
+			Kind:        targets.KindDir,
+			LocalPath:   dir,
+			DisplayPath: "github.com/test/repo",
+		},
+		Findings:   mock.Findings,
+		Advisories: mock.Advisories,
+		Stats:      vulnerability.StatsFromConsolidated(cons, len(mock.Findings)),
+		Warnings:   mock.Warnings,
+	})
+	data, err := internalproto.CLIJSONMarshalOptions().Marshal(scanResp)
+	if err != nil {
+		t.Fatalf("marshal scan report: %v", err)
+	}
+	path := filepath.Join(dir, "report.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write scan report: %v", err)
+	}
+	return path
 }

--- a/internal/otel/trace.go
+++ b/internal/otel/trace.go
@@ -98,6 +98,11 @@ var (
 	AttrOSVResponseLen         = attribute.Key("deputy.osv.response_len")
 	AttrOSVDroppedNoVersion    = attribute.Key("deputy.osv.dropped_no_version")
 	AttrOSVDroppedNoIdentifier = attribute.Key("deputy.osv.dropped_no_identifier")
+	// AttrOSVUnresolvedAdvisories counts advisories a batch query reported whose
+	// full records OSV would not serve, so their findings are missing from the
+	// results. A non-zero value means the answer is incomplete even though the
+	// query succeeded.
+	AttrOSVUnresolvedAdvisories = attribute.Key("deputy.osv.unresolved_advisories")
 
 	// Policy attributes
 	AttrPolicyName       = attribute.Key("deputy.policy.name")

--- a/internal/otel/trace.go
+++ b/internal/otel/trace.go
@@ -79,16 +79,16 @@ var (
 	AttrTargetRemote = attribute.Key("deputy.target.remote")
 
 	// Scan attributes
-	AttrEcosystem               = attribute.Key("deputy.ecosystem")
-	AttrPackageCount            = attribute.Key("deputy.package.count")
-	AttrVulnerabilityCount      = attribute.Key("deputy.vulnerability.count")
-	AttrVulnerabilityCritical   = attribute.Key("deputy.vulnerability.critical")
-	AttrVulnerabilityHigh       = attribute.Key("deputy.vulnerability.high")
-	AttrVulnerabilityMedium     = attribute.Key("deputy.vulnerability.medium")
-	AttrVulnerabilityLow        = attribute.Key("deputy.vulnerability.low")
-	AttrDirectDepsOnly  = attribute.Key("deputy.direct_deps_only")
-	AttrPolicyEvaluated = attribute.Key("deputy.policy.evaluated")
-	AttrPolicyPassed    = attribute.Key("deputy.policy.passed")
+	AttrEcosystem             = attribute.Key("deputy.ecosystem")
+	AttrPackageCount          = attribute.Key("deputy.package.count")
+	AttrVulnerabilityCount    = attribute.Key("deputy.vulnerability.count")
+	AttrVulnerabilityCritical = attribute.Key("deputy.vulnerability.critical")
+	AttrVulnerabilityHigh     = attribute.Key("deputy.vulnerability.high")
+	AttrVulnerabilityMedium   = attribute.Key("deputy.vulnerability.medium")
+	AttrVulnerabilityLow      = attribute.Key("deputy.vulnerability.low")
+	AttrDirectDepsOnly        = attribute.Key("deputy.direct_deps_only")
+	AttrPolicyEvaluated       = attribute.Key("deputy.policy.evaluated")
+	AttrPolicyPassed          = attribute.Key("deputy.policy.passed")
 
 	// OSV attributes
 	AttrOSVBatchSize           = attribute.Key("deputy.osv.batch_size")

--- a/internal/proto/container_diff.go
+++ b/internal/proto/container_diff.go
@@ -1,6 +1,7 @@
 package proto
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/google/osv-scalibr/extractor"
@@ -26,6 +27,7 @@ func BuildContainerDiffResponseFromScanning(baseResult, targetResult *scanning.R
 		GeneratedAt:   now,
 		BaseContext:   extractContainerContextFromScanning(baseResult),
 		TargetContext: extractContainerContextFromScanning(targetResult),
+		Warnings:      containerDiffWarnings(baseResult, targetResult),
 	}
 
 	// Compare packages
@@ -45,6 +47,55 @@ func BuildContainerDiffResponseFromScanning(baseResult, targetResult *scanning.R
 	response.Summary = calculateContainerDiffSummary(response)
 
 	return response
+}
+
+// Warning prefixes naming the side of the diff a scan warning came from. They
+// say "base image" rather than repeating the reference, which the response
+// already carries in base_image and target_image: a warning that inlined it
+// would be a second copy of the same fact, free to drift.
+const (
+	containerDiffBaseWarningPrefix   = "base image: "
+	containerDiffTargetWarningPrefix = "target image: "
+)
+
+// containerDiffWarnings carries both scans' warnings onto the diff. A diff is
+// only as complete as the two scans behind it, so a warning that an advisory
+// could not be expanded has to survive into the comparison: without it, a
+// vulnerability missing from one side reads as a vulnerability that image does
+// not have. Each warning is labelled with the side it came from, because the
+// same advisory usually fails to expand on both images and an unlabelled merge
+// would show one line twice with nothing to say which image was short.
+//
+// Base warnings come first, and within a side the scan's own order is kept,
+// which the OSV expansion has already made deterministic.
+func containerDiffWarnings(baseResult, targetResult *scanning.Result) []string {
+	return slices.Concat(
+		labelScanWarnings(containerDiffBaseWarningPrefix, baseResult),
+		labelScanWarnings(containerDiffTargetWarningPrefix, targetResult),
+	)
+}
+
+// labelScanWarnings prefixes one scan's warnings with the side of the diff they
+// describe, dropping blanks and exact repeats so a reader is not told the same
+// thing twice about the same image.
+func labelScanWarnings(prefix string, result *scanning.Result) []string {
+	if result == nil || len(result.Warnings) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(result.Warnings))
+	seen := make(map[string]struct{}, len(result.Warnings))
+	for _, warning := range result.Warnings {
+		warning = strings.TrimSpace(warning)
+		if warning == "" {
+			continue
+		}
+		if _, dup := seen[warning]; dup {
+			continue
+		}
+		seen[warning] = struct{}{}
+		out = append(out, prefix+warning)
+	}
+	return out
 }
 
 // Helper functions for scanning.Result (used by DiffHandler)
@@ -684,13 +735,13 @@ func ContainerDiffResponseToReport(resp *diffv1.DiffContainerImagesResponse) *co
 	// Convert package changes
 	for _, pc := range resp.PackageChanges {
 		report.PackageChanges = append(report.PackageChanges, compare.ImagePackageChange{
-			Name:          pc.Name,
-			Ecosystem:     pc.Ecosystem,
-			ChangeType:    protoChangeKindToCompare(pc.ChangeKind),
-			BaseVersion:   pc.BaseVersion,
-			TargetVersion: pc.TargetVersion,
-			OldName:       pc.OldName,
-			IsDirect:      pc.IsDirect,
+			Name:               pc.Name,
+			Ecosystem:          pc.Ecosystem,
+			ChangeType:         protoChangeKindToCompare(pc.ChangeKind),
+			BaseVersion:        pc.BaseVersion,
+			TargetVersion:      pc.TargetVersion,
+			OldName:            pc.OldName,
+			IsDirect:           pc.IsDirect,
 			BaseLayerDetails:   pc.BaseLayerDetails,
 			TargetLayerDetails: pc.TargetLayerDetails,
 		})

--- a/internal/proto/container_diff_test.go
+++ b/internal/proto/container_diff_test.go
@@ -85,8 +85,8 @@ func TestBuildContainerDiffResponseFromScanningDeduplicatesAdvisoryAliases(t *te
 // indistinguishable from a clean one.
 func TestBuildContainerDiffResponseFromScanningCarriesScanWarnings(t *testing.T) {
 	const (
-		missingAdvisory = "osv: advisory GO-2026-6255 reported for github.com/moby/buildkit@v0.30.0 is missing from this report: withdrawn"
-		otherAdvisory   = "osv: advisory GHSA-7236-3392-c5c6 reported for github.com/example/other@v1.0.0 is missing from this report: withdrawn"
+		missingAdvisory = "osv: advisory GO-2026-6255 reported for github.com/moby/buildkit@v0.30.0 is absent from osv's findings: withdrawn"
+		otherAdvisory   = "osv: advisory GHSA-7236-3392-c5c6 reported for github.com/example/other@v1.0.0 is absent from osv's findings: withdrawn"
 	)
 
 	tests := []struct {

--- a/internal/proto/container_diff_test.go
+++ b/internal/proto/container_diff_test.go
@@ -1,12 +1,13 @@
 package proto
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/google/osv-scalibr/extractor"
 
 	diffv1 "github.com/temporalio/deputy/gen/deputy/diff/v1"
-	"github.com/temporalio/deputy/gen/deputy/vulnerability/v1"
+	vulnerabilityv1 "github.com/temporalio/deputy/gen/deputy/vulnerability/v1"
 	"github.com/temporalio/deputy/internal/dependency"
 	"github.com/temporalio/deputy/internal/scanning"
 	"github.com/temporalio/deputy/internal/vulnerability"
@@ -73,6 +74,98 @@ func TestBuildContainerDiffResponseFromScanningDeduplicatesAdvisoryAliases(t *te
 	}
 	if resp.Advisories["CVE-2024-1234"] == nil {
 		t.Fatalf("expected advisory keyed by primary ID")
+	}
+}
+
+// TestBuildContainerDiffResponseFromScanningCarriesScanWarnings pins the
+// guarantee a diff has to inherit from its two scans: if either scan could not
+// expand an advisory, the diff is not a complete comparison, and a vulnerability
+// missing from one side must not read as one that image does not have. Warnings
+// are the only thing carrying that, so losing them here makes an incomplete diff
+// indistinguishable from a clean one.
+func TestBuildContainerDiffResponseFromScanningCarriesScanWarnings(t *testing.T) {
+	const (
+		missingAdvisory = "osv: advisory GO-2026-6255 reported for github.com/moby/buildkit@v0.30.0 is missing from this report: withdrawn"
+		otherAdvisory   = "osv: advisory GHSA-7236-3392-c5c6 reported for github.com/example/other@v1.0.0 is missing from this report: withdrawn"
+	)
+
+	tests := []struct {
+		name          string
+		baseWarnings  []string
+		otherWarnings []string
+		// nilBase and nilTarget exercise the callers that hand in no result at
+		// all, which must stay a diff with no warnings rather than a panic.
+		nilBase   bool
+		nilTarget bool
+		want      []string
+	}{
+		{
+			name: "clean scans add no warnings",
+		},
+		{
+			name:      "nil results add no warnings",
+			nilBase:   true,
+			nilTarget: true,
+		},
+		{
+			name:         "base-only warning names the base image",
+			baseWarnings: []string{missingAdvisory},
+			want:         []string{"base image: " + missingAdvisory},
+		},
+		{
+			name:          "target-only warning names the target image",
+			otherWarnings: []string{missingAdvisory},
+			want:          []string{"target image: " + missingAdvisory},
+		},
+		{
+			// The common case: the advisory is withdrawn upstream, so both
+			// scans hit it. Two lines, each saying which image it is about,
+			// beats one line that leaves the reader guessing.
+			name:          "warning on both sides is reported once per image",
+			baseWarnings:  []string{missingAdvisory},
+			otherWarnings: []string{missingAdvisory},
+			want: []string{
+				"base image: " + missingAdvisory,
+				"target image: " + missingAdvisory,
+			},
+		},
+		{
+			name:          "base warnings precede target warnings",
+			baseWarnings:  []string{otherAdvisory},
+			otherWarnings: []string{missingAdvisory},
+			want: []string{
+				"base image: " + otherAdvisory,
+				"target image: " + missingAdvisory,
+			},
+		},
+		{
+			name:         "repeat within one scan is not shown twice",
+			baseWarnings: []string{missingAdvisory, missingAdvisory},
+			want:         []string{"base image: " + missingAdvisory},
+		},
+		{
+			name:         "blank warnings are dropped",
+			baseWarnings: []string{"", "   ", missingAdvisory},
+			want:         []string{"base image: " + missingAdvisory},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			base := &scanning.Result{Warnings: tt.baseWarnings}
+			if tt.nilBase {
+				base = nil
+			}
+			target := &scanning.Result{Warnings: tt.otherWarnings}
+			if tt.nilTarget {
+				target = nil
+			}
+
+			resp := BuildContainerDiffResponseFromScanning(base, target)
+			if !slices.Equal(resp.GetWarnings(), tt.want) {
+				t.Fatalf("warnings = %q, want %q", resp.GetWarnings(), tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/scanning/scanning.go
+++ b/internal/scanning/scanning.go
@@ -174,14 +174,14 @@ func ScanRepository(ctx context.Context, target, ref string, refProvided bool, o
 	}
 
 	// Query vulnerabilities
-	findings, advisories, coverage, err := queryVulnerabilities(ctx, invExec.Result.Packages, invExec.Result.Direct, invExec.Result.Target.OriginURL)
+	vulns, err := queryVulnerabilities(ctx, invExec.Result.Packages, invExec.Result.Direct, invExec.Result.Target.OriginURL)
 	if err != nil {
 		cleanup()
 		otel.SetSpanError(span, err)
 		return nil, fmt.Errorf("query vulnerabilities: %w", err)
 	}
 
-	cons, stats := consolidateAndResolve(ctx, findings, advisories, opts)
+	cons, stats := consolidateAndResolve(ctx, vulns.Findings, vulns.Advisories, opts)
 
 	return &Execution{
 		Result: Result{
@@ -189,11 +189,12 @@ func ScanRepository(ctx context.Context, target, ref string, refProvided bool, o
 			Packages:        invExec.Result.Packages,
 			PackagesScanned: len(invExec.Result.Packages),
 			Direct:          invExec.Result.Direct,
-			Findings:        findings,
+			Findings:        vulns.Findings,
 			Consolidated:    cons,
-			Advisories:      advisories,
+			Advisories:      vulns.Advisories,
 			Stats:           stats,
-			Coverage:        coverage,
+			Coverage:        vulns.Coverage,
+			Warnings:        vulns.Warnings,
 			GeneratedAt:     time.Now().UTC(),
 		},
 		cleanup: cleanup,
@@ -227,14 +228,14 @@ func ScanContainerImage(ctx context.Context, target string, targetOpts map[strin
 	}
 
 	// Query vulnerabilities
-	findings, advisories, coverage, err := queryVulnerabilities(ctx, invExec.Result.Packages, invExec.Result.Direct, invExec.Result.Target.OriginURL)
+	vulns, err := queryVulnerabilities(ctx, invExec.Result.Packages, invExec.Result.Direct, invExec.Result.Target.OriginURL)
 	if err != nil {
 		cleanup()
 		otel.SetSpanError(span, err)
 		return nil, fmt.Errorf("query vulnerabilities: %w", err)
 	}
 
-	cons, stats := consolidateAndResolve(ctx, findings, advisories, opts)
+	cons, stats := consolidateAndResolve(ctx, vulns.Findings, vulns.Advisories, opts)
 
 	return &Execution{
 		Result: Result{
@@ -242,11 +243,12 @@ func ScanContainerImage(ctx context.Context, target string, targetOpts map[strin
 			Packages:        invExec.Result.Packages,
 			PackagesScanned: len(invExec.Result.Packages),
 			Direct:          invExec.Result.Direct,
-			Findings:        findings,
+			Findings:        vulns.Findings,
 			Consolidated:    cons,
-			Advisories:      advisories,
+			Advisories:      vulns.Advisories,
 			Stats:           stats,
-			Coverage:        coverage,
+			Coverage:        vulns.Coverage,
+			Warnings:        vulns.Warnings,
 			ImageInfo:       invExec.Result.ImageInfo,
 			GeneratedAt:     time.Now().UTC(),
 		},
@@ -277,14 +279,14 @@ func ScanDirectory(ctx context.Context, path string, opts Options) (*Execution, 
 	}
 
 	// Query vulnerabilities
-	findings, advisories, coverage, err := queryVulnerabilities(ctx, invExec.Result.Packages, invExec.Result.Direct, invExec.Result.Target.OriginURL)
+	vulns, err := queryVulnerabilities(ctx, invExec.Result.Packages, invExec.Result.Direct, invExec.Result.Target.OriginURL)
 	if err != nil {
 		cleanup()
 		otel.SetSpanError(span, err)
 		return nil, fmt.Errorf("query vulnerabilities: %w", err)
 	}
 
-	cons, stats := consolidateAndResolve(ctx, findings, advisories, opts)
+	cons, stats := consolidateAndResolve(ctx, vulns.Findings, vulns.Advisories, opts)
 
 	return &Execution{
 		Result: Result{
@@ -292,11 +294,12 @@ func ScanDirectory(ctx context.Context, path string, opts Options) (*Execution, 
 			Packages:        invExec.Result.Packages,
 			PackagesScanned: len(invExec.Result.Packages),
 			Direct:          invExec.Result.Direct,
-			Findings:        findings,
+			Findings:        vulns.Findings,
 			Consolidated:    cons,
-			Advisories:      advisories,
+			Advisories:      vulns.Advisories,
 			Stats:           stats,
-			Coverage:        coverage,
+			Coverage:        vulns.Coverage,
+			Warnings:        vulns.Warnings,
 			GeneratedAt:     time.Now().UTC(),
 		},
 		cleanup: cleanup,
@@ -327,14 +330,14 @@ func ScanVMImage(ctx context.Context, target string, targetOpts map[string]strin
 	}
 
 	// Query vulnerabilities
-	findings, advisories, coverage, err := queryVulnerabilities(ctx, invExec.Result.Packages, invExec.Result.Direct, invExec.Result.Target.OriginURL)
+	vulns, err := queryVulnerabilities(ctx, invExec.Result.Packages, invExec.Result.Direct, invExec.Result.Target.OriginURL)
 	if err != nil {
 		cleanup()
 		otel.SetSpanError(span, err)
 		return nil, fmt.Errorf("query vulnerabilities: %w", err)
 	}
 
-	cons, stats := consolidateAndResolve(ctx, findings, advisories, opts)
+	cons, stats := consolidateAndResolve(ctx, vulns.Findings, vulns.Advisories, opts)
 
 	return &Execution{
 		Result: Result{
@@ -342,11 +345,12 @@ func ScanVMImage(ctx context.Context, target string, targetOpts map[string]strin
 			Packages:        invExec.Result.Packages,
 			PackagesScanned: len(invExec.Result.Packages),
 			Direct:          invExec.Result.Direct,
-			Findings:        findings,
+			Findings:        vulns.Findings,
 			Consolidated:    cons,
-			Advisories:      advisories,
+			Advisories:      vulns.Advisories,
 			Stats:           stats,
-			Coverage:        coverage,
+			Coverage:        vulns.Coverage,
+			Warnings:        vulns.Warnings,
 			GeneratedAt:     time.Now().UTC(),
 		},
 		cleanup: cleanup,
@@ -465,6 +469,7 @@ func ScanPURL(ctx context.Context, purlStr string, opts Options) (*Execution, er
 			Advisories:      advisories,
 			Stats:           stats,
 			Coverage:        coverage,
+			Warnings:        agg.Warnings,
 			GeneratedAt:     time.Now().UTC(),
 		},
 	}, nil
@@ -562,9 +567,21 @@ func persistFixVerdicts(cons []vulnerability.Consolidated, advisories map[string
 	}
 }
 
+// advisoryQuery is what querying the advisory sources produced for a target:
+// the findings, the advisory records they reference, the source-coverage report,
+// and the non-fatal warnings the sources raised. Warnings travel with the
+// findings because a source that could not retrieve a record it knows about
+// leaves a gap the report has to admit to.
+type advisoryQuery struct {
+	Findings   []vulnerability.Finding
+	Advisories map[string]*vulnerabilityv1.Advisory
+	Coverage   *vulnerabilityv1.ScanCoverage
+	Warnings   []string
+}
+
 // queryVulnerabilities queries OSV for vulnerabilities and checks for
 // supply-chain risks (e.g., unpinned GitHub Actions references).
-func queryVulnerabilities(ctx context.Context, pkgs []*extractor.Package, direct map[string]bool, originURL string) ([]vulnerability.Finding, map[string]*vulnerabilityv1.Advisory, *vulnerabilityv1.ScanCoverage, error) {
+func queryVulnerabilities(ctx context.Context, pkgs []*extractor.Package, direct map[string]bool, originURL string) (advisoryQuery, error) {
 	ctx, span := otel.StartSpan(ctx, "deputy.scanning.query_vulnerabilities",
 		trace.WithAttributes(
 			attribute.Int("deputy.package.count", len(pkgs)),
@@ -581,7 +598,7 @@ func queryVulnerabilities(ctx context.Context, pkgs []*extractor.Package, direct
 	agg, err := advisorysource.NewDefaultRegistry(ctx, osv.NewClient()).Query(ctx, inputs)
 	if err != nil {
 		otel.SetSpanError(span, err)
-		return nil, nil, nil, err
+		return advisoryQuery{}, err
 	}
 	// Convert proto findings to domain at the consolidation boundary; supply-chain
 	// findings below are already domain and append cleanly.
@@ -598,7 +615,12 @@ func queryVulnerabilities(ctx context.Context, pkgs []*extractor.Package, direct
 	}
 
 	span.SetAttributes(attribute.Int("deputy.finding.count", len(findings)))
-	return findings, advisories, agg.Coverage, nil
+	return advisoryQuery{
+		Findings:   findings,
+		Advisories: advisories,
+		Coverage:   agg.Coverage,
+		Warnings:   agg.Warnings,
+	}, nil
 }
 
 // packagesToProto converts extractor packages to the proto packages the

--- a/internal/scanning/suppression_recovery_test.go
+++ b/internal/scanning/suppression_recovery_test.go
@@ -1,0 +1,141 @@
+package scanning
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/ossf/osv-schema/bindings/go/osvschema"
+	"osv.dev/bindings/go/api"
+
+	"github.com/temporalio/deputy/internal/analysis/osv"
+	"github.com/temporalio/deputy/internal/cache/disk"
+	"github.com/temporalio/deputy/internal/ignore"
+)
+
+// recoveringOSVClient reports one withdrawn advisory for the queried package and
+// answers the expansion the way OSV answers a merged record: a 404 whose body
+// names the live alias, which then resolves. This is the sequence that used to
+// hand the finding back under the alias's ID.
+type recoveringOSVClient struct {
+	withdrawnID string
+	aliasID     string
+	pkgName     string
+}
+
+func (c *recoveringOSVClient) QueryBatch(_ context.Context, queries []*api.Query) (*api.BatchVulnerabilityList, error) {
+	results := make([]*api.VulnerabilityList, 0, len(queries))
+	for range queries {
+		results = append(results, &api.VulnerabilityList{
+			Vulns: []*osvschema.Vulnerability{{Id: c.withdrawnID}},
+		})
+	}
+	return &api.BatchVulnerabilityList{Results: results}, nil
+}
+
+func (c *recoveringOSVClient) GetVulnByID(_ context.Context, id string) (*osvschema.Vulnerability, error) {
+	if id == c.aliasID {
+		return &osvschema.Vulnerability{
+			Id:      c.aliasID,
+			Summary: "Recovered under the live alias",
+			Affected: []*osvschema.Affected{{
+				Package: &osvschema.Package{Name: c.pkgName, Ecosystem: "Go"},
+				Ranges: []*osvschema.Range{{
+					Type:   osvschema.Range_SEMVER,
+					Events: []*osvschema.Event{{Introduced: "0"}},
+				}},
+			}},
+		}, nil
+	}
+	return nil, errors.New(`client error: status="404 Not Found" body={"code":5,` +
+		`"message":"Vulnerability not found, but the following aliases were: ` + c.aliasID + `"}`)
+}
+
+// TestIgnoreRuleSurvivesAliasRecovery is the user-visible point of preserving
+// the superseded advisory ID. Someone puts the ID OSV reported into
+// .deputyignore.yaml; later OSV merges that record into an alias, so Deputy
+// recovers the finding through the alias. If the finding came back under the
+// alias's ID, the suppression would quietly stop matching and a vulnerability
+// the user had triaged and accepted would reappear with no explanation.
+//
+// This drives the real recovery path and the real FilterIgnored, which matches
+// on the finding's advisory ID alone, so it fails if identity is not preserved.
+func TestIgnoreRuleSurvivesAliasRecovery(t *testing.T) {
+	const (
+		pkgName     = "github.com/moby/buildkit"
+		pkgVersion  = "v0.30.0"
+		withdrawnID = "GO-2026-6255"
+		aliasID     = "GHSA-7236-3392-c5c6"
+	)
+
+	tests := []struct {
+		name string
+		// ignoreID is the advisory the user suppressed.
+		ignoreID string
+		// wantIgnored is whether the rule should suppress the finding.
+		wantIgnored bool
+	}{
+		{
+			// The regression this guards: the ID the user actually saw and
+			// suppressed is the one OSV reported, not the one we recovered.
+			name:        "rule naming the superseded ID still matches",
+			ignoreID:    withdrawnID,
+			wantIgnored: true,
+		},
+		{
+			// A rule for an unrelated advisory must not start matching.
+			name:     "rule naming an unrelated advisory does not match",
+			ignoreID: "CVE-2020-00000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(disk.SetBaseDirForTest(t.TempDir()))
+
+			client := &recoveringOSVClient{withdrawnID: withdrawnID, aliasID: aliasID, pkgName: pkgName}
+			findings, advisories, unresolved, err := osv.Query(t.Context(), client, []osv.PkgInput{{
+				QueryKey: osv.QueryKey{Name: pkgName, Version: pkgVersion, Ecosystem: "Go"},
+			}})
+			if err != nil {
+				t.Fatalf("osv.Query() error = %v, want nil", err)
+			}
+			if len(unresolved) != 0 {
+				t.Fatalf("unresolved = %+v, want none: the alias recovered the record", unresolved)
+			}
+			if len(findings) != 1 {
+				t.Fatalf("findings = %d, want 1", len(findings))
+			}
+			if got := findings[0].AdvisoryID; got != withdrawnID {
+				t.Fatalf("finding advisory ID = %q, want %q: recovery must not change the reported identity", got, withdrawnID)
+			}
+
+			rules, err := ignore.LoadFromBytes([]byte(strings.Join([]string{
+				"ignore:",
+				"  - id: " + tt.ignoreID,
+				"    reason: Accepted during triage",
+			}, "\n")))
+			if err != nil {
+				t.Fatalf("ignore.LoadFromBytes() error = %v", err)
+			}
+
+			filtered, ignored := FilterIgnored(Result{Findings: findings, Advisories: advisories}, rules)
+			if tt.wantIgnored {
+				if ignored != 1 {
+					t.Errorf("ignored = %d, want 1: the suppression for %s stopped matching after recovery", ignored, tt.ignoreID)
+				}
+				if len(filtered.Findings) != 0 {
+					t.Errorf("findings after filtering = %d, want 0", len(filtered.Findings))
+				}
+				return
+			}
+			if ignored != 0 {
+				t.Errorf("ignored = %d, want 0", ignored)
+			}
+			if len(filtered.Findings) != 1 {
+				t.Errorf("findings after filtering = %d, want 1", len(filtered.Findings))
+			}
+		})
+	}
+}

--- a/internal/server/remediation_handler.go
+++ b/internal/server/remediation_handler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/temporalio/deputy/gen/deputy/agent/v1/agentv1connect"
 	remediationv1 "github.com/temporalio/deputy/gen/deputy/remediation/v1"
 	"github.com/temporalio/deputy/gen/deputy/remediation/v1/remediationv1connect"
+	scanv1 "github.com/temporalio/deputy/gen/deputy/scan/v1"
 	"github.com/temporalio/deputy/internal/agent"
 	"github.com/temporalio/deputy/internal/logs"
 	internalproto "github.com/temporalio/deputy/internal/proto"
@@ -127,6 +128,7 @@ func (h *RemediationHandler) GeneratePlan(
 			Target:      scanResult.GetTarget(),
 			GeneratedAt: timestamppb.Now(),
 			Stats:       &remediationv1.PlanStats{},
+			Warnings:    planWarnings(scanResult),
 		}), nil
 	}
 
@@ -182,6 +184,7 @@ func (h *RemediationHandler) GeneratePlan(
 		GeneratedAt:                timestamppb.Now(),
 		Stats:                      planStats(steps, addressed, len(unaddressed)),
 		UnaddressedVulnerabilities: unaddressed,
+		Warnings:                   planWarnings(scanResult),
 	}
 
 	logs.Info(ctx, "remediation plan generated",
@@ -192,6 +195,17 @@ func (h *RemediationHandler) GeneratePlan(
 	)
 
 	return connect.NewResponse(response), nil
+}
+
+// planWarnings carries the scan's warnings onto the plan response. A plan is
+// only as trustworthy as the scan behind it: when an advisory could not be
+// expanded, the finding never reached planning, so no step addresses it and it
+// is missing from unaddressed_vulnerabilities too. The warning is the only thing
+// left telling a consumer that "nothing to remediate" may mean "we could not see
+// it", which matters most on the empty-plan path. Cloned so the response does
+// not share a slice with the request it was built from.
+func planWarnings(scanResult *scanv1.ScanResponse) []string {
+	return slices.Clone(scanResult.GetWarnings())
 }
 
 // guidanceContextFor maps the requested guidance profile onto the internal

--- a/internal/server/remediation_handler_test.go
+++ b/internal/server/remediation_handler_test.go
@@ -84,8 +84,8 @@ func TestGeneratePlanAcceptsEcosystemlessPackages(t *testing.T) {
 // no remediation is needed.
 func TestGeneratePlanCarriesScanWarnings(t *testing.T) {
 	const (
-		unresolved = "osv: advisory GO-2026-6255 reported for github.com/moby/buildkit@v0.30.0 is missing from this report: withdrawn"
-		other      = "osv: advisory GHSA-7236-3392-c5c6 reported for github.com/example/other@v1.0.0 is missing from this report: withdrawn"
+		unresolved = "osv: advisory GO-2026-6255 reported for github.com/moby/buildkit@v0.30.0 is absent from osv's findings: withdrawn"
+		other      = "osv: advisory GHSA-7236-3392-c5c6 reported for github.com/example/other@v1.0.0 is absent from osv's findings: withdrawn"
 	)
 
 	vulnerable := &dependencyv1.Package{

--- a/internal/server/remediation_handler_test.go
+++ b/internal/server/remediation_handler_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"slices"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -71,5 +72,113 @@ func TestGeneratePlanAcceptsEcosystemlessPackages(t *testing.T) {
 	}
 	if !covered {
 		t.Fatalf("no step remediates GO-2026-0001: %+v", resp.Msg.GetPlan().GetSteps())
+	}
+}
+
+// TestGeneratePlanCarriesScanWarnings pins the guarantee a plan inherits from
+// its scan. When an advisory could not be expanded, its finding never reached
+// planning: no step addresses it and it is absent from
+// unaddressed_vulnerabilities, so the warning is the only thing distinguishing
+// "nothing to fix" from "we could not see everything". The empty-plan case is
+// the one that matters most, because that is the response that tells a consumer
+// no remediation is needed.
+func TestGeneratePlanCarriesScanWarnings(t *testing.T) {
+	const (
+		unresolved = "osv: advisory GO-2026-6255 reported for github.com/moby/buildkit@v0.30.0 is missing from this report: withdrawn"
+		other      = "osv: advisory GHSA-7236-3392-c5c6 reported for github.com/example/other@v1.0.0 is missing from this report: withdrawn"
+	)
+
+	vulnerable := &dependencyv1.Package{
+		Name:      "github.com/example/widget",
+		Version:   "v1.4.0",
+		Ecosystem: "go",
+		Purl:      "pkg:golang/github.com/example/widget@v1.4.0",
+		Direct:    true,
+		ManifestRefs: []*dependencyv1.ManifestRef{
+			{Path: "go.mod", Manager: "go"},
+		},
+	}
+	fixableFindings := []*vulnerabilityv1.Finding{
+		{AdvisoryId: "GO-2026-0001", Package: vulnerable, Affected: true},
+	}
+	fixableAdvisories := map[string]*vulnerabilityv1.Advisory{
+		"GO-2026-0001": {
+			Id:            "GO-2026-0001",
+			Summary:       "Fixable vulnerability",
+			Severity:      vulnerability.NewSeverity("HIGH", ""),
+			FixedVersions: []string{"1.5.0"},
+		},
+	}
+
+	tests := []struct {
+		name       string
+		scan       *scanv1.ScanResponse
+		wantSteps  bool
+		wantWarned []string
+	}{
+		{
+			// The path that currently reads as clean: no findings, empty plan,
+			// and until now no sign that a record went missing.
+			name: "empty plan still reports the scan's warnings",
+			scan: &scanv1.ScanResponse{
+				PackagesScanned: 1,
+				Packages:        []*dependencyv1.Package{vulnerable},
+				Stats:           &vulnerabilityv1.Stats{},
+				Warnings:        []string{unresolved},
+			},
+			wantWarned: []string{unresolved},
+		},
+		{
+			name: "populated plan reports the scan's warnings",
+			scan: &scanv1.ScanResponse{
+				PackagesScanned: 1,
+				Packages:        []*dependencyv1.Package{vulnerable},
+				Findings:        fixableFindings,
+				Advisories:      fixableAdvisories,
+				Stats:           &vulnerabilityv1.Stats{Total: 1, Unique: 1, High: 1},
+				Warnings:        []string{unresolved},
+			},
+			wantSteps:  true,
+			wantWarned: []string{unresolved},
+		},
+		{
+			name: "every warning survives, in the scan's order",
+			scan: &scanv1.ScanResponse{
+				PackagesScanned: 1,
+				Packages:        []*dependencyv1.Package{vulnerable},
+				Findings:        fixableFindings,
+				Advisories:      fixableAdvisories,
+				Stats:           &vulnerabilityv1.Stats{Total: 1, Unique: 1, High: 1},
+				Warnings:        []string{other, unresolved},
+			},
+			wantSteps:  true,
+			wantWarned: []string{other, unresolved},
+		},
+		{
+			name: "a clean scan adds no warnings",
+			scan: &scanv1.ScanResponse{
+				PackagesScanned: 1,
+				Packages:        []*dependencyv1.Package{vulnerable},
+				Stats:           &vulnerabilityv1.Stats{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := NewRemediationHandler()
+			resp, err := handler.GeneratePlan(t.Context(), connect.NewRequest(&remediationv1.GeneratePlanRequest{
+				Source: &remediationv1.GeneratePlanRequest_ScanResult{ScanResult: tt.scan},
+			}))
+			if err != nil {
+				t.Fatalf("GeneratePlan: %v", err)
+			}
+			if gotSteps := len(resp.Msg.GetPlan().GetSteps()) > 0; gotSteps != tt.wantSteps {
+				t.Fatalf("plan has steps = %t, want %t", gotSteps, tt.wantSteps)
+			}
+			if !slices.Equal(resp.Msg.GetWarnings(), tt.wantWarned) {
+				t.Fatalf("warnings = %q, want %q", resp.Msg.GetWarnings(), tt.wantWarned)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #320.

`deputy scan` returned nothing at all when OSV refused to serve one advisory record. Measured on this repository, before and after:

```
before:  exit 1, no report
after:   exit 0, 142 line report
```

## The same call had two policies

`GetVulnByID` is treated as skippable in `hydrate.go` and was fatal in `query.go`. The tolerant version is right there twice, at [`hydrate.go#L38-L41`](https://github.com/temporalio/deputy/blob/d09172abaceddb20c19417b6b94942b8c476335d/internal/analysis/osv/hydrate.go#L38-L41) and again at line 275. The fatal one ran inside an `errgroup`, so a single failure cancelled the group and abandoned every other expansion still in flight.

Tolerance is correct in `hydrate.go` because hydration only enriches a record we already have. It is not sufficient in `query.go`, where the record *is* the finding: the batch query has already told us this package has this vulnerability, so a bare `continue` would drop a real finding and leave the scan looking clean. That is the failure this had to avoid rather than trade for.

## Recover first, report what cannot be recovered

OSV names the aliases that do exist in its 404 body, so a missing record has usually been superseded rather than deleted:

```
$ curl -s https://api.osv.dev/v1/vulns/GO-2026-6255
{"code":5,"message":"Vulnerability not found, but the following aliases were: CVE-2026-61711 GHSA-7236-3392-c5c6"}
```

[`IsNotFoundError` and `NotFoundAliases`](https://github.com/temporalio/deputy/blob/d09172abaceddb20c19417b6b94942b8c476335d/internal/analysis/osv/errors.go#L24-L81) separate a permanent 404 from a transport failure and read those aliases, and the expansion retries against them. On this repository that recovers the record in full rather than degrading:

```
github.com/moby/buildkit v0.30.0 [direct]:
  • CVE-2026-61711 [MED] (↑ 0.31.1)
    BuildKit: Custom frontend could bypass Seccomp/AppArmor
    Aliases: GHSA-7236-3392-c5c6
```

When recovery fails, [`UnresolvedAdvisory`](https://github.com/temporalio/deputy/blob/d09172abaceddb20c19417b6b94942b8c476335d/internal/analysis/osv/query.go#L83-L124) carries the advisory ID, the package it was attributed to, and the reason onto the scan's existing warning list. A scan that lost a record does not read the same as a scan that found nothing, which is the distinction #294 is about.

Failures are not written to the on-disk cache, so a record that reappears upstream resolves on the next run instead of staying broken for the cache TTL.

## Reviewer notes

The judgment call worth checking is the transient case. A 404 is permanent and worth recovering from; a network failure is not, and treating them alike would either abort on a blip or quietly under-report during an outage. `IsNotFoundError` is what draws that line.

Scope is wider than the abort site because surfacing had to reach the caller: `advisorysource` carries the unresolved list, `scanning` renders the warnings, and `internal/otel` gains `deputy.osv.unresolved_advisories` so an incomplete answer is visible in a trace rather than only in output nobody reads.



## Known limit, tracked separately

The unresolved-advisory warning reaches the scan only from the in-process OSV source. `AdvisoryQueryResponse` in `api/deputy/plugin/v1/advisory_source.proto` carries `findings` and `advisories` and no warning field, so a plugin or ConnectRPC source in the same position has nowhere to report it. That is not a regression, since no source could report a warning before this change, but it does mean the guarantee is currently narrower than the type suggests. Closing it is a plugin wire change that external implementors would have to follow, so it belongs in its own change rather than here.
